### PR TITLE
Fix incorrect labels being applied to the Synapse check config Job

### DIFF
--- a/charts/matrix-stack/templates/synapse/synapse_check_config_job_hook.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_check_config_job_hook.yaml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 {{- if and .enabled .checkConfigHook.enabled -}}
 {{- $enabledWorkers := (include "element-io.synapse.enabledWorkers" (dict "root" $)) | fromJson }}
 {{- $processType := "check-config-hook" }}
-{{- $perProcessRoot := merge (dict "processType" $processType "isHook" true) ($.Values.synapse | deepCopy) (.checkConfigHook | deepCopy)}}
+{{- $perProcessRoot := merge (dict "processType" $processType "isHook" true) (.checkConfigHook | deepCopy) ($.Values.synapse | deepCopy) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/newsfragments/270.fixed.md
+++ b/newsfragments/270.fixed.md
@@ -1,0 +1,1 @@
+Fix the wrong labels being applied to the Synapse Config Check Hook Job.


### PR DESCRIPTION
Labels from Synapse were overwriting labels from the check config job