### PR TITLE
Increase test cluster logging capacity from 5x10=50Mi to 10x100=1000Mi

### DIFF
--- a/tests/integration/fixtures/files/clusters/kind-ci.yml
+++ b/tests/integration/fixtures/files/clusters/kind-ci.yml
@@ -13,6 +13,11 @@ nodes:
     nodeRegistration:
       kubeletExtraArgs:
         node-labels: "ingress-ready=true"
+  - |-
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    kind: KubeletConfiguration
+    containerLogMaxSize: 100Mi
+    containerLogMaxFiles: 10
   extraPortMappings:
   - containerPort: 80
     hostPort: 80

--- a/tests/integration/fixtures/files/clusters/kind.yml
+++ b/tests/integration/fixtures/files/clusters/kind.yml
@@ -13,6 +13,11 @@ nodes:
     nodeRegistration:
       kubeletExtraArgs:
         node-labels: "ingress-ready=true"
+  - |-
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    kind: KubeletConfiguration
+    containerLogMaxSize: 100Mi
+    containerLogMaxFiles: 10
   extraPortMappings:
   - containerPort: 80
     hostPort: 80


### PR DESCRIPTION
Providing https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration via https://github.com/kubernetes-sigs/kind/blob/main/site/content/docs/user/kind-example-config.yaml#L6-L11 