### PR TITLE
pytest: read value file to chose tests to run

### DIFF
--- a/tests/env/element-web.rc
+++ b/tests/env/element-web.rc
@@ -2,5 +2,4 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 
-export TEST_ELEMENT_WEB=1
 export TEST_VALUES_FILE=charts/matrix-stack/ci/pytest-element-web-values.yaml

--- a/tests/env/synapse.rc
+++ b/tests/env/synapse.rc
@@ -2,5 +2,4 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 
-export TEST_SYNAPSE=1
 export TEST_VALUES_FILE=charts/matrix-stack/ci/pytest-synapse-values.yaml

--- a/tests/integration/test_element_web.py
+++ b/tests/integration/test_element_web.py
@@ -3,16 +3,15 @@
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 
 import asyncio
-import os
 
 import pytest
 
 from ..fixtures import ESSData
 from ..lib.helpers import install_matrix_stack, kubernetes_tls_secret
-from ..lib.utils import aiottp_get_json
+from ..lib.utils import aiottp_get_json, value_file_has
 
 
-@pytest.mark.skipif(os.environ.get("TEST_ELEMENT_WEB") != "1", reason="ElementWeb not deployed")
+@pytest.mark.skipif(value_file_has("elementWeb.enabled", False), reason="ElementWeb not deployed")
 @pytest.mark.asyncio_cooperative
 async def test_element_web(
     cluster,
@@ -32,7 +31,7 @@ async def test_element_web(
     await asyncio.gather(revision, *[kube_client.create(r) for r in resources])
 
 
-@pytest.mark.skipif(os.environ.get("TEST_ELEMENT_WEB") != "1", reason="ElementWeb not deployed")
+@pytest.mark.skipif(value_file_has("elementWeb.enabled", False), reason="ElementWeb not deployed")
 @pytest.mark.asyncio_cooperative
 async def test_can_access_config_json(cluster, revision_deployed, generated_data: ESSData, ssl_context):
     await asyncio.to_thread(

--- a/tests/integration/test_synapse.py
+++ b/tests/integration/test_synapse.py
@@ -4,7 +4,6 @@
 
 import asyncio
 import hashlib
-import os
 from pathlib import Path
 
 import pytest
@@ -12,11 +11,11 @@ import pytest
 from ..fixtures import ESSData
 from ..lib.helpers import install_matrix_stack, kubernetes_tls_secret
 from ..lib.synapse import assert_downloaded_content, download_media, upload_media
-from ..lib.utils import KubeCtl, aiohttp_post_json, aiottp_get_json
+from ..lib.utils import KubeCtl, aiohttp_post_json, aiottp_get_json, value_file_has
 from ..services import PostgresServer
 
 
-@pytest.mark.skipif(os.environ.get("TEST_SYNAPSE") != "1", reason="Synapse not deployed")
+@pytest.mark.skipif(value_file_has("synapse.enabled", False), reason="Synapse not deployed")
 @pytest.mark.asyncio_cooperative
 async def test_synapse(
     cluster,
@@ -56,7 +55,7 @@ async def test_synapse(
     assert "unstable_features" in json_content
 
 
-@pytest.mark.skipif(os.environ.get("TEST_SYNAPSE") != "1", reason="Synapse not deployed")
+@pytest.mark.skipif(value_file_has("synapse.enabled", False), reason="Synapse not deployed")
 @pytest.mark.parametrize("synapse_users", [("sliding-sync-user",)], indirect=True)
 @pytest.mark.asyncio_cooperative
 async def test_simplified_sliding_sync_syncs(ssl_context, synapse_users, generated_data: ESSData):
@@ -72,7 +71,7 @@ async def test_simplified_sliding_sync_syncs(ssl_context, synapse_users, generat
     assert "pos" in sync_result
 
 
-@pytest.mark.skipif(os.environ.get("TEST_SYNAPSE") != "1", reason="Synapse not deployed")
+@pytest.mark.skipif(value_file_has("synapse.enabled", False), reason="Synapse not deployed")
 @pytest.mark.parametrize("synapse_users", [("media-upload-unauth",)], indirect=True)
 @pytest.mark.asyncio_cooperative
 async def test_synapse_media_upload_fetch_authenticated(

--- a/tests/lib/utils.py
+++ b/tests/lib/utils.py
@@ -5,6 +5,7 @@
 import asyncio
 import base64
 import json
+import os
 import random
 from dataclasses import dataclass
 from ssl import SSLContext
@@ -12,6 +13,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 import aiohttp
+import yaml
 from aiohttp_retry import ExponentialRetry, RetryClient
 from pytest_kubernetes.providers import AClusterManager
 
@@ -107,3 +109,19 @@ async def aiohttp_post_json(url: str, data: dict, headers: dict, ssl_context: SS
         url.replace(host, "127.0.0.1"), headers=headers | {"Host": host}, server_hostname=host, json=data
     ) as response:
         return await response.json()
+
+
+def value_file_has(property_path, expected):
+    """
+    Check if a nested property (given as a dot-separated string) is set to true in the YAML file.
+    """
+    with open(os.environ["TEST_VALUES_FILE"]) as file:
+        data = yaml.safe_load(file)
+
+    keys = property_path.split(".")
+    for key in keys:
+        if isinstance(data, dict) and key in data:
+            data = data[key]
+        else:
+            return False
+    return data == expected


### PR DESCRIPTION
- Instead of using env var, let's use the value file as it contains everything we need