### PR TITLE
tests: verify secrets consistency in env variables

### DIFF
--- a/newsfragments/124.added.md
+++ b/newsfragments/124.added.md
@@ -1,0 +1,1 @@
+Tests: Verify that we can find secrets in env variables.


### PR DESCRIPTION
This is required if some secrets paths are passed through env variables.