### PR TITLE
Charts: allow setting of labels globally or for a given component

### DIFF
--- a/charts/element-web/source/values.schema.json
+++ b/charts/element-web/source/values.schema.json
@@ -41,6 +41,12 @@
     "ingress": {
       "$ref": "file://./../../matrix-stack/sub_schemas/ingress.json"
     },
+    "labels": {
+      "$ref": "file://./../../matrix-stack/sub_schemas/labels.json"
+    },
+    "annotations": {
+      "$ref": "file://./../../matrix-stack/sub_schemas/workloadAnnotations.json"
+    },
     "containersSecurityContext": {
       "$ref": "file://./../../matrix-stack/sub_schemas/containersSecurityContext.json"
     },
@@ -55,9 +61,6 @@
     },
     "tolerations": {
       "$ref": "file://./../../matrix-stack/sub_schemas/tolerations.json"
-    },
-    "annotations": {
-      "$ref": "file://./../../matrix-stack/sub_schemas/workloadAnnotations.json"
     }
   }
 }

--- a/charts/element-web/source/values.yaml.j2
+++ b/charts/element-web/source/values.yaml.j2
@@ -20,9 +20,10 @@ defaultMatrixServer: {}
 replicas: 2
 {{ sub_schema_values.image(registry='docker.io', repository='vectorim/element-web') }}
 {{ sub_schema_values.ingress() }}
+{{ sub_schema_values.labels() }}
+{{ sub_schema_values.workloadAnnotations() }}
 {{ sub_schema_values.containersSecurityContext() }}
 {{ sub_schema_values.nodeSelector() }}
 {{ sub_schema_values.podSecurityContext(user_id='10004', group_id='10004') }}
 {{ sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='200Mi') }}
 {{ sub_schema_values.tolerations() }}
-{{ sub_schema_values.workloadAnnotations() }}

--- a/charts/element-web/templates/_helpers.tpl
+++ b/charts/element-web/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 
 {{- define "element-io.element-web.labels" -}}
-app.kubernetes.io/part-of: matrix-stack
+{{ include "element-io.ess-library.labels.common" (list $ .Values.labels) }}
 app.kubernetes.io/component: matrix-client
 app.kubernetes.io/name: element-web
 app.kubernetes.io/instance: {{ .Release.Name }}-element-web

--- a/charts/element-web/values.schema.json
+++ b/charts/element-web/values.schema.json
@@ -40,6 +40,12 @@
             "server_name": {
               "type": "string"
             },
+            "labels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
             "imagePullSecrets": {
               "type": "array",
               "items": {
@@ -140,6 +146,18 @@
         }
       },
       "additionalProperties": false
+    },
+    "labels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "annotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
     },
     "containersSecurityContext": {
       "properties": {
@@ -321,12 +339,6 @@
         },
         "type": "object",
         "additionalProperties": false
-      }
-    },
-    "annotations": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "string"
       }
     }
   },

--- a/charts/element-web/values.yaml
+++ b/charts/element-web/values.yaml
@@ -12,6 +12,9 @@ global:
     ## It can not change after the initial deployment.
     # server_name: ess.localhost
 
+    ## Labels to add to all manifest in this chart and all sub-charts
+    labels: {}
+
     ## A list of Secrets in this namespace to use as pull Secrets.
     ## Ignored if a given component specifies its own pull Secrets.
     ## e.g.
@@ -74,6 +77,12 @@ ingress:
   ## How the service behind the ingress is constructed
   service:
     type: ClusterIP
+
+## Labels to add to all manifest in this chart
+labels: {}
+
+## Defines the annotations to add to the workload
+# annotations: {}
 
 ## A subset of SecurityContext. ContainersSecurityContext holds pod-level security attributes and common container settings
 containersSecurityContext:
@@ -181,6 +190,3 @@ resources:
 ##   value:
 
 tolerations: []
-
-## Defines the annotations to add to the workload
-# annotations: {}

--- a/charts/ess-library/templates/_labels.tpl
+++ b/charts/ess-library/templates/_labels.tpl
@@ -1,0 +1,24 @@
+# Copyright 2024 New Vector Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+
+{{- define "element-io.ess-library.labels.common" -}}
+{{- $ := index . 0 }}
+{{- $userLabels := dict -}}
+{{- $userLabels = merge $userLabels $.Values.global.ess.labels }}
+{{- $userLabels = merge $userLabels ( index . 1) }}
+{{- /* These labels are owned by the chart, don't allow overriding */}}
+{{- $userLabels = unset $userLabels "helm.sh/chart.sh" }}
+{{- $userLabels = unset $userLabels "app.kubernetes.io/managed-by" }}
+{{- $userLabels = unset $userLabels "app.kubernetes.io/part-of" }}
+{{- $userLabels = unset $userLabels "app.kubernetes.io/component" }}
+{{- $userLabels = unset $userLabels "app.kubernetes.io/name" }}
+{{- $userLabels = unset $userLabels "app.kubernetes.io/instance" }}
+{{- $userLabels = unset $userLabels "app.kubernetes.io/version" }}
+{{- if $userLabels }}
+{{- toYaml $userLabels }}
+{{- end }}
+helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
+app.kubernetes.io/managed-by: {{ $.Release.Service }}
+app.kubernetes.io/part-of: matrix-stack
+{{- end }}

