### PR TITLE
Add topologySpreadConstraints support

### DIFF
--- a/charts/matrix-stack/source/common/ess.json
+++ b/charts/matrix-stack/source/common/ess.json
@@ -18,6 +18,9 @@
           }
         }
       }
+    },
+    "topologySpreadConstraints": {
+      "$ref": "file://./common/topologySpreadConstraints.json"
     }
   }
 }

--- a/charts/matrix-stack/source/common/labelSelector.json
+++ b/charts/matrix-stack/source/common/labelSelector.json
@@ -1,0 +1,44 @@
+{
+  "type": "object",
+  "properties": {
+    "matchExpressions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "operator"
+        ],
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "operator": {
+            "type": "string",
+            "enum": [
+              "In",
+              "NotIn",
+              "Exists",
+              "DoesNotExist"
+            ]
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "matchLabels": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -23,6 +23,8 @@ ess:
   ## imagePullSecrets:
   ## - name: ess-pull-secret
   imagePullSecrets: []
+
+  {{- topologySpreadConstraints(global=true) | indent(2) }}
 {%- endmacro %}
 
 
@@ -309,6 +311,22 @@ labels: {}
 ##   operator:
 ##   value:
 
+{{ key }}: []
+{%- endmacro %}
+
+{% macro topologySpreadConstraints(global=false, key='topologySpreadConstraints') %}
+## TopologySpreadConstraints describes how Pods for {{ 'a' if global else 'this' }} component should be spread between nodes.
+## https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for in-depth details
+## labelSelector can be omitted and the chart will populate a sensible value for {{ 'each' if global else 'this' }} component.
+## Similarly `pod-template-hash` will be aded to `matchLabelKeys` if appropriate for {{ 'each' if global else 'this' }} component.
+## If any TopologySpreadConstraints are provided for a component any global TopologySpreadConstraints are ignored for that component.
+## e.g.
+## {{ key }}:
+## - maxSkew: 1
+##   topologyKey: topology.kubernetes.io/zone
+##   # nodeAffinityPolicy: Honor/Ignore
+##   # nodeTaintsPolicy: Honor/Ignore
+##   # whenUnsatisfiable: DoNotSchedule/ScheduleAnyway
 {{ key }}: []
 {%- endmacro %}
 

--- a/charts/matrix-stack/source/common/topologySpreadConstraints.json
+++ b/charts/matrix-stack/source/common/topologySpreadConstraints.json
@@ -1,0 +1,56 @@
+{
+  "type": "array",
+  "items": {
+    "required": [
+      "maxSkew",
+      "topologyKey"
+    ],
+    "properties": {
+      "labelSelector": {
+        "$ref": "file://common/labelSelector.json"
+      },
+      "matchLabelKeys": {
+        "type": [
+          "array",
+          "null"
+        ],
+        "items": {
+          "type": "string"
+        }
+      },
+      "maxSkew": {
+        "type": "integer",
+        "minium": 1
+      },
+      "minDomains": {
+        "type": "integer",
+        "minium": 0
+      },
+      "nodeAffinityPolicy": {
+        "type": "string",
+        "enum": [
+          "Honor",
+          "Ignore"
+        ]
+      },
+      "nodeTaintsPolicy": {
+        "type": "string",
+        "enum": [
+          "Honor",
+          "Ignore"
+        ]
+      },
+      "topologyKey": {
+        "type": "string"
+      },
+      "whenUnsatisfiable": {
+        "type": "string",
+        "enum": [
+          "DoNotSchedule",
+          "ScheduleAnyway"
+        ]
+      }
+    },
+    "type": "object"
+  }
+}

--- a/charts/matrix-stack/source/element-web.json
+++ b/charts/matrix-stack/source/element-web.json
@@ -46,6 +46,9 @@
     },
     "tolerations": {
       "$ref": "file://./common/tolerations.json"
+    },
+    "topologySpreadConstraints": {
+      "$ref": "file://./common/topologySpreadConstraints.json"
     }
   }
 }

--- a/charts/matrix-stack/source/element-web.yaml.j2
+++ b/charts/matrix-stack/source/element-web.yaml.j2
@@ -23,4 +23,5 @@ replicas: 2
 {{- sub_schema_values.podSecurityContext(user_id='10004', group_id='10004') -}}
 {{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='200Mi') -}}
 {{- sub_schema_values.serviceAccount() -}}
-{{- sub_schema_values.tolerations() }}
+{{- sub_schema_values.tolerations() -}}
+{{- sub_schema_values.topologySpreadConstraints() }}

