### PR TITLE
Expose the image digest setting

### DIFF
--- a/charts/element-web/values.schema.json
+++ b/charts/element-web/values.schema.json
@@ -52,6 +52,9 @@
         "tag": {
           "type": "string"
         },
+        "digest": {
+          "type": "string"
+        },
         "pullPolicy": {
           "type": "string",
           "enum": [

--- a/charts/element-web/values.yaml
+++ b/charts/element-web/values.yaml
@@ -31,7 +31,12 @@ image:
   ## Defaults to the Chart's appVersion if not set
   # tag:
 
+  ## Container digest to use. Used to pull the image instead of the image tag / Chart appVersion if set
+  # digest:
+
   ## Whether the image should be pulled on container startup. Valid values are Always, IfNotPresent and Never
+  ## If this isn't provided it defaults to Always when using the image tag / Chart appVersion or
+  ## IfNotPresent if using a digest
   # pullPolicy:
 
   ## A list of pull secrets to use for this image

--- a/charts/matrix-stack/sub_schemas/image.json
+++ b/charts/matrix-stack/sub_schemas/image.json
@@ -13,6 +13,9 @@
         "tag": {
             "type": "string"
         },
+        "digest": {
+            "type": "string"
+        },
         "pullPolicy": {
             "type": "string",
             "enum": [

--- a/charts/matrix-stack/sub_schemas/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/sub_schemas/sub_schema_values.yaml.j2
@@ -61,7 +61,12 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
   # tag:
 {%- endif %}
 
+  ## Container digest to use. Used to pull the image instead of the image tag / Chart appVersion if set
+  # digest:
+
   ## Whether the image should be pulled on container startup. Valid values are Always, IfNotPresent and Never
+  ## If this isn't provided it defaults to Always when using the image tag / Chart appVersion or
+  ## IfNotPresent if using a digest
   # pullPolicy:
 
   ## A list of pull secrets to use for this image


### PR DESCRIPTION
#3 included the logic for setting the digest on the Element Web deployment. It didn't include it in the schema or the values files