### PR TITLE
MAS: Fix render-config was lacking extraEnv

### DIFF
--- a/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
@@ -86,6 +86,7 @@ spec:
           {{- end }}
         - /config-templates/config.yaml
         env:
+        {{- include "element-io.matrix-authentication-service.env" (dict "root" $ "context" .) | nindent 8 }}
         - name: POSTGRES_PASSWORD
           value: >-
             {{

--- a/newsfragments/199.fixed.md
+++ b/newsfragments/199.fixed.md
@@ -1,0 +1,1 @@
+Fix Matrix Authentication Service render-config container was lacking extraEnv.


### PR DESCRIPTION
When debugging my MAS setup, I realized that I could not render the config because the extraEnv was not passed through its initContainer.