### PR TITLE
integration tests: reduce retries to 7

### DIFF
--- a/newsfragments/160.internal.md
+++ b/newsfragments/160.internal.md
@@ -1,0 +1,1 @@
+Reduce retries on HTTP Post/Get in integration tests.

--- a/tests/integration/lib/matrix_authentication_service.py
+++ b/tests/integration/lib/matrix_authentication_service.py
@@ -19,7 +19,7 @@ async def get_client_token(mas_fqdn: str, generated_data: ESSData, ssl_context: 
 
     async with (
         aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=ssl_context)) as session,
-        RetryClient(session, retry_options=retry_options, raise_for_status=True) as retry,
+        RetryClient(session, _options=retry_options, raise_for_status=True) as retry,
         retry.post(
             url.replace(host, "127.0.0.1"),
             headers={"Host": host},

--- a/tests/integration/lib/synapse.py
+++ b/tests/integration/lib/synapse.py
@@ -13,7 +13,7 @@ from aiohttp_retry import JitterRetry, RetryClient
 
 from .utils import KubeCtl, aiohttp_post_json, aiottp_get_json
 
-retry_options = JitterRetry(attempts=30, statuses=[429], retry_all_server_errors=False)
+retry_options = JitterRetry(attempts=7, statuses=[429], retry_all_server_errors=False)
 
 
 async def get_nonce(synapse_fqdn: str, ssl_context) -> str:

--- a/tests/integration/lib/utils.py
+++ b/tests/integration/lib/utils.py
@@ -19,7 +19,7 @@ from lightkube.generic_resource import async_load_in_cluster_generic_resources, 
 from lightkube.resources.apiextensions_v1 import CustomResourceDefinition
 from pytest_kubernetes.providers import AClusterManager
 
-retry_options = JitterRetry(attempts=30, statuses=[429, 500, 503], retry_all_server_errors=False)
+retry_options = JitterRetry(attempts=7, statuses=[429, 500, 503], retry_all_server_errors=False)
 
 
 @dataclass


### PR DESCRIPTION
30 retries hide the HTTP failure behind a test timeout. Let's reduce to 7, it is enough now that the stack properly waits to be mostly ready before running the tests.