### PR TITLE
Ensure all Secrets set their type

### DIFF
--- a/charts/matrix-stack/templates/matrix-authentication-service/secret.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/secret.yaml
@@ -13,6 +13,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "element-io.matrix-authentication-service.labels" (dict "root" $ "context" .) | nindent 4 }}
+type: Opaque
 data:
 {{- with .additional }}
 {{- range $key := (. | keys | uniq | sortAlpha) }}

--- a/charts/matrix-stack/templates/synapse/synapse_secret.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2024 New Vector Ltd
+Copyright 2024-2025 New Vector Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 */ -}}
@@ -13,6 +13,7 @@ metadata:
     {{- include "element-io.synapse.labels" (dict "root" $ "context" .) | nindent 4 }}
   name: {{ $.Release.Name }}-synapse
   namespace: {{ $.Release.Namespace }}
+type: Opaque
 data:
 {{- with .additional }}
 {{- range $key := (. | keys | uniq | sortAlpha) }}

--- a/newsfragments/243.changed.md
+++ b/newsfragments/243.changed.md
@@ -1,0 +1,1 @@
+Ensure all managed `Secrets` set their `type`.

--- a/tests/manifests/test_secrets.py
+++ b/tests/manifests/test_secrets.py
@@ -1,0 +1,17 @@
+# Copyright 2025 New Vector Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+
+import pytest
+
+from . import values_files_to_test
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_all_secrets_have_type(templates):
+    for template in templates:
+        if template["kind"] == "Secret":
+            id = f"{template['kind']}/{template['metadata']['name']}"
+            assert "type" in template, f"{id} has not set the Secret type"
+            assert template["type"] in ["Opaque"], f"{id} has an unexpected Secret type {template['type']}"


### PR DESCRIPTION
Makes it explicit what type the `Secret` is and will allow other tests to `template["type"]` rather than `template.get("type", "Opaque")` or similar