### PR TITLE
Allow nginx snippets on the test cluster

### DIFF
--- a/scripts/setup_test_cluster.sh
+++ b/scripts/setup_test_cluster.sh
@@ -57,6 +57,7 @@ helm --kube-context $kind_context_name upgrade -i ingress-nginx --repo https://k
   --set controller.ingressClassResource.default=true \
   --set controller.config.hsts=false \
   --set controller.hostPort.enabled=true \
+  --set controller.allowSnippetAnnotations=true \
   --set controller.service.enabled=false
 
 helm --kube-context $kind_context_name upgrade -i metrics-server --repo https://kubernetes-sigs.github.io/metrics-server metrics-server \


### PR DESCRIPTION
The test cluster is only used for testing, and snippets are a very powerful tool to make Ingress more hackable.

In particular, it allows you to set up `.well-known` lookups simply with annotations.