### PR TITLE
Add default postgres port value

### DIFF
--- a/charts/matrix-stack/templates/ess-library/_postgres.tpl
+++ b/charts/matrix-stack/templates/ess-library/_postgres.tpl
@@ -10,7 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 {{- $root := .root -}}
 {{- with required "element-io.ess-library.postgres-secret-name requires context" .context -}}
 {{- if .postgres -}}
-{{ (tpl .postgres.host $root) }}:{{ .postgres.port }}
+{{ (tpl .postgres.host $root) }}:{{ .postgres.port | default 5432 }}
 {{- else if $root.Values.postgres.enabled -}}
 {{ $root.Release.Name }}-postgres.{{ $root.Release.Namespace }}.svc.cluster.local:5432
 {{- else }}

--- a/newsfragments/233.fixed.md
+++ b/newsfragments/233.fixed.md
@@ -1,0 +1,1 @@
+Fix an issue where postgres port could be missing when waiting for db.


### PR DESCRIPTION
We encountered the following issue : 

```
Waiting for TCP connection on <postgres host>:
Waiting for TCP connection on <postgres host>:
Waiting for TCP connection on <postgres host>:
```