### PR TITLE
manifests tests: handle noqa at the mount key level.

### DIFF
--- a/newsfragments/274.internal.md
+++ b/newsfragments/274.internal.md
@@ -1,0 +1,1 @@
+Manifests tests: handle noqa at the mount key level.

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -170,7 +170,7 @@ all_components_details = [
         name="element-web",
         helm_key="elementWeb",
         has_service_monitor=False,
-        paths_consistency_noqa=("/etc/nginx/nginx.conf"),
+        paths_consistency_noqa=("/etc/nginx/nginx.conf", "/etc/nginx/mime.types"),
     ),
     ComponentDetails(
         name="matrix-authentication-service",


### PR DESCRIPTION
By mapping parents paths to mounted keys, we can check if we should noqa the parent based on the mounted key which it relates to.