--- a/charts/matrix-stack/sub_schemas/global.json
+++ b/charts/matrix-stack/sub_schemas/global.json
@@ -8,6 +8,9 @@
         "server_name": {
           "type": "string"
         },
+        "labels": {
+          "$ref": "file://./../../matrix-stack/sub_schemas/labels.json"
+        },
         "imagePullSecrets": {
           "type": "array",
           "items": {

--- a/charts/matrix-stack/sub_schemas/labels.json
+++ b/charts/matrix-stack/sub_schemas/labels.json
@@ -1,0 +1,6 @@
+{
+  "type": "object",
+  "additionalProperties": {
+    "type": "string"
+  }
+}

--- a/charts/matrix-stack/sub_schemas/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/sub_schemas/sub_schema_values.yaml.j2
@@ -16,6 +16,7 @@ global:
     ## The server name of the Matrix Stack. This gets embedded in user IDs & room IDs
     ## It can not change after the initial deployment.
     # server_name: ess.localhost
+{{ labels(global=true) | indent(4) }}
 
     ## A list of Secrets in this namespace to use as pull Secrets.
     ## Ignored if a given component specifies its own pull Secrets.
@@ -139,6 +140,11 @@ global:
   ## How the service behind the ingress is constructed
   service:
     type: ClusterIP
+{%- endmacro %}
+
+{% macro labels(global=false, key='labels') %}
+## Labels to add to all manifest in this chart{{ ' and all sub-charts' if global else '' }}
+labels: {}
 {%- endmacro %}
 
 {% macro nodeSelector(key='nodeSelector') %}

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -13,6 +13,12 @@
             "server_name": {
               "type": "string"
             },
+            "labels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
             "imagePullSecrets": {
               "type": "array",
               "items": {

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -12,6 +12,9 @@ global:
     ## It can not change after the initial deployment.
     # server_name: ess.localhost
 
+    ## Labels to add to all manifest in this chart and all sub-charts
+    labels: {}
+
     ## A list of Secrets in this namespace to use as pull Secrets.
     ## Ignored if a given component specifies its own pull Secrets.
     ## e.g.

--- a/charts/synapse/source/values.schema.json
+++ b/charts/synapse/source/values.schema.json
@@ -107,6 +107,12 @@
     "image": {
       "$ref": "file://./../../matrix-stack/sub_schemas/image.json"
     },
+    "labels": {
+      "$ref": "file://./../../matrix-stack/sub_schemas/labels.json"
+    },
+    "annotations": {
+      "$ref": "file://./../../matrix-stack/sub_schemas/workloadAnnotations.json"
+    },
     "containersSecurityContext": {
       "$ref": "file://./../../matrix-stack/sub_schemas/containersSecurityContext.json"
     },
@@ -130,9 +136,6 @@
     },
     "tolerations": {
       "$ref": "file://./../../matrix-stack/sub_schemas/tolerations.json"
-    },
-    "annotations": {
-      "$ref": "file://./../../matrix-stack/sub_schemas/workloadAnnotations.json"
     },
     "workers": {
       "type": "object",
@@ -203,6 +206,12 @@
         "image": {
           "$ref": "file://./../../matrix-stack/sub_schemas/image.json"
         },
+        "labels": {
+          "$ref": "file://./../../matrix-stack/sub_schemas/labels.json"
+        },
+        "annotations": {
+          "$ref": "file://./../../matrix-stack/sub_schemas/workloadAnnotations.json"
+        },
         "containersSecurityContext": {
           "$ref": "file://./../../matrix-stack/sub_schemas/containersSecurityContext.json"
         },
@@ -220,9 +229,6 @@
         },
         "tolerations": {
           "$ref": "file://./../../matrix-stack/sub_schemas/tolerations.json"
-        },
-        "annotations": {
-          "$ref": "file://./../../matrix-stack/sub_schemas/workloadAnnotations.json"
         }
       }
     },
@@ -231,6 +237,12 @@
       "properties": {
         "image": {
           "$ref": "file://./../../matrix-stack/sub_schemas/image.json"
+        },
+        "labels": {
+          "$ref": "file://./../../matrix-stack/sub_schemas/labels.json"
+        },
+        "annotations": {
+          "$ref": "file://./../../matrix-stack/sub_schemas/workloadAnnotations.json"
         },
         "containersSecurityContext": {
           "$ref": "file://./../../matrix-stack/sub_schemas/containersSecurityContext.json"
@@ -246,9 +258,6 @@
         },
         "tolerations": {
           "$ref": "file://./../../matrix-stack/sub_schemas/tolerations.json"
-        },
-        "annotations": {
-          "$ref": "file://./../../matrix-stack/sub_schemas/workloadAnnotations.json"
         }
       }
     }