--- a/charts/matrix-stack/source/synapse.json
+++ b/charts/matrix-stack/source/synapse.json
@@ -140,6 +140,9 @@
     "tolerations": {
       "$ref": "file://./common/tolerations.json"
     },
+    "topologySpreadConstraints": {
+      "$ref": "file://./common/topologySpreadConstraints.json"
+    },
     "workers": {
       "type": "object",
       "properties": {
@@ -235,6 +238,9 @@
         },
         "tolerations": {
           "$ref": "file://./common/tolerations.json"
+        },
+        "topologySpreadConstraints": {
+          "$ref": "file://./common/topologySpreadConstraints.json"
         }
       }
     },

--- a/charts/matrix-stack/source/synapse.yaml.j2
+++ b/charts/matrix-stack/source/synapse.yaml.j2
@@ -84,6 +84,7 @@ logging:
 {{- sub_schema_values.serviceAccount() }}
 {{- sub_schema_values.serviceMonitors() }}
 {{- sub_schema_values.tolerations() }}
+{{- sub_schema_values.topologySpreadConstraints() }}
 
 haproxy:
   replicas: 2
@@ -97,6 +98,7 @@ haproxy:
 {{- sub_schema_values.serviceAccount() | indent(2) }}
 {{- sub_schema_values.serviceMonitors() | indent(2) }}
 {{- sub_schema_values.tolerations() | indent(2) }}
+{{- sub_schema_values.topologySpreadConstraints() | indent(2) }}
 
 redis:
 {{- sub_schema_values.image(registry='docker.io', repository='library/redis', tag='7.4-alpine') | indent(2) }}

--- a/charts/matrix-stack/source/synapse/scalable_worker.json
+++ b/charts/matrix-stack/source/synapse/scalable_worker.json
@@ -12,6 +12,9 @@
     },
     "resources": {
       "$ref": "file://./common/resources.json"
+    },
+    "topologySpreadConstraints": {
+      "$ref": "file://./common/topologySpreadConstraints.json"
     }
   },
   "type": "object"

--- a/charts/matrix-stack/templates/element-web/deployment.yaml
+++ b/charts/matrix-stack/templates/element-web/deployment.yaml
@@ -66,6 +66,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
 {{- end }}
+{{- include "element-io.ess-library.pods.topologySpreadConstraints" (dict "root" $ "context" (dict "instanceSuffix" "element-web" "deployment" true "topologySpreadConstraints" .topologySpreadConstraints)) | indent 6 }}
       containers:
       - name: element-web
 {{- with .image -}}

--- a/charts/matrix-stack/templates/ess-library/_pods.tpl
+++ b/charts/matrix-stack/templates/ess-library/_pods.tpl
@@ -6,13 +6,30 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 
 {{- define "element-io.ess-library.pods.pullSecrets" -}}
 {{- $root := .root -}}
-{{- with required "element-io.ess-library.check-credential missing context" .context -}}
+{{- with required "element-io.ess-library.pods.pullSecrets missing context" .context -}}
 {{- $pullSecrets := list -}}
 {{- if $root.Values.ess -}}
 {{- $pullSecrets := concat .pullSecrets $root.Values.ess.imagePullSecrets }}
 {{- end -}}
 {{- with ($pullSecrets | uniq) }}
 imagePullSecrets:
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "element-io.ess-library.pods.topologySpreadConstraints" -}}
+{{- $root := .root -}}
+{{- with required "element-io.ess-libary.pods.topologySpreadConstraints missing context" .context -}}
+{{- $labelSelector := (dict "matchLabels" (dict "app.kubernetes.io/instance" (printf "%s-%s" $root.Release.Name .instanceSuffix))) }}
+{{- $matchLabelKeys := .deployment | ternary (list "pod-template-hash") list }}
+{{- $defaultConstraintSettings := dict "labelSelector" $labelSelector "matchLabelKeys" $matchLabelKeys "whenUnsatisfiable" "DoNotSchedule" }}
+{{- $topologySpreadConstraints := list -}}
+{{- range $constraint := coalesce .topologySpreadConstraints $root.Values.ess.topologySpreadConstraints -}}
+{{- $topologySpreadConstraints = append $topologySpreadConstraints (mergeOverwrite (deepCopy $defaultConstraintSettings) $constraint) -}}
+{{- end }}
+{{- with $topologySpreadConstraints }}
+topologySpreadConstraints:
 {{ toYaml . }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/haproxy_deployment.yaml
+++ b/charts/matrix-stack/templates/synapse/haproxy_deployment.yaml
@@ -69,6 +69,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
 {{- end }}
+{{- include "element-io.ess-library.pods.topologySpreadConstraints" (dict "root" $ "context" (dict "instanceSuffix" "synapse-haproxy" "deployment" true "topologySpreadConstraints" .topologySpreadConstraints)) | indent 6 }}
       containers:
       - name: haproxy
 {{- with .image -}}

--- a/charts/matrix-stack/templates/synapse/synapse_statefulset.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_statefulset.yaml
@@ -66,6 +66,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
 {{- end }}
+{{- include "element-io.ess-library.pods.topologySpreadConstraints" (dict "root" $ "context" (dict "instanceSuffix" (printf "synapse-%s" $processType) "deployment" false "topologySpreadConstraints" .topologySpreadConstraints)) | indent 6 }}
 {{- with .hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}
@@ -265,4 +266,3 @@ We have an init container to render & merge the config for several reasons:
 {{- end }}
 {{- end -}}
 {{- end -}}
-

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -31,6 +31,106 @@
             },
             "additionalProperties": false
           }
