### PR TITLE
releasing: fix download artifact path

### DIFF
--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -114,7 +114,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: helm-package
-        path: charts/matrix-stack/
+        path: ./
 
     - name: Calculate versions
       id: versions


### PR DESCRIPTION
The artifact is packaged from the root directory.