### PR TITLE
Charts: create ServiceAccounts so we don't ever reference the default one

### DIFF
--- a/charts/element-web/source/values.schema.json
+++ b/charts/element-web/source/values.schema.json
@@ -59,6 +59,9 @@
     "resources": {
       "$ref": "file://./../../matrix-stack/sub_schemas/resources.json"
     },
+    "serviceAccount": {
+      "$ref": "file://./../../matrix-stack/sub_schemas/serviceAccount.json"
+    },
     "tolerations": {
       "$ref": "file://./../../matrix-stack/sub_schemas/tolerations.json"
     }

--- a/charts/element-web/source/values.yaml.j2
+++ b/charts/element-web/source/values.yaml.j2
@@ -26,4 +26,5 @@ replicas: 2
 {{ sub_schema_values.nodeSelector() }}
 {{ sub_schema_values.podSecurityContext(user_id='10004', group_id='10004') }}
 {{ sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='200Mi') }}
+{{ sub_schema_values.serviceAccount() }}
 {{ sub_schema_values.tolerations() }}

--- a/charts/element-web/templates/_helpers.tpl
+++ b/charts/element-web/templates/_helpers.tpl
@@ -10,6 +10,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}-element-web
 app.kubernetes.io/version: {{ .Values.image.tag | default $.Chart.AppVersion }}
 {{- end }}
 
+{{- define "element-io.element-web.serviceAccountName" -}}
+{{ default (printf "%s-element-web" .Release.Name ) .Values.serviceAccount.name }}
+{{- end }}
+
 {{- define "element-io.element-web.config" }}
 {{- $config := dict }}
 {{- $serverName := required "Element Web requires global.ess.server_name set" .Values.global.ess.server_name }}

--- a/charts/element-web/templates/deployment.yaml
+++ b/charts/element-web/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
               topologyKey: kubernetes.io/hostname
 {{- end }}
       automountServiceAccountToken: false
+      serviceAccountName: {{ include "element-io.element-web.serviceAccountName" . }}
 {{- include "element-io.ess-library.pods.pullSecrets" (list $ .Values.image) | indent 6 }}
 {{- with .Values.podSecurityContext }}
       securityContext:

