### PR TITLE
ci: add gotestfmt

### DIFF
--- a/.github/workflows/matrix-tools.yml
+++ b/.github/workflows/matrix-tools.yml
@@ -43,7 +43,7 @@ jobs:
         golangci-lint run ./... -v --show-stats --no-config --modules-download-mode readonly --timeout 5m
 
     - name: Run tests
-      run: cd matrix-tools && go test -v ./...
+      run: cd matrix-tools && go test -v  -json ./... 2>&1 | gotestfmt
 
   # Build our application docker images in parallel.
   docker-build-and-push:

--- a/Dockerfile.ci-runner
+++ b/Dockerfile.ci-runner
@@ -11,6 +11,7 @@ ENV KUBECTL_VERSION=v1.31.0
 ARG POETRY_VERSION=1.8.4
 ARG YQ_VERSION=4.44.3
 ARG GO_VERSION=1.23.5
+ARG GOTESTFMT_VERSION=2.5.0
 
 ARG PIPX_BIN_DIR=/usr/local/bin
 
@@ -49,6 +50,10 @@ RUN <<EOT bash
   # Install golangci-lint
   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.63.4
   golangci-lint --version
+
+  # Install gotest-fmt
+  curl -L https://github.com/GoTestTools/gotestfmt/releases/download/v${GOTESTFMT_VERSION}/gotestfmt_${GOTESTFMT_VERSION}_linux_amd64.tar.gz | tar -C /usr/local/bin -xvz
+  gotestfmt -help
 
   # Helm
   mkdir helm && pushd helm

--- a/newsfragments/147.internal.md
+++ b/newsfragments/147.internal.md
@@ -1,0 +1,1 @@
+Add gotestfmt in golang CI tests.


### PR DESCRIPTION
It's a classic go tool to format test output properly in diverse CI contexts. 

https://github.com/GoTestTools/gotestfmt