### PR TITLE
tests: fix prometheus crds namespace in pytest

### DIFF
--- a/tests/integration/fixtures/cluster.py
+++ b/tests/integration/fixtures/cluster.py
@@ -157,8 +157,8 @@ async def prometheus_operator_crds(helm_client):
             "prometheus-operator-crds",
             chart,
             {},
-            namespace="default",
-            create_namespace=False,
+            namespace="prometheus-operator",
+            create_namespace=True,
             atomic=True,
             wait=True,
         )


### PR DESCRIPTION
The `setup_test_cluster.sh` scripts creates this chart in this namespace. Running pytest against this cluster fails because the chart is not in the same namespace.