### PR TITLE
Synapse: upgrade to 1.121.1

### DIFF
--- a/charts/matrix-stack/source/synapse.yaml.j2
+++ b/charts/matrix-stack/source/synapse.yaml.j2
@@ -75,7 +75,7 @@ logging:
   ## levelOverrides:
   ##   synapse.util.caches.lrucache: WARNING
   levelOverrides: {}
-{{- sub_schema_values.image(registry='docker.io', repository='matrixdotorg/synapse', tag='v1.120.2') }}
+{{- sub_schema_values.image(registry='docker.io', repository='matrixdotorg/synapse', tag='v1.121.1') }}
 {{- sub_schema_values.ingress() }}
 {{- sub_schema_values.labels() }}
 {{- sub_schema_values.workloadAnnotations() }}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -692,7 +692,7 @@ synapse:
 
     ## The tag of the container image to use.
     ## Defaults to the Chart's appVersion if not set
-    tag: v1.120.2
+    tag: v1.121.1
 
     ## Container digest to use. Used to pull the image instead of the image tag / Chart appVersion if set
     # digest:


### PR DESCRIPTION
Brings in https://github.com/element-hq/synapse/releases/tag/v1.121.0