### PR TITLE
Correct the SHA used in dev builds to match the commit sha

### DIFF
--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -51,7 +51,13 @@ jobs:
         if [ "$GITHUB_REF_TYPE" = "tag" ]; then
           scripts/set_chart_version.sh "$GITHUB_REF_NAME"
         elif [ "$GITHUB_REF_NAME" != "main" ]; then
-          version=$(yq '.version' charts/matrix-stack/Chart.yaml | sed "s/-dev/-sha$GITHUB_SHA/")
+          # https://github.com/orgs/community/discussions/26325
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            actual_pr_head_commit=$(cat $GITHUB_EVENT_PATH | yq --input-format json -r .pull_request.head.sha)
+            version=$(yq '.version' charts/matrix-stack/Chart.yaml | sed "s/-dev/-sha$actual_pr_head_commit/")
+          else
+            version=$(yq '.version' charts/matrix-stack/Chart.yaml | sed "s/-dev/-sha$GITHUB_SHA/")
+          fi
           scripts/set_chart_version.sh "$version"
         fi
 

--- a/newsfragments/134.internal.md
+++ b/newsfragments/134.internal.md
@@ -1,0 +1,1 @@
+Correct SHA used in dev builds to match the commit sha.


### PR DESCRIPTION
Without this the sha is a merge commit between the base branch (`main`) and the PR branch