### PR TITLE
MAS: drop init container

### DIFF
--- a/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
@@ -127,33 +127,6 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
 {{- end }}
-{{- /* This init container job is kept despite https://github.com/matrix-org/matrix-authentication-service/pull/2432 so as to have --prune */}}
-      - name: config
-        args: ["config", "sync", "--prune"]
-{{- with .image -}}
-{{- if .digest }}
-        image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
-        imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
-{{- else }}
-        image: "{{ .registry }}/{{ .repository }}:{{ required "matrixAuthenticationService.image.tag is required if no digest" .tag }}"
-        imagePullPolicy: {{ .pullPolicy | default "Always" }}
-{{- end }}
-{{- end }}
-{{- with .containersSecurityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-{{- end }}
-        env:
-        {{- include "element-io.matrix-authentication-service.env" (dict "root" $ "context" .) | nindent 10 }}
-{{- with .resources }}
-        resources:
-          {{- toYaml . | nindent 10 }}
-{{- end }}
-        volumeMounts:
-        - mountPath: "/config.yaml"
-          name: rendered-config
-          subPath: config.yaml
-          readOnly: true
       containers:
       - name: matrix-authentication-service
         args: ["server"]

--- a/newsfragments/307.changed.md
+++ b/newsfragments/307.changed.md
@@ -1,0 +1,1 @@
+Matrix Authentication Service does not need to prune database anymore, OIDC providers are being disabled instead.


### PR DESCRIPTION
@sandhose How does MAS handle IdP changes nowadays ? 

We used to keep this init container as so to have `prune` available. But it feels dangerous as in case of misconfiguration, all the oauth IdP links are lost.

What would be your recommandations nowadays?