--- a/charts/synapse/source/values.yaml.j2
+++ b/charts/synapse/source/values.yaml.j2
@@ -77,6 +77,8 @@ logging:
   levelOverrides: {}
 {{ sub_schema_values.image(registry='docker.io', repository='matrixdotorg/synapse') }}
 {{ sub_schema_values.ingress() }}
+{{ sub_schema_values.labels() }}
+{{ sub_schema_values.workloadAnnotations() }}
 {{ sub_schema_values.containersSecurityContext() }}
 {{ sub_schema_values.extraEnv() }}
 {{ sub_schema_values.hostAliases() }}
@@ -85,24 +87,25 @@ logging:
 {{ sub_schema_values.resources(requests_memory='100Mi', requests_cpu='100m', limits_memory='4Gi') }}
 {{ sub_schema_values.serviceMonitors() }}
 {{ sub_schema_values.tolerations() }}
-{{ sub_schema_values.workloadAnnotations() }}
 
 haproxy:
   replicas: 2
 {{ sub_schema_values.image(registry='docker.io', repository='library/haproxy', tag='3.0-alpine') | indent(2) }}
+{{ sub_schema_values.labels() | indent(2) }}
+{{ sub_schema_values.workloadAnnotations() | indent(2) }}
 {{ sub_schema_values.containersSecurityContext() | indent(2) }}
 {{ sub_schema_values.nodeSelector() | indent(2) }}
 {{ sub_schema_values.podSecurityContext(user_id='10001', group_id='10001') | indent(2) }}
 {{ sub_schema_values.resources(requests_memory='100Mi', requests_cpu='100m', limits_memory='200Mi') | indent(2) }}
 {{ sub_schema_values.serviceMonitors() | indent(2) }}
 {{ sub_schema_values.tolerations() | indent(2) }}
-{{ sub_schema_values.workloadAnnotations() | indent(2) }}
 
 redis:
 {{- sub_schema_values.image(registry='docker.io', repository='library/redis', tag='7.4-alpine') | indent(2) }}
+{{ sub_schema_values.labels() | indent(2) }}
+{{ sub_schema_values.workloadAnnotations() | indent(2) }}
 {{ sub_schema_values.containersSecurityContext() | indent(2) }}
 {{ sub_schema_values.nodeSelector() | indent(2) }}
 {{ sub_schema_values.podSecurityContext(user_id='10002', group_id='10002') | indent(2) }}
 {{ sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='50Mi') | indent(2) }}
 {{ sub_schema_values.tolerations() | indent(2) }}
-{{ sub_schema_values.workloadAnnotations() | indent(2) }}

--- a/charts/synapse/templates/_helpers.tpl
+++ b/charts/synapse/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 
 {{- define "element-io.synapse.labels" -}}
-app.kubernetes.io/part-of: matrix-stack
+{{ include "element-io.ess-library.labels.common" (list $ .Values.labels) }}
 app.kubernetes.io/component: matrix-server
 app.kubernetes.io/name: synapse
 app.kubernetes.io/instance: {{ .Release.Name }}-synapse
@@ -12,7 +12,7 @@ k8s.element.io/synapse-instance: {{ .Release.Name }}-synapse
 {{- end }}
 
 {{- define "element-io.synapse.process.labels" -}}
-app.kubernetes.io/part-of: matrix-stack
+{{ include "element-io.ess-library.labels.common" (list $ .Values.labels) }}
 app.kubernetes.io/component: matrix-server
 app.kubernetes.io/name: synapse-{{ .ProcessType }}
 app.kubernetes.io/instance: {{ .Release.Name }}-synapse-{{ .ProcessType }}
@@ -21,6 +21,7 @@ k8s.element.io/synapse-instance: {{ .Release.Name }}-synapse
 {{- end }}
 
 {{- define "element-io.synapse.redis.labels" -}}
