### PR TITLE
matrix-tools: only build when necessary

### DIFF
--- a/newsfragments/153.internal.md
+++ b/newsfragments/153.internal.md
@@ -1,0 +1,1 @@
+Only build matrix-tools image when necessary.


### PR DESCRIPTION
In CI, we now have to add `BUILD_MATRIX_TOOLS` temporarily to the CI run to test it dynamically. By default, it is going to use the `matrix-tools` image specified in values.