### PR TITLE
CI: the licensing check doesn't need to be pull_request_target anymore as we're not using the DIND runners

### DIFF
--- a/.github/workflows/licensing.yml
+++ b/.github/workflows/licensing.yml
@@ -5,7 +5,7 @@
 name: Licensing checks
 
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches:
     - main


### PR DESCRIPTION
#3 3 switched over the `reuse` check to a custom container image and moved away from the DIND runners. We can now safely move this job to `pull_request` not `pull_request_target`