+{{ include "element-io.ess-library.labels.common" (list $ .Values.redis.labels) }}
 app.kubernetes.io/part-of: matrix-stack
 app.kubernetes.io/component: matrix-server-pubsub
 app.kubernetes.io/name: synapse-redis
@@ -29,6 +30,7 @@ app.kubernetes.io/version: {{ .Values.redis.image.tag }}
 {{- end }}
 
 {{- define "element-io.synapse.haproxy.labels" -}}
+{{ include "element-io.ess-library.labels.common" (list $ .Values.haproxy.labels) }}
 app.kubernetes.io/part-of: matrix-stack
 app.kubernetes.io/component: matrix-server-ingress
 app.kubernetes.io/name: synapse-haproxy

--- a/charts/synapse/values.schema.json
+++ b/charts/synapse/values.schema.json
@@ -302,6 +302,12 @@
             "server_name": {
               "type": "string"
             },
+            "labels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
             "imagePullSecrets": {
               "type": "array",
               "items": {
@@ -475,6 +481,18 @@
         }
       },
       "additionalProperties": false
+    },
+    "labels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "annotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
     },
     "containersSecurityContext": {
       "properties": {
@@ -702,12 +720,6 @@
         },
         "type": "object",
         "additionalProperties": false
-      }
-    },
-    "annotations": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "string"
       }
     },
     "workers": {
@@ -1601,6 +1613,18 @@
           },
           "additionalProperties": false
         },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "containersSecurityContext": {
           "properties": {
             "allowPrivilegeEscalation": {
@@ -1791,12 +1815,6 @@
             "type": "object",
             "additionalProperties": false
           }
-        },
-        "annotations": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
         }
       },
       "additionalProperties": false
@@ -1844,6 +1862,18 @@
             }
           },
           "additionalProperties": false
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "containersSecurityContext": {
           "properties": {
@@ -2025,12 +2055,6 @@
             },
             "type": "object",
             "additionalProperties": false
-          }
-        },
-        "annotations": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
           }
         }
       },

--- a/charts/synapse/values.yaml
+++ b/charts/synapse/values.yaml
@@ -13,6 +13,9 @@ global:
     ## It can not change after the initial deployment.
     # server_name: ess.localhost
 
+    ## Labels to add to all manifest in this chart and all sub-charts
+    labels: {}
+
     ## A list of Secrets in this namespace to use as pull Secrets.
     ## Ignored if a given component specifies its own pull Secrets.
     ## e.g.
@@ -355,6 +358,12 @@ ingress:
   service:
     type: ClusterIP
 
+## Labels to add to all manifest in this chart
+labels: {}
+
+## Defines the annotations to add to the workload
+# annotations: {}
+
 ## A subset of SecurityContext. ContainersSecurityContext holds pod-level security attributes and common container settings
 containersSecurityContext:
   ## Controls whether a process can gain more privileges than its parent process.
@@ -487,9 +496,6 @@ serviceMonitors:
 
 tolerations: []
 
-## Defines the annotations to add to the workload
-# annotations: {}
-
 haproxy:
   replicas: 2
 
@@ -519,6 +525,12 @@ haproxy:
     ## pullSecrets:
     ## - name: dockerhub
     pullSecrets: []
+
+  ## Labels to add to all manifest in this chart
+  labels: {}
+
+  ## Defines the annotations to add to the workload
+  # annotations: {}
 
   ## A subset of SecurityContext. ContainersSecurityContext holds pod-level security attributes and common container settings
   containersSecurityContext:
@@ -632,9 +644,6 @@ haproxy:
 
   tolerations: []
 
-  ## Defines the annotations to add to the workload
-  # annotations: {}
-
 redis:
   # Details of the image to be used
   image:
@@ -662,6 +671,12 @@ redis:
     ## pullSecrets:
     ## - name: dockerhub
     pullSecrets: []
+
+  ## Labels to add to all manifest in this chart
+  labels: {}
+
+  ## Defines the annotations to add to the workload
+  # annotations: {}
 
   ## A subset of SecurityContext. ContainersSecurityContext holds pod-level security attributes and common container settings
   containersSecurityContext:
@@ -769,6 +784,3 @@ redis:
   ##   value:
 
   tolerations: []
-
-  ## Defines the annotations to add to the workload
-  # annotations: {}


### PR DESCRIPTION
The precedence order is (lowest -> highest): global -> component -> chart built-in.

Additionally add `helm.sh/chart` and `app.kubernetes.io/managed-by` as per https://helm.sh/docs/chart_best_practices/labels/. `app.kubernetes.io/managed-by` was already being added to manifests directly managed by Helm but this means that things like `Pods` will also get it