### PR TITLE
Synapse: ensure registration ConfigMaps as templated

### DIFF
--- a/charts/matrix-stack/templates/synapse/synapse_statefulset.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_statefulset.yaml
@@ -252,8 +252,8 @@ We have an init container to render & merge the config for several reasons:
 {{- range $appservice := .appservices }}
       - configMap:
           defaultMode: 420
-          name: "{{ $appservice.registrationFileConfigMap }}"
-        name: {{ $appservice.registrationFileConfigMap }}
+          name: "{{ tpl $appservice.registrationFileConfigMap $ }}"
+        name: {{ tpl $appservice.registrationFileConfigMap $ }}
 {{- end }}
 {{- if (include "element-io.synapse.process.responsibleForMedia" (dict "root" $ "context" (dict "processType" $processType "enabledWorkerTypes" (keys $enabledWorkers)))) }}
       - persistentVolumeClaim:

--- a/tests/manifests/test_synapse.py
+++ b/tests/manifests/test_synapse.py
@@ -1,0 +1,29 @@
+# Copyright 2024 New Vector Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+
+import pytest
+
+
+@pytest.mark.parametrize("values_file", ["synapse-minimal-values.yaml"])
+@pytest.mark.asyncio_cooperative
+async def test_appservice_configmaps_are_templated(values, make_templates):
+    values["synapse"].setdefault("appservices", []).append({"registrationFileConfigMap": "as-{{ $.Release.Name }}"})
+
+    for template in await make_templates(values):
+        if template["kind"] == "StatefulSet":
+            for volume in template["spec"]["template"]["spec"]["volumes"]:
+                if (
+                    "configMap" in volume
+                    and volume["configMap"]["name"] == "as-pytest"
+                    and volume["name"] == "as-pytest"
+                ):
+                    break
+            else:
+                raise AssertionError("The appservice configMap wasn't included in the volumes")
+
+            for volumeMount in template["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]:
+                if volumeMount["name"] == "as-pytest" and volumeMount["mountPath"] == "/as/as-pytest/registration.yaml":
+                    break
+            else:
+                raise AssertionError("The appservice configMap isn't mounted at the expected location")


### PR DESCRIPTION
This was partially corrected in #90 but the `volume` entry was missed, so let's test it!