### PR TITLE
Make serverName optional for element web

### DIFF
--- a/charts/matrix-stack/ci/element-web-minimal-values.yaml
+++ b/charts/matrix-stack/ci/element-web-minimal-values.yaml
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 
-serverName: ess.localhost
-
 elementWeb:
   enabled: true
   additional:

--- a/charts/matrix-stack/templates/element-web/_helpers.tpl
+++ b/charts/matrix-stack/templates/element-web/_helpers.tpl
@@ -26,11 +26,12 @@ app.kubernetes.io/version: {{ .image.tag | default $root.Chart.AppVersion }}
 {{- $root := .root -}}
 {{- with required "element-io.element-web.config missing context" .context -}}
 {{- $config := dict -}}
-{{- $serverName := required "Element Web requires serverName set" $root.Values.serverName -}}
-{{- $mHomeserver := dict "server_name" $serverName }}
+{{- $mHomeserver := dict }}
+{{- if $root.Values.serverName }}
+{{- $_ := set $mHomeserver "server_name" $root.Values.serverName }}
+{{- end }}
 {{- if $root.Values.synapse.enabled }}
-{{- $baseUrl := "https://{{ $root.Values.synapse.ingress.host }}" -}}
-{{- $mHomeserver := merge (dict "base_url" $baseUrl) $mHomeserver }}
+{{- $_ := set $mHomeserver "base_url" (printf "https://%s" $root.Values.synapse.ingress.host) -}}
 {{- end }}
 {{- $defaultServerConfig := dict "m.homeserver" $mHomeserver -}}
 {{- $_ := set $config "default_server_config" $defaultServerConfig -}}


### PR DESCRIPTION
In the same way that Element Web no longer requires Synapse or a manual configuration of the homeserver URL, it shouldn't require setting of a specific server name