### PR TITLE
matrix-tools: dont print post processed yaml without debug rendering

### DIFF
--- a/matrix-tools/internal/pkg/renderer/renderer.go
+++ b/matrix-tools/internal/pkg/renderer/renderer.go
@@ -137,7 +137,10 @@ func RenderConfig(sourceConfigs []io.Reader) (map[string]any, error) {
 
 		var data map[string]any
 		if err := yaml.Unmarshal(fileContent, &data); err != nil {
-			return nil, fmt.Errorf("Post-processed YAML is invalid: %s with error: %v", string(fileContent), err)
+			if os.Getenv("DEBUG_RENDERING") == "1" {
+				fmt.Println(string(fileContent))
+			}
+			return nil, fmt.Errorf("Post-processed YAML is invalid: %v", err)
 		}
 
 		if err := deepMergeMaps(data, output); err != nil {

--- a/newsfragments/164.internal.md
+++ b/newsfragments/164.internal.md
@@ -1,0 +1,1 @@
+Dont print failed yaml with matrix-tools without `DEBUG_RENDERING` enabled.


### PR DESCRIPTION
Printing automatically on errors can lead to secrets leak.