### PR TITLE
Load matrix-tools into the local dockerd if built

### DIFF
--- a/newsfragments/162.internal.md
+++ b/newsfragments/162.internal.md
@@ -1,0 +1,1 @@
+Fix local builds of matrix-tools not being available to pytest.

--- a/tests/integration/fixtures/matrix_tools.py
+++ b/tests/integration/fixtures/matrix_tools.py
@@ -19,6 +19,7 @@ async def build_matrix_tools():
             files=str(project_folder / "docker-bake.hcl"),
             targets="matrix-tools",
             set={"*.tags": "localhost:5000/matrix-tools:pytest"},
+            load=True,
         )
 
 


### PR DESCRIPTION
Or tests fail with
```
 => [internal] load local bake definitions                                                                                                                                                                                               0.0s
 => => reading /home/ben/Work/github/element-hq/ess-helm-oss/docker-bake.hcl 596B / 596B                                                                                                                                                 0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                     0.0s
 => => transferring dockerfile: 600B                                                                                                                                                                                                     0.0s
 => [internal] load metadata for gcr.io/distroless/static-debian12:latest                                                                                                                                                                0.3s
 => [internal] load metadata for docker.io/library/golang:1.23                                                                                                                                                                           0.4s
 => [internal] load .dockerignore                                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                                          0.0s
 => [stage-1 1/3] FROM gcr.io/distroless/static-debian12:latest@sha256:3f2b64ef97bd285e36132c684e6b2ae8f2723293d09aae046196cca64251acac                                                                                                  0.0s
 => => resolve gcr.io/distroless/static-debian12:latest@sha256:3f2b64ef97bd285e36132c684e6b2ae8f2723293d09aae046196cca64251acac                                                                                                          0.0s
 => [buildstage 1/6] FROM docker.io/library/golang:1.23@sha256:927112936d6b496ed95f55f362cc09da6e3e624ef868814c56d55bd7323e0959                                                                                                          0.0s
 => => resolve docker.io/library/golang:1.23@sha256:927112936d6b496ed95f55f362cc09da6e3e624ef868814c56d55bd7323e0959                                                                                                                     0.0s
 => [internal] load build context                                                                                                                                                                                                        0.0s
 => => transferring context: 1.30kB                                                                                                                                                                                                      0.0s
 => CACHED [buildstage 2/6] WORKDIR /app                                                                                                                                                                                                 0.0s
 => CACHED [buildstage 3/6] COPY . /app                                                                                                                                                                                                  0.0s
 => CACHED [buildstage 4/6] RUN go mod download                                                                                                                                                                                          0.0s
 => CACHED [buildstage 5/6] RUN CGO_ENABLED=0 go build -o /app/matrix-tools cmd/main.go                                                                                                                                                  0.0s
 => CACHED [buildstage 6/6] RUN chmod 755 /app/matrix-tools                                                                                                                                                                              0.0s
 => CACHED [stage-1 2/3] COPY --from=buildstage  /app/matrix-tools /                                                                                                                                                                     0.0s
WARNING: No output specified for matrix-tools target(s) with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load

...

        if completed_process.returncode != 0:
            if completed_process.stderr is not None:
                decoded_stderr = completed_process.stderr.decode().lower()
                if "no such image" in decoded_stderr or "image not known" in decoded_stderr:
>                   raise NoSuchImage(
                        args,
                        completed_process.returncode,
                        completed_process.stdout,
                        completed_process.stderr,
                    )
E                   python_on_whales.exceptions.NoSuchImage: The command executed was `/usr/bin/docker image inspect localhost:5000/matrix-tools:pytest`.
E                   It returned with code 1
E                   The content of stdout is '[]
E                   '
E                   The content of stderr is 'Error response from daemon: No such image: localhost:5000/matrix-tools:pytest
E                   '

.venv/lib/python3.12/site-packages/python_on_whales/utils.py:169: NoSuchImage
```