### PR TITLE
Remove usage of Chart.AppVersion, we don't have it after the flattening

### DIFF
--- a/charts/matrix-stack/templates/element-web/_helpers.tpl
+++ b/charts/matrix-stack/templates/element-web/_helpers.tpl
@@ -11,7 +11,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 app.kubernetes.io/component: matrix-client
 app.kubernetes.io/name: element-web
 app.kubernetes.io/instance: {{ $root.Release.Name }}-element-web
-app.kubernetes.io/version: {{ .image.tag | default $root.Chart.AppVersion }}
+app.kubernetes.io/version: {{ .image.tag }}
 {{- end }}
 {{- end }}
 

--- a/charts/matrix-stack/templates/element-web/deployment.yaml
+++ b/charts/matrix-stack/templates/element-web/deployment.yaml
@@ -74,7 +74,7 @@ spec:
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
         imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
 {{- else }}
-        image: "{{ .registry }}/{{ .repository }}:{{ .tag | default $.Chart.AppVersion }}"
+        image: "{{ .registry }}/{{ .repository }}:{{ required "elementWeb.image.tag is required if no digest" .tag }}"
         imagePullPolicy: {{ .pullPolicy | default "Always" }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/_helpers.tpl
+++ b/charts/matrix-stack/templates/synapse/_helpers.tpl
@@ -11,7 +11,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 app.kubernetes.io/component: matrix-server
 app.kubernetes.io/name: synapse
 app.kubernetes.io/instance: {{ $root.Release.Name }}-synapse
-app.kubernetes.io/version: {{ .image.tag | default $root.Chart.AppVersion }}
+app.kubernetes.io/version: {{ .image.tag }}
 k8s.element.io/synapse-instance: {{ $root.Release.Name }}-synapse
 {{- end }}
 {{- end }}
@@ -23,7 +23,7 @@ k8s.element.io/synapse-instance: {{ $root.Release.Name }}-synapse
 app.kubernetes.io/component: matrix-server
 app.kubernetes.io/name: synapse-{{ .ProcessType }}
 app.kubernetes.io/instance: {{ $root.Release.Name }}-synapse-{{ .ProcessType }}
-app.kubernetes.io/version: {{ .image.tag | default $root.Chart.AppVersion }}
+app.kubernetes.io/version: {{ .image.tag }}
 k8s.element.io/synapse-instance: {{ $root.Release.Name }}-synapse
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/haproxy_deployment.yaml
+++ b/charts/matrix-stack/templates/synapse/haproxy_deployment.yaml
@@ -77,7 +77,7 @@ spec:
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
         imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
 {{- else }}
-        image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
+        image: "{{ .registry }}/{{ .repository }}:{{ required "synapse.haproxy.image.tag is required if no digest" .tag }}"
         imagePullPolicy: {{ .pullPolicy | default "Always" }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/redis_deployment.yaml
+++ b/charts/matrix-stack/templates/synapse/redis_deployment.yaml
@@ -64,7 +64,7 @@ spec:
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
         imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
 {{- else }}
-        image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
+        image: "{{ .registry }}/{{ .repository }}:{{ required "synapse.redis.image.tag is required if no digest" .tag }}"
         imagePullPolicy: {{ .pullPolicy | default "Always" }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/synapse_statefulset.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_statefulset.yaml
@@ -85,7 +85,7 @@ We have an init container to render & merge the config for several reasons:
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
         imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
 {{- else }}
-        image: "{{ .registry }}/{{ .repository }}:{{ .tag | default $.Chart.AppVersion }}"
+        image: "{{ .registry }}/{{ .repository }}:{{ required "synapse.image.tag is required if no digest" .tag }}"
         imagePullPolicy: {{ .pullPolicy | default "Always" }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
https://github.com/element-hq/ess-helm/blob/main/charts/matrix-stack/Chart.yaml has no `appVersion`. Require a tag if we're not using digests. Accept a blank label if we are using digests and unset the default tag