### PR TITLE
pytest: disable initSecrets when its not needed

### DIFF
--- a/charts/matrix-stack/ci/pytest-element-web-values.yaml
+++ b/charts/matrix-stack/ci/pytest-element-web-values.yaml
@@ -4,10 +4,8 @@
 
 serverName: ess.localhost
 
-matrixTools:
-  image:
-    pullPolicy: Never
-    digest: ""
+initSecrets:
+  enabled: false
 
 elementWeb:
   ingress:

--- a/charts/matrix-stack/ci/pytest-well-known-values.yaml
+++ b/charts/matrix-stack/ci/pytest-well-known-values.yaml
@@ -8,6 +8,9 @@ global:
 # To check that templating works against the ingress
 serverName: "{{ $.Values.global.baseDomain }}"
 
+initSecrets:
+  enabled: false
+
 synapse:
   enabled: false
 

--- a/newsfragments/149.internal.md
+++ b/newsfragments/149.internal.md
@@ -1,0 +1,1 @@
+Disable initSecrets in pytests which do not need it.


### PR DESCRIPTION
Follow-up of https://github.com/element-hq/ess-helm/pull/142#pullrequestreview-2598041749