--- a/charts/element-web/templates/serviceaccount.yaml
+++ b/charts/element-web/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+# Copyright 2024 New Vector Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "element-io.element-web.labels" . | nindent 4 }}
+  name: {{ include "element-io.element-web.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/element-web/values.schema.json
+++ b/charts/element-web/values.schema.json
@@ -312,6 +312,24 @@
       "type": "object",
       "additionalProperties": false
     },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "tolerations": {
       "type": "array",
       "items": {

--- a/charts/element-web/values.yaml
+++ b/charts/element-web/values.yaml
@@ -173,6 +173,17 @@ resources:
   limits:
     memory: 200Mi
 
+## Controls configuration of the ServiceAccount for this component
+serviceAccount:
+  ## Whether a ServiceAccount should be created by the chart or not
+  create: true
+
+  ## What name to give the ServiceAccount. If not provided the chart will provide the name automatically
+  name: ""
+
+  ## Annotations to add to the service account
+  annotations: {}
+
 ## Workload tolerations
 ## The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
 ##

--- a/charts/matrix-stack/sub_schemas/serviceAccount.json
+++ b/charts/matrix-stack/sub_schemas/serviceAccount.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "create": {
+      "type": "boolean"
+    },
+    "name": {
+      "type": "string"
+    },
+    "annotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/charts/matrix-stack/sub_schemas/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/sub_schemas/sub_schema_values.yaml.j2
@@ -254,6 +254,19 @@ labels: {}
     memory: {{ limits_memory }}
 {%- endmacro %}
 
+{% macro serviceAccount(key='serviceAccount') %}
+## Controls configuration of the ServiceAccount for this component
+{{ key }}:
+  ## Whether a ServiceAccount should be created by the chart or not
+  create: true
+
+  ## What name to give the ServiceAccount. If not provided the chart will provide the name automatically
+  name: ""
+
+  ## Annotations to add to the service account
+  annotations: {}
+{%- endmacro %}
+
 {% macro serviceMonitors(key='serviceMonitors') %}
 ## Whether to deploy ServiceMonitors into the cluster for this component
 ## Requires the ServiceMonitor CRDs to be in the cluster

--- a/charts/synapse/source/values.schema.json
+++ b/charts/synapse/source/values.schema.json
@@ -131,6 +131,9 @@
     "resources": {
       "$ref": "file://./../../matrix-stack/sub_schemas/resources.json"
     },
+    "serviceAccount": {
+      "$ref": "file://./../../matrix-stack/sub_schemas/serviceAccount.json"
+    },
     "serviceMonitors": {
       "$ref": "file://./../../matrix-stack/sub_schemas/serviceMonitors.json"
     },
@@ -224,6 +227,9 @@
         "resources": {
           "$ref": "file://./../../matrix-stack/sub_schemas/resources.json"
         },
+        "serviceAccount": {
+          "$ref": "file://./../../matrix-stack/sub_schemas/serviceAccount.json"
+        },
         "serviceMonitors": {
           "$ref": "file://./../../matrix-stack/sub_schemas/serviceMonitors.json"
         },
@@ -255,6 +261,9 @@
         },
         "resources": {
           "$ref": "file://./../../matrix-stack/sub_schemas/resources.json"
+        },
+        "serviceAccount": {
+          "$ref": "file://./../../matrix-stack/sub_schemas/serviceAccount.json"
         },
         "tolerations": {
           "$ref": "file://./../../matrix-stack/sub_schemas/tolerations.json"

--- a/charts/synapse/source/values.yaml.j2
+++ b/charts/synapse/source/values.yaml.j2
@@ -85,6 +85,7 @@ logging:
 {{ sub_schema_values.nodeSelector() }}
 {{ sub_schema_values.podSecurityContext(user_id='10091', group_id='10091') }}
 {{ sub_schema_values.resources(requests_memory='100Mi', requests_cpu='100m', limits_memory='4Gi') }}
+{{ sub_schema_values.serviceAccount() }}
 {{ sub_schema_values.serviceMonitors() }}
 {{ sub_schema_values.tolerations() }}
 
@@ -97,6 +98,7 @@ haproxy:
 {{ sub_schema_values.nodeSelector() | indent(2) }}
 {{ sub_schema_values.podSecurityContext(user_id='10001', group_id='10001') | indent(2) }}
 {{ sub_schema_values.resources(requests_memory='100Mi', requests_cpu='100m', limits_memory='200Mi') | indent(2) }}
+{{ sub_schema_values.serviceAccount() | indent(2) }}
 {{ sub_schema_values.serviceMonitors() | indent(2) }}
 {{ sub_schema_values.tolerations() | indent(2) }}
 
@@ -108,4 +110,5 @@ redis:
 {{ sub_schema_values.nodeSelector() | indent(2) }}
 {{ sub_schema_values.podSecurityContext(user_id='10002', group_id='10002') | indent(2) }}
 {{ sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='50Mi') | indent(2) }}
+{{ sub_schema_values.serviceAccount() | indent(2) }}
 {{ sub_schema_values.tolerations() | indent(2) }}

--- a/charts/synapse/templates/_helpers.tpl
+++ b/charts/synapse/templates/_helpers.tpl
@@ -38,6 +38,18 @@ app.kubernetes.io/instance: {{ .Release.Name }}-synapse-haproxy
 app.kubernetes.io/version: {{ .Values.haproxy.image.tag }}
 {{- end }}
 
+{{- define "element-io.synapse.serviceAccountName" -}}
+{{ default (printf "%s-synapse" .Release.Name ) .Values.serviceAccount.name }}
+{{- end }}
+
+{{- define "element-io.synapse.redis.serviceAccountName" -}}
+{{ default (printf "%s-synapse-redis" .Release.Name ) .Values.redis.serviceAccount.name }}
+{{- end }}
+
+{{- define "element-io.synapse.haproxy.serviceAccountName" -}}
+{{ default (printf "%s-synapse-haproxy" .Release.Name ) .Values.haproxy.serviceAccount.name }}
+{{- end }}
+
 {{- define "element-io.synapse.enabledWorkers" -}}
 {{ $enabledWorkers := dict }}
 {{- range $workerType, $workerDetails := .Values.workers }}

--- a/charts/synapse/templates/haproxy_deployment.yaml
+++ b/charts/synapse/templates/haproxy_deployment.yaml
@@ -50,6 +50,7 @@ spec:
               topologyKey: kubernetes.io/hostname
 {{- end }}
       automountServiceAccountToken: false
+      serviceAccountName: {{ include "element-io.synapse.haproxy.serviceAccountName" $ }}
 {{- include "element-io.ess-library.pods.pullSecrets" (list $ .image) | nindent 6 }}
 {{- with .podSecurityContext }}
       securityContext:

--- a/charts/synapse/templates/haproxy_serviceaccount.yaml
+++ b/charts/synapse/templates/haproxy_serviceaccount.yaml
@@ -1,0 +1,18 @@
+# Copyright 2024 New Vector Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+
+{{- if .Values.haproxy.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- with .Values.haproxy.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "element-io.synapse.haproxy.labels" . | nindent 4 }}
+  name: {{ include "element-io.synapse.haproxy.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/synapse/templates/redis_deployment.yaml
+++ b/charts/synapse/templates/redis_deployment.yaml
@@ -37,6 +37,7 @@ spec:
 {{- end }}
     spec:
       automountServiceAccountToken: false
+      serviceAccountName: {{ include "element-io.synapse.redis.serviceAccountName" $ }}
 {{- include "element-io.ess-library.pods.pullSecrets" (list $ .image) | nindent 6 }}
 {{- with .podSecurityContext }}
       securityContext:

--- a/charts/synapse/templates/redis_serviceaccount.yaml
+++ b/charts/synapse/templates/redis_serviceaccount.yaml
@@ -1,0 +1,20 @@
+# Copyright 2024 New Vector Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+
+{{- if (include "element-io.synapse.enabledWorkers" $) | fromJson }}
+{{- if .Values.redis.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- with .Values.redis.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "element-io.synapse.redis.labels" . | nindent 4 }}
+  name: {{ include "element-io.synapse.redis.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+automountServiceAccountToken: false
+{{- end }}
+{{- end }}

--- a/charts/synapse/templates/synapse_serviceaccount.yaml
+++ b/charts/synapse/templates/synapse_serviceaccount.yaml
@@ -1,0 +1,18 @@
+# Copyright 2024 New Vector Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "element-io.synapse.labels" . | nindent 4 }}
+  name: {{ include "element-io.synapse.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/synapse/templates/synapse_statefulset.yaml
+++ b/charts/synapse/templates/synapse_statefulset.yaml
@@ -48,6 +48,7 @@ spec:
 {{- end }}
     spec:
       automountServiceAccountToken: false
+      serviceAccountName: {{ include "element-io.synapse.serviceAccountName" $ }}
 {{- include "element-io.ess-library.pods.pullSecrets" (list $ .Values.image) | nindent 6 }}
 {{- with .Values.podSecurityContext }}
       securityContext:

--- a/charts/synapse/values.schema.json
+++ b/charts/synapse/values.schema.json
@@ -684,6 +684,24 @@
       "type": "object",
       "additionalProperties": false
     },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "serviceMonitors": {
       "type": "object",
       "properties": {
@@ -1778,6 +1796,24 @@
           "type": "object",
           "additionalProperties": false
         },
+        "serviceAccount": {
+          "type": "object",
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
         "serviceMonitors": {
           "type": "object",
           "properties": {
@@ -2026,6 +2062,24 @@
             }
           },
           "type": "object",
+          "additionalProperties": false
+        },
+        "serviceAccount": {
+          "type": "object",
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
           "additionalProperties": false
         },
         "tolerations": {

--- a/charts/synapse/values.yaml
+++ b/charts/synapse/values.yaml
@@ -473,6 +473,17 @@ resources:
   limits:
     memory: 4Gi
 
+## Controls configuration of the ServiceAccount for this component
+serviceAccount:
+  ## Whether a ServiceAccount should be created by the chart or not
+  create: true
+
+  ## What name to give the ServiceAccount. If not provided the chart will provide the name automatically
+  name: ""
+
+  ## Annotations to add to the service account
+  annotations: {}
+
 ## Whether to deploy ServiceMonitors into the cluster for this component
 ## Requires the ServiceMonitor CRDs to be in the cluster
 serviceMonitors:
@@ -621,6 +632,17 @@ haproxy:
     limits:
       memory: 200Mi
 
+  ## Controls configuration of the ServiceAccount for this component
+  serviceAccount:
+    ## Whether a ServiceAccount should be created by the chart or not
+    create: true
+
+    ## What name to give the ServiceAccount. If not provided the chart will provide the name automatically
+    name: ""
+
+    ## Annotations to add to the service account
+    annotations: {}
+
   ## Whether to deploy ServiceMonitors into the cluster for this component
   ## Requires the ServiceMonitor CRDs to be in the cluster
   serviceMonitors:
@@ -766,6 +788,17 @@ redis:
     ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     limits:
       memory: 50Mi
+
+  ## Controls configuration of the ServiceAccount for this component
+  serviceAccount:
+    ## Whether a ServiceAccount should be created by the chart or not
+    create: true
+
+    ## What name to give the ServiceAccount. If not provided the chart will provide the name automatically
+    name: ""
+
+    ## Annotations to add to the service account
+    annotations: {}
 
   ## Workload tolerations
   ## The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.


### PR DESCRIPTION
https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/

If no `ServiceAccount` is specified `default` is used. We consistently set `automountServiceAccountToken: false` so the `default` `ServiceAccount` shouldn't be usable, but belt-and-braces let's construct unprivileged `ServiceAccounts`