### PR TITLE
Support running more than 1 values_file per component

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,6 @@ build-backend = "poetry.core.masonry.api"
 [tool.pytest.ini_options]
 # we use asyncio-cooperative
 addopts = "-p no:asyncio --strict-markers"
-markers = [
-    "values_file(filename): use specific values file for this test",
-]
 
 [tool.ruff]
 line-length = 120

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -9,7 +9,11 @@ _raw_component_details = {
     "elementWeb": {
         "hyphened_name": "element-web",
     },
-    "synapse": {},
+    "synapse": {
+        "additional_values_files": [
+            "synapse-worker-example-values.yaml",
+        ]
+    },
 }
 
 
@@ -18,15 +22,25 @@ def _enrich_components_to_test() -> Dict[str, Any]:
     for component in _raw_component_details:
         _component_details[component].setdefault("hyphened_name", component)
 
-        _component_details[component]["minimal_values_file"] = (
-            f"{_component_details[component]["hyphened_name"]}-minimal-values.yaml"
-        )
+        values_files = _component_details[component].setdefault("additional_values_files", [])
+        values_files.append(f"{_component_details[component]["hyphened_name"]}-minimal-values.yaml")
+        _component_details[component]["values_files"] = values_files
+        del _component_details[component]["additional_values_files"]
+
         _component_details[component].setdefault("has_ingress", True)
     return _component_details
 
 
 component_details = _enrich_components_to_test()
