### PR TITLE
Synapse: increase the DNS response size to support large SRV responses

### DIFF
--- a/charts/synapse/configs/haproxy/haproxy.cfg.tpl
+++ b/charts/synapse/configs/haproxy/haproxy.cfg.tpl
@@ -79,6 +79,7 @@ defaults
 
 resolvers kubedns
   parse-resolv-conf
+  accepted_payload_size 8192
   hold timeout 600s
   hold refused 600s
 


### PR DESCRIPTION
https://www.haproxy.com/documentation/haproxy-configuration-tutorials/dns-resolution/#dns-service-discovery

> In your load balancer configuration, add a resolvers section.
> * Add one or more `nameserver` lines to specify the IP addresses and ports of your DNS nameservers.
> * Set the `accepted_payload_size` to 8192 to allow larger DNS payloads, which is required to receive more server IP addresses within a single DNS response.