### PR TITLE
Don't gate presence on having a presence-writer worker

### DIFF
--- a/charts/matrix-stack/templates/synapse/_synapse_config.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_config.tpl
@@ -156,9 +156,6 @@ media_store_path: "/media/media_store"
 media_instance_running_background_jobs: "media-repository-0"
 {{- end }}
 
-presence:
-  enabled: {{ dig "presence-writer" "enabled" false .workers }}
-
 {{- if dig "pusher" "enabled" false .workers }}
 
 start_pushers: false

--- a/newsfragments/252.changed.md
+++ b/newsfragments/252.changed.md
@@ -1,0 +1,1 @@
+Don't gate enabling presence in Synapse on having a presence writer worker, use the Synapse defaults and allow easy configuration.


### PR DESCRIPTION
Having a presence-writer worker is a performance optimisation. We should accept the upstream defaults and not disable functionality without good reason.

The only thing we could do differently is to force presence on with a presence-writer but have no-opinion about presence without a presence-writer. This issue with this is that [`presence.enabled`](https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#presence) also accepts a `untracked` value. So we can't easily accept that whilst also blocking `presence.enabled: false`. Getting out of the way is best