-components_to_test = component_details.keys()
-components_with_ingresses = [
-    component for component in components_to_test if component_details[component]["has_ingress"]
+
+values_files_to_components = {
+    values_file: component
+    for component, details in component_details.items()
+    for values_file in details["values_files"]
+}
+values_files_to_test = values_files_to_components.keys()
+values_files_with_ingresses = [
+    values_file
+    for values_file, component in values_files_to_components.items()
+    if component_details[component]["has_ingress"]
 ]

--- a/tests/manifests/test_basic.py
+++ b/tests/manifests/test_basic.py
@@ -4,21 +4,19 @@
 
 import pytest
 
-from . import component_details, components_to_test
+from . import component_details, values_files_to_test
 
 
-@pytest.mark.values_file("nothing-enabled-values.yaml")
+@pytest.mark.parametrize("values_file", ["nothing-enabled-values.yaml"])
 @pytest.mark.asyncio_cooperative
 async def test_nothing_enabled_renders_nothing(templates):
     assert len(templates) == 0
 
 
-@pytest.mark.parametrize("component", components_to_test)
+@pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_minimal_values_file_renders_only_itself(component, templates):
+async def test_values_file_renders_only_itself(component, templates):
     assert len(templates) > 0
 
-    # We can't easily check that the values file is truely minimal
-    # But we can check that it includes no other components
     for template in templates:
         assert template["metadata"]["name"].startswith(f"pytest-{component_details[component]["hyphened_name"]}")

--- a/tests/manifests/test_ingresses.py
+++ b/tests/manifests/test_ingresses.py
@@ -4,10 +4,10 @@
 
 import pytest
 
-from . import components_to_test, components_with_ingresses
+from . import component_details, values_files_to_test, values_files_with_ingresses
 
 
-@pytest.mark.parametrize("component", components_to_test)
+@pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_has_ingress(component, templates):
     has_ingress = False
@@ -15,10 +15,10 @@ async def test_has_ingress(component, templates):
         if template["kind"] == "Ingress":
             has_ingress = True
 
-    assert has_ingress == (component in components_with_ingresses)
+    assert has_ingress == component_details[component]["has_ingress"]
 
 
-@pytest.mark.parametrize("component", components_with_ingresses)
+@pytest.mark.parametrize("values_file", values_files_with_ingresses)
 @pytest.mark.asyncio_cooperative
 async def test_ingress_is_expected_host(component, values, templates):
     for template in templates:
@@ -31,9 +31,9 @@ async def test_ingress_is_expected_host(component, values, templates):
                 assert rule["host"] == values[component]["ingress"]["host"]
 
 
-@pytest.mark.parametrize("component", components_with_ingresses)
+@pytest.mark.parametrize("values_file", values_files_with_ingresses)
 @pytest.mark.asyncio_cooperative
-async def test_ingress_paths_are_all_prefix(component, templates):
+async def test_ingress_paths_are_all_prefix(templates):
     for template in templates:
         if template["kind"] == "Ingress":
             assert "rules" in template["spec"]
@@ -49,15 +49,15 @@ async def test_ingress_paths_are_all_prefix(component, templates):
                     assert path["pathType"] == "Prefix"
 
 
-@pytest.mark.parametrize("component", components_with_ingresses)
+@pytest.mark.parametrize("values_file", values_files_with_ingresses)
 @pytest.mark.asyncio_cooperative
-async def test_no_ingress_annotations_by_default(component, templates):
+async def test_no_ingress_annotations_by_default(templates):
     for template in templates:
         if template["kind"] == "Ingress":
             assert "annotations" not in template["metadata"]
 
 
-@pytest.mark.parametrize("component", components_with_ingresses)
+@pytest.mark.parametrize("values_file", values_files_with_ingresses)
 @pytest.mark.asyncio_cooperative
 async def test_renders_component_ingress_annotations(component, values, make_templates):
     values[component]["ingress"]["annotations"] = {
@@ -71,9 +71,9 @@ async def test_renders_component_ingress_annotations(component, values, make_tem
             assert template["metadata"]["annotations"]["component"] == "set"
 
 
-@pytest.mark.parametrize("component", components_with_ingresses)
+@pytest.mark.parametrize("values_file", values_files_with_ingresses)
 @pytest.mark.asyncio_cooperative
-async def test_renders_global_ingress_annotations(component, values, make_templates):
+async def test_renders_global_ingress_annotations(values, make_templates):
     values.setdefault("ingress", {})["annotations"] = {
         "global": "set",
     }
@@ -85,7 +85,7 @@ async def test_renders_global_ingress_annotations(component, values, make_templa
             assert template["metadata"]["annotations"]["global"] == "set"
 
 
-@pytest.mark.parametrize("component", components_with_ingresses)
+@pytest.mark.parametrize("values_file", values_files_with_ingresses)
 @pytest.mark.asyncio_cooperative
 async def test_merges_global_and_component_ingress_annotations(component, values, make_templates):
     values[component]["ingress"]["annotations"] = {
@@ -113,15 +113,15 @@ async def test_merges_global_and_component_ingress_annotations(component, values
             assert template["metadata"]["annotations"]["global"] is None
 
 
-@pytest.mark.parametrize("component", components_with_ingresses)
+@pytest.mark.parametrize("values_file", values_files_with_ingresses)
 @pytest.mark.asyncio_cooperative
-async def test_no_ingress_tlsSecret_by_default(component, templates):
+async def test_no_ingress_tlsSecret_by_default(templates):
     for template in templates:
         if template["kind"] == "Ingress":
             assert "tls" not in template["spec"]
 
 
-@pytest.mark.parametrize("component", components_with_ingresses)
+@pytest.mark.parametrize("values_file", values_files_with_ingresses)
 @pytest.mark.asyncio_cooperative
 async def test_uses_component_ingress_tlsSecret(component, values, make_templates):
     values[component]["ingress"]["tlsSecret"] = "component"
@@ -135,9 +135,9 @@ async def test_uses_component_ingress_tlsSecret(component, values, make_template
             assert template["spec"]["tls"][0]["secretName"] == "component"
 
 
-@pytest.mark.parametrize("component", components_with_ingresses)
+@pytest.mark.parametrize("values_file", values_files_with_ingresses)
 @pytest.mark.asyncio_cooperative
-async def test_uses_global_ingress_tlsSecret(component, values, make_templates):
+async def test_uses_global_ingress_tlsSecret(values, make_templates):
     values.setdefault("ingress", {})["tlsSecret"] = "global"
 
     for template in await make_templates(values):
@@ -149,7 +149,7 @@ async def test_uses_global_ingress_tlsSecret(component, values, make_templates):
             assert template["spec"]["tls"][0]["secretName"] == "global"
 
 
-@pytest.mark.parametrize("component", components_with_ingresses)
+@pytest.mark.parametrize("values_file", values_files_with_ingresses)
 @pytest.mark.asyncio_cooperative
 async def test_component_ingress_tlsSecret_beats_global(component, values, make_templates):
     values[component]["ingress"]["tlsSecret"] = "component"
@@ -164,15 +164,15 @@ async def test_component_ingress_tlsSecret_beats_global(component, values, make_
             assert template["spec"]["tls"][0]["secretName"] == "component"
 
 
-@pytest.mark.parametrize("component", components_with_ingresses)
+@pytest.mark.parametrize("values_file", values_files_with_ingresses)
 @pytest.mark.asyncio_cooperative
-async def test_no_ingressClassName_by_default(component, templates):
+async def test_no_ingressClassName_by_default(templates):
     for template in templates:
         if template["kind"] == "Ingress":
             assert "ingressClassName" not in template["spec"]
 
 
-@pytest.mark.parametrize("component", components_with_ingresses)
+@pytest.mark.parametrize("values_file", values_files_with_ingresses)
 @pytest.mark.asyncio_cooperative
 async def test_uses_component_ingressClassName(component, values, make_templates):
     values[component]["ingress"]["className"] = "component"
@@ -183,9 +183,9 @@ async def test_uses_component_ingressClassName(component, values, make_templates
             assert template["spec"]["ingressClassName"] == "component"
 
 
-@pytest.mark.parametrize("component", components_with_ingresses)
+@pytest.mark.parametrize("values_file", values_files_with_ingresses)
 @pytest.mark.asyncio_cooperative
-async def test_uses_global_ingressClassName(component, values, make_templates):
+async def test_uses_global_ingressClassName(values, make_templates):
     values.setdefault("ingress", {})["className"] = "global"
 
     for template in await make_templates(values):
@@ -194,7 +194,7 @@ async def test_uses_global_ingressClassName(component, values, make_templates):
             assert template["spec"]["ingressClassName"] == "global"
 
 
-@pytest.mark.parametrize("component", components_with_ingresses)
+@pytest.mark.parametrize("values_file", values_files_with_ingresses)
 @pytest.mark.asyncio_cooperative
 async def test_component_ingressClassName_beats_global(component, values, make_templates):
     values[component]["ingress"]["className"] = "component"

--- a/tests/manifests/test_manifest_test_infrastructure.py
+++ b/tests/manifests/test_manifest_test_infrastructure.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from . import component_details, components_to_test
+from . import component_details, values_files_to_test
 
 
 def test_all_components_covered():
@@ -22,8 +22,9 @@ def test_all_components_covered():
         assert contents.name in expected_folders
 
 
-@pytest.mark.parametrize("component", components_to_test)
-def test_component_has_minimal_values_file(component):
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+def test_component_has_values_file(values_file):
     ci_folder = Path(__file__).parent.parent.parent / Path("charts/matrix-stack/ci")
-    values_file = ci_folder / Path(component_details[component]["minimal_values_file"])
+    values_file = ci_folder / values_file
     assert values_file.exists()

--- a/tests/manifests/utils.py
+++ b/tests/manifests/utils.py
@@ -9,7 +9,7 @@ import pyhelm3
 import pytest
 import yaml
 
-from . import component_details
+from . import values_files_to_components
 
 
 @pytest.fixture(scope="session")
@@ -23,18 +23,12 @@ async def chart(helm_client: pyhelm3.Client):
 
 
 @pytest.fixture(scope="function")
-def component(request):
-    return request.param
+def component(values_file):
+    return values_files_to_components[values_file]
 
 
 @pytest.fixture(scope="function")
-def values(request) -> Dict[str, Any]:
-    values_file_marker = request.node.get_closest_marker("values_file")
-    if values_file_marker:
-        values_file = values_file_marker.args[0]
-    else:
-        component = request.param
-        values_file = component_details[component]["minimal_values_file"]
+def values(values_file) -> Dict[str, Any]:
     return yaml.safe_load((Path("charts/matrix-stack/ci") / values_file).read_text("utf-8"))
 
 


### PR DESCRIPTION
Breaks the 1:1 link between component and values_file. This also has the advantage of testing a specific values file is done in the same way as testing the default set of values files.

We still expect there to be a minimal values file for each component but now additional ones can be provided. Synapse takes advantage of this to run the workers values file as well.

We can now also remove the unused `component` argument from tests that don't need it as we parameterize on `values_file` rather than `component`