### PR TITLE
Manifest Tests: use a dynamically generated release name

### DIFF
--- a/newsfragments/151.internal.md
+++ b/newsfragments/151.internal.md
@@ -1,0 +1,1 @@
+Use a dynamic Helm release name in the manifest tests.

--- a/tests/manifests/test_basic.py
+++ b/tests/manifests/test_basic.py
@@ -15,14 +15,14 @@ async def test_nothing_enabled_renders_nothing(templates):
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_values_file_renders_only_itself(component, templates):
+async def test_values_file_renders_only_itself(release_name, component, templates):
     # init-secrets does not render any manifest without any component needing it
     assert len(templates) > 0
 
     allowed_starts_with = [
-        f"pytest-{component_details[component]['hyphened_name']}",
+        f"{release_name}-{component_details[component]['hyphened_name']}",
     ]
     for shared_component in component_details[component].get("shared_components", []):
-        allowed_starts_with.append(f"pytest-{shared_component}")
+        allowed_starts_with.append(f"{release_name}-{shared_component}")
     for template in templates:
         assert any(template["metadata"]["name"].startswith(allowed_start) for allowed_start in allowed_starts_with)

--- a/tests/manifests/test_labels.py
+++ b/tests/manifests/test_labels.py
@@ -9,7 +9,7 @@ from . import values_files_to_test
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_templates_have_expected_labels(templates):
+async def test_templates_have_expected_labels(release_name, templates):
     expected_labels = [
         "helm.sh/chart",
         "app.kubernetes.io/managed-by",
@@ -34,15 +34,17 @@ async def test_templates_have_expected_labels(templates):
         assert labels["app.kubernetes.io/managed-by"] == "Helm"
         assert labels["app.kubernetes.io/part-of"] == "matrix-stack"
 
-        # The instance label is <release name>-<name label>. The release name for the manifest tests is "pytest"
-        assert labels["app.kubernetes.io/instance"].startswith("pytest-"), (
+        # The instance label is <release name>-<name label>.
+        assert labels["app.kubernetes.io/instance"].startswith(f"{release_name}-"), (
             f"The app.kubernetes.io/instance label for {id}"
-            "does not start with the expected chart release name of 'pytest'. "
+            f"does not start with the expected chart release name of '{release_name}'. "
         )
         f"The label value is {labels['app.kubernetes.io/instance']}"
 
-        assert labels["app.kubernetes.io/instance"].replace("pytest-", "") == labels["app.kubernetes.io/name"], (
+        assert (
+            labels["app.kubernetes.io/instance"].replace(f"{release_name}-", "") == labels["app.kubernetes.io/name"]
+        ), (
             f"The app.kubernetes.io/name label for {id}"
-            "is not a concatenation of the expected chart release name of 'pytest' and the instance label. "
+            "is not a concatenation of the expected chart release name of '{release_name}' and the instance label. "
             f"The label value is {labels['app.kubernetes.io/instance']} vs {labels['app.kubernetes.io/name']}"
         )

--- a/tests/manifests/test_synapse.py
+++ b/tests/manifests/test_synapse.py
@@ -7,7 +7,7 @@ import pytest
 
 @pytest.mark.parametrize("values_file", ["synapse-minimal-values.yaml"])
 @pytest.mark.asyncio_cooperative
-async def test_appservice_configmaps_are_templated(values, make_templates):
+async def test_appservice_configmaps_are_templated(release_name, values, make_templates):
     values["synapse"].setdefault("appservices", []).append({"registrationFileConfigMap": "as-{{ $.Release.Name }}"})
 
     for template in await make_templates(values):
@@ -15,15 +15,18 @@ async def test_appservice_configmaps_are_templated(values, make_templates):
             for volume in template["spec"]["template"]["spec"]["volumes"]:
                 if (
                     "configMap" in volume
-                    and volume["configMap"]["name"] == "as-pytest"
-                    and volume["name"] == "as-pytest"
+                    and volume["configMap"]["name"] == f"as-{release_name}"
+                    and volume["name"] == f"as-{release_name}"
                 ):
                     break
             else:
                 raise AssertionError("The appservice configMap wasn't included in the volumes")
 
             for volumeMount in template["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]:
-                if volumeMount["name"] == "as-pytest" and volumeMount["mountPath"] == "/as/as-pytest/registration.yaml":
+                if (
+                    volumeMount["name"] == f"as-{release_name}"
+                    and volumeMount["mountPath"] == f"/as/as-{release_name}/registration.yaml"
+                ):
                     break
             else:
                 raise AssertionError("The appservice configMap isn't mounted at the expected location")

--- a/tests/manifests/test_well_known_delegation.py
+++ b/tests/manifests/test_well_known_delegation.py
@@ -9,7 +9,7 @@ import pytest
 
 @pytest.mark.parametrize("values_file", ["well-known-minimal-values.yaml"])
 @pytest.mark.asyncio_cooperative
-async def test_only_additional_if_all_disabled_in_well_known(values, make_templates):
+async def test_only_additional_if_all_disabled_in_well_known(release_name, values, make_templates):
     client_config = {"testclientkey": {"testsubket": "testvalue"}}
     server_config = {"testserverkey": {"testsubket": "testvalue"}}
     element_config = {"testelementkey": {"testsubket": "testvalue"}}
@@ -19,7 +19,7 @@ async def test_only_additional_if_all_disabled_in_well_known(values, make_templa
     values["wellKnownDelegation"].setdefault("additional", {})["element"] = json.dumps(element_config)
     values["wellKnownDelegation"].setdefault("additional", {})["support"] = json.dumps(support_config)
     for template in await make_templates(values):
-        if template["kind"] == "ConfigMap" and template["metadata"]["name"] == "pytest-well-known-haproxy":
+        if template["kind"] == "ConfigMap" and template["metadata"]["name"] == f"{release_name}-well-known-haproxy":
             client_from_json = json.loads(template["data"]["client"])
             assert client_from_json == client_config
 
@@ -39,7 +39,7 @@ async def test_only_additional_if_all_disabled_in_well_known(values, make_templa
 
 @pytest.mark.parametrize("values_file", ["well-known-synapse-values.yaml"])
 @pytest.mark.asyncio_cooperative
-async def test_synapse_injected_in_server_and_client_well_known(values, make_templates):
+async def test_synapse_injected_in_server_and_client_well_known(release_name, values, make_templates):
     client_config = {"testclientkey": {"testsubket": "testvalue"}}
     server_config = {"testserverkey": {"testsubket": "testvalue"}}
     element_config = {"testelementkey": {"testsubket": "testvalue"}}
@@ -52,7 +52,7 @@ async def test_synapse_injected_in_server_and_client_well_known(values, make_tem
     synapse_federation = {"m.server": "synapse.ess.localhost:443"}
     synapse_base_url = {"m.homeserver": {"base_url": "https://synapse.ess.localhost"}}
     for template in await make_templates(values):
-        if template["kind"] == "ConfigMap" and template["metadata"]["name"] == "pytest-well-known-haproxy":
+        if template["kind"] == "ConfigMap" and template["metadata"]["name"] == f"{release_name}-well-known-haproxy":
             client_from_json = json.loads(template["data"]["client"])
             assert client_from_json == client_config | synapse_base_url
 

--- a/tests/manifests/utils.py
+++ b/tests/manifests/utils.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 
 import json
+import random
+import string
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -12,6 +14,11 @@ import pytest
 import yaml
 
 from . import component_details, values_files_to_components
+
+
+@pytest.fixture(scope="session")
+async def release_name():
+    return f"pytest-{''.join(random.choices(string.ascii_lowercase, k=6))}"
 
 
 @pytest.fixture(scope="session")
@@ -35,8 +42,8 @@ def values(values_file) -> dict[str, Any]:
 
 
 @pytest.fixture(scope="function")
-async def templates(chart: pyhelm3.Chart, values: dict[str, Any]):
-    return list([template for template in await helm_template(chart, "pytest", values) if template is not None])
+async def templates(chart: pyhelm3.Chart, release_name: str, values: dict[str, Any]):
+    return list([template for template in await helm_template(chart, release_name, values) if template is not None])
 
 
 async def helm_template(chart: pyhelm3.Chart, release_name: str, values: Any | None) -> Iterator[Any]:
@@ -69,9 +76,9 @@ async def helm_template(chart: pyhelm3.Chart, release_name: str, values: Any | N
 
 
 @pytest.fixture
-def make_templates(chart: pyhelm3.Chart):
+def make_templates(chart: pyhelm3.Chart, release_name: str):
     async def _make_templates(values):
-        return list([template for template in await helm_template(chart, "pytest", values) if template is not None])
+        return list([template for template in await helm_template(chart, release_name, values) if template is not None])
 
     return _make_templates
 


### PR DESCRIPTION
Let's not proliferate hard-coding of `pytest` in lots of places