+        },
+        "topologySpreadConstraints": {
+          "type": "array",
+          "items": {
+            "required": [
+              "maxSkew",
+              "topologyKey"
+            ],
+            "properties": {
+              "labelSelector": {
+                "type": "object",
+                "properties": {
+                  "matchExpressions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "operator": {
+                          "type": "string",
+                          "enum": [
+                            "In",
+                            "NotIn",
+                            "Exists",
+                            "DoesNotExist"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "matchLabels": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "matchLabelKeys": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "maxSkew": {
+                "type": "integer",
+                "minium": 1
+              },
+              "minDomains": {
+                "type": "integer",
+                "minium": 0
+              },
+              "nodeAffinityPolicy": {
+                "type": "string",
+                "enum": [
+                  "Honor",
+                  "Ignore"
+                ]
+              },
+              "nodeTaintsPolicy": {
+                "type": "string",
+                "enum": [
+                  "Honor",
+                  "Ignore"
+                ]
+              },
+              "topologyKey": {
+                "type": "string"
+              },
+              "whenUnsatisfiable": {
+                "type": "string",
+                "enum": [
+                  "DoNotSchedule",
+                  "ScheduleAnyway"
+                ]
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          }
         }
       }
     },
@@ -337,6 +437,106 @@
               },
               "value": {
                 "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "topologySpreadConstraints": {
+          "type": "array",
+          "items": {
+            "required": [
+              "maxSkew",
+              "topologyKey"
+            ],
+            "properties": {
+              "labelSelector": {
+                "type": "object",
+                "properties": {
+                  "matchExpressions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "operator": {
+                          "type": "string",
+                          "enum": [
+                            "In",
+                            "NotIn",
+                            "Exists",
+                            "DoesNotExist"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "matchLabels": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "matchLabelKeys": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "maxSkew": {
+                "type": "integer",
+                "minium": 1
+              },
+              "minDomains": {
+                "type": "integer",
+                "minium": 0
+              },
+              "nodeAffinityPolicy": {
+                "type": "string",
+                "enum": [
+                  "Honor",
+                  "Ignore"
+                ]
+              },
+              "nodeTaintsPolicy": {
+                "type": "string",
+                "enum": [
+                  "Honor",
+                  "Ignore"
+                ]
+              },
+              "topologyKey": {
+                "type": "string"
+              },
+              "whenUnsatisfiable": {
+                "type": "string",
+                "enum": [
+                  "DoNotSchedule",
+                  "ScheduleAnyway"
+                ]
               }
             },
             "type": "object",
@@ -954,6 +1154,106 @@
             "additionalProperties": false
           }
         },
+        "topologySpreadConstraints": {
+          "type": "array",
+          "items": {
+            "required": [
+              "maxSkew",
+              "topologyKey"
+            ],
+            "properties": {
+              "labelSelector": {
+                "type": "object",
+                "properties": {
+                  "matchExpressions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "operator": {
+                          "type": "string",
+                          "enum": [
+                            "In",
+                            "NotIn",
+                            "Exists",
+                            "DoesNotExist"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "matchLabels": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "matchLabelKeys": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "maxSkew": {
+                "type": "integer",
+                "minium": 1
+              },
+              "minDomains": {
+                "type": "integer",
+                "minium": 0
+              },
+              "nodeAffinityPolicy": {
+                "type": "string",
+                "enum": [
+                  "Honor",
+                  "Ignore"
+                ]
+              },
+              "nodeTaintsPolicy": {
+                "type": "string",
+                "enum": [
+                  "Honor",
+                  "Ignore"
+                ]
+              },
+              "topologyKey": {
+                "type": "string"
+              },
+              "whenUnsatisfiable": {
+                "type": "string",
+                "enum": [
+                  "DoNotSchedule",
+                  "ScheduleAnyway"
+                ]
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
         "workers": {
           "type": "object",
           "properties": {
@@ -1088,6 +1388,106 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "topologySpreadConstraints": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "maxSkew",
+                      "topologyKey"
+                    ],
+                    "properties": {
+                      "labelSelector": {
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "enum": [
+                                    "In",
+                                    "NotIn",
+                                    "Exists",
+                                    "DoesNotExist"
+                                  ]
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "matchLabels": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "maxSkew": {
+                        "type": "integer",
+                        "minium": 1
+                      },
+                      "minDomains": {
+                        "type": "integer",
+                        "minium": 0
+                      },
+                      "nodeAffinityPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "nodeTaintsPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "type": "string",
+                        "enum": [
+                          "DoNotSchedule",
+                          "ScheduleAnyway"
+                        ]
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
                 }
               },
               "type": "object",
@@ -1181,6 +1581,106 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "topologySpreadConstraints": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "maxSkew",
+                      "topologyKey"
+                    ],
+                    "properties": {
+                      "labelSelector": {
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "enum": [
+                                    "In",
+                                    "NotIn",
+                                    "Exists",
+                                    "DoesNotExist"
+                                  ]
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "matchLabels": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "maxSkew": {
+                        "type": "integer",
+                        "minium": 1
+                      },
+                      "minDomains": {
+                        "type": "integer",
+                        "minium": 0
+                      },
+                      "nodeAffinityPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "nodeTaintsPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "type": "string",
+                        "enum": [
+                          "DoNotSchedule",
+                          "ScheduleAnyway"
+                        ]
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
                 }
               },
               "type": "object",
@@ -1231,6 +1731,106 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "topologySpreadConstraints": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "maxSkew",
+                      "topologyKey"
+                    ],
+                    "properties": {
+                      "labelSelector": {
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "enum": [
+                                    "In",
+                                    "NotIn",
+                                    "Exists",
+                                    "DoesNotExist"
+                                  ]
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "matchLabels": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "maxSkew": {
+                        "type": "integer",
+                        "minium": 1
+                      },
+                      "minDomains": {
+                        "type": "integer",
+                        "minium": 0
+                      },
+                      "nodeAffinityPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "nodeTaintsPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "type": "string",
+                        "enum": [
+                          "DoNotSchedule",
+                          "ScheduleAnyway"
+                        ]
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
                 }
               },
               "type": "object",
@@ -1281,6 +1881,106 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "topologySpreadConstraints": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "maxSkew",
+                      "topologyKey"
+                    ],
+                    "properties": {
+                      "labelSelector": {
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "enum": [
+                                    "In",
+                                    "NotIn",
+                                    "Exists",
+                                    "DoesNotExist"
+                                  ]
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "matchLabels": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "maxSkew": {
+                        "type": "integer",
+                        "minium": 1
+                      },
+                      "minDomains": {
+                        "type": "integer",
+                        "minium": 0
+                      },
+                      "nodeAffinityPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "nodeTaintsPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "type": "string",
+                        "enum": [
+                          "DoNotSchedule",
+                          "ScheduleAnyway"
+                        ]
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
                 }
               },
               "type": "object",
@@ -1331,6 +2031,106 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "topologySpreadConstraints": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "maxSkew",
+                      "topologyKey"
+                    ],
+                    "properties": {
+                      "labelSelector": {
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "enum": [
+                                    "In",
+                                    "NotIn",
+                                    "Exists",
+                                    "DoesNotExist"
+                                  ]
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "matchLabels": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "maxSkew": {
+                        "type": "integer",
+                        "minium": 1
+                      },
+                      "minDomains": {
+                        "type": "integer",
+                        "minium": 0
+                      },
+                      "nodeAffinityPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "nodeTaintsPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "type": "string",
+                        "enum": [
+                          "DoNotSchedule",
+                          "ScheduleAnyway"
+                        ]
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
                 }
               },
               "type": "object",
@@ -1381,6 +2181,106 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "topologySpreadConstraints": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "maxSkew",
+                      "topologyKey"
+                    ],
+                    "properties": {
+                      "labelSelector": {
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "enum": [
+                                    "In",
+                                    "NotIn",
+                                    "Exists",
+                                    "DoesNotExist"
+                                  ]
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "matchLabels": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "maxSkew": {
+                        "type": "integer",
+                        "minium": 1
+                      },
+                      "minDomains": {
+                        "type": "integer",
+                        "minium": 0
+                      },
+                      "nodeAffinityPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "nodeTaintsPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "type": "string",
+                        "enum": [
+                          "DoNotSchedule",
+                          "ScheduleAnyway"
+                        ]
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
                 }
               },
               "type": "object",
@@ -1517,6 +2417,106 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "topologySpreadConstraints": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "maxSkew",
+                      "topologyKey"
+                    ],
+                    "properties": {
+                      "labelSelector": {
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "enum": [
+                                    "In",
+                                    "NotIn",
+                                    "Exists",
+                                    "DoesNotExist"
+                                  ]
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "matchLabels": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "maxSkew": {
+                        "type": "integer",
+                        "minium": 1
+                      },
+                      "minDomains": {
+                        "type": "integer",
+                        "minium": 0
+                      },
+                      "nodeAffinityPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "nodeTaintsPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "type": "string",
+                        "enum": [
+                          "DoNotSchedule",
+                          "ScheduleAnyway"
+                        ]
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
                 }
               },
               "type": "object",
@@ -1610,6 +2610,106 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "topologySpreadConstraints": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "maxSkew",
+                      "topologyKey"
+                    ],
+                    "properties": {
+                      "labelSelector": {
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "enum": [
+                                    "In",
+                                    "NotIn",
+                                    "Exists",
+                                    "DoesNotExist"
+                                  ]
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "matchLabels": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "maxSkew": {
+                        "type": "integer",
+                        "minium": 1
+                      },
+                      "minDomains": {
+                        "type": "integer",
+                        "minium": 0
+                      },
+                      "nodeAffinityPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "nodeTaintsPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "type": "string",
+                        "enum": [
+                          "DoNotSchedule",
+                          "ScheduleAnyway"
+                        ]
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
                 }
               },
               "type": "object",
@@ -1703,6 +2803,106 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "topologySpreadConstraints": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "maxSkew",
+                      "topologyKey"
+                    ],
+                    "properties": {
+                      "labelSelector": {
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "enum": [
+                                    "In",
+                                    "NotIn",
+                                    "Exists",
+                                    "DoesNotExist"
+                                  ]
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "matchLabels": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "maxSkew": {
+                        "type": "integer",
+                        "minium": 1
+                      },
+                      "minDomains": {
+                        "type": "integer",
+                        "minium": 0
+                      },
+                      "nodeAffinityPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "nodeTaintsPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "type": "string",
+                        "enum": [
+                          "DoNotSchedule",
+                          "ScheduleAnyway"
+                        ]
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
                 }
               },
               "type": "object",
@@ -2060,6 +3260,106 @@
                   },
                   "value": {
                     "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "topologySpreadConstraints": {
+              "type": "array",
+              "items": {
+                "required": [
+                  "maxSkew",
+                  "topologyKey"
+                ],
+                "properties": {
+                  "labelSelector": {
+                    "type": "object",
+                    "properties": {
+                      "matchExpressions": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "type": "string",
+                              "enum": [
+                                "In",
+                                "NotIn",
+                                "Exists",
+                                "DoesNotExist"
+                              ]
+                            },
+                            "values": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "matchLabels": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "matchLabelKeys": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "maxSkew": {
+                    "type": "integer",
+                    "minium": 1
+                  },
+                  "minDomains": {
+                    "type": "integer",
+                    "minium": 0
+                  },
+                  "nodeAffinityPolicy": {
+                    "type": "string",
+                    "enum": [
+                      "Honor",
+                      "Ignore"
+                    ]
+                  },
+                  "nodeTaintsPolicy": {
+                    "type": "string",
+                    "enum": [
+                      "Honor",
+                      "Ignore"
+                    ]
+                  },
+                  "topologyKey": {
+                    "type": "string"
+                  },
+                  "whenUnsatisfiable": {
+                    "type": "string",
+                    "enum": [
+                      "DoNotSchedule",
+                      "ScheduleAnyway"
+                    ]
                   }
                 },
                 "type": "object",

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -18,6 +18,19 @@ ess:
   ## imagePullSecrets:
   ## - name: ess-pull-secret
   imagePullSecrets: []
+  ## TopologySpreadConstraints describes how Pods for a component should be spread between nodes.
+  ## https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for in-depth details
+  ## labelSelector can be omitted and the chart will populate a sensible value for each component.
+  ## Similarly `pod-template-hash` will be aded to `matchLabelKeys` if appropriate for each component.
+  ## If any TopologySpreadConstraints are provided for a component any global TopologySpreadConstraints are ignored for that component.
+  ## e.g.
+  ## topologySpreadConstraints:
+  ## - maxSkew: 1
+  ##   topologyKey: topology.kubernetes.io/zone
+  ##   # nodeAffinityPolicy: Honor/Ignore
+  ##   # nodeTaintsPolicy: Honor/Ignore
+  ##   # whenUnsatisfiable: DoNotSchedule/ScheduleAnyway
+  topologySpreadConstraints: []
 
 elementWeb:
   enabled: true
@@ -186,6 +199,19 @@ elementWeb:
   ##   value:
 
   tolerations: []
+  ## TopologySpreadConstraints describes how Pods for this component should be spread between nodes.
+  ## https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for in-depth details
+  ## labelSelector can be omitted and the chart will populate a sensible value for this component.
+  ## Similarly `pod-template-hash` will be aded to `matchLabelKeys` if appropriate for this component.
+  ## If any TopologySpreadConstraints are provided for a component any global TopologySpreadConstraints are ignored for that component.
+  ## e.g.
+  ## topologySpreadConstraints:
+  ## - maxSkew: 1
+  ##   topologyKey: topology.kubernetes.io/zone
+  ##   # nodeAffinityPolicy: Honor/Ignore
+  ##   # nodeTaintsPolicy: Honor/Ignore
+  ##   # whenUnsatisfiable: DoNotSchedule/ScheduleAnyway
+  topologySpreadConstraints: []
 
 synapse:
   enabled: true
@@ -634,6 +660,19 @@ synapse:
   ##   value:
 
   tolerations: []
+  ## TopologySpreadConstraints describes how Pods for this component should be spread between nodes.
+  ## https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for in-depth details
+  ## labelSelector can be omitted and the chart will populate a sensible value for this component.
+  ## Similarly `pod-template-hash` will be aded to `matchLabelKeys` if appropriate for this component.
+  ## If any TopologySpreadConstraints are provided for a component any global TopologySpreadConstraints are ignored for that component.
+  ## e.g.
+  ## topologySpreadConstraints:
+  ## - maxSkew: 1
+  ##   topologyKey: topology.kubernetes.io/zone
+  ##   # nodeAffinityPolicy: Honor/Ignore
+  ##   # nodeTaintsPolicy: Honor/Ignore
+  ##   # whenUnsatisfiable: DoNotSchedule/ScheduleAnyway
+  topologySpreadConstraints: []
 
   haproxy:
     replicas: 2
@@ -783,6 +822,19 @@ synapse:
     ##   value:
 
     tolerations: []
+    ## TopologySpreadConstraints describes how Pods for this component should be spread between nodes.
+    ## https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ for in-depth details
+    ## labelSelector can be omitted and the chart will populate a sensible value for this component.
+    ## Similarly `pod-template-hash` will be aded to `matchLabelKeys` if appropriate for this component.
+    ## If any TopologySpreadConstraints are provided for a component any global TopologySpreadConstraints are ignored for that component.
+    ## e.g.
+    ## topologySpreadConstraints:
+    ## - maxSkew: 1
+    ##   topologyKey: topology.kubernetes.io/zone
+    ##   # nodeAffinityPolicy: Honor/Ignore
+    ##   # nodeTaintsPolicy: Honor/Ignore
+    ##   # whenUnsatisfiable: DoNotSchedule/ScheduleAnyway
+    topologySpreadConstraints: []
 
   redis:
     # Details of the image to be used


### PR DESCRIPTION
Support configuring topologySpreadConstraints both globally (via `ess.topologySpreadConstraints`) and on a per-component basis.

Given this is an array we don't merge the global and per-component settings, the per-component settings entirely replace the global ones.

To ease usage we automatically set sensible `labelSelectors` and, in the case of a `Deployment`, `matchLabelKeys`. The defaults can be removed by setting `matchLabelKeys: null`/`labelSelectors.matchLabels: null`/`labelSelectors.matchLabels['app.kubernetes.io/instance']: null` otherwise they're merged in