### PR TITLE
Element Web: upgrade to 1.11.89

### DIFF
--- a/charts/matrix-stack/source/element-web.yaml.j2
+++ b/charts/matrix-stack/source/element-web.yaml.j2
@@ -17,7 +17,7 @@ additional: {}
 
 # Number of Element Web replicas to start up
 replicas: 2
-{{- sub_schema_values.image(registry='docker.io', repository='vectorim/element-web', tag='v1.11.87') -}}
+{{- sub_schema_values.image(registry='docker.io', repository='vectorim/element-web', tag='v1.11.89') -}}
 {{- sub_schema_values.ingress() -}}
 {{- sub_schema_values.labels() -}}
 {{- sub_schema_values.workloadAnnotations() -}}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -90,7 +90,7 @@ elementWeb:
 
     ## The tag of the container image to use.
     ## Defaults to the Chart's appVersion if not set
-    tag: v1.11.87
+    tag: v1.11.89
 
     ## Container digest to use. Used to pull the image instead of the image tag / Chart appVersion if set
     # digest:


### PR DESCRIPTION
Brings in https://github.com/element-hq/element-web/releases/tag/v1.11.88 & https://github.com/element-hq/element-web/releases/tag/v1.11.89