### PR TITLE
Don't allow matrix-org/element-hq floating tags for GitHub actions

### DIFF
--- a/.github/workflows/actions-linting.yml
+++ b/.github/workflows/actions-linting.yml
@@ -54,14 +54,13 @@ jobs:
 
     - name: Find unpinned actions
       run: |
-        # Find all actions that aren't ours, aren't docker images by digest or aren't GitHub commits by id
+        # Find all actions that aren't docker images by digest or aren't GitHub commits by id
         # All with digest/commit ids also need comments
         unpinned_actions=$(
           find .github/workflows -type f \( -iname \*.yaml -o -iname \*.yml \) -print0 \
             | xargs -0 -I {} grep -E 'use[s]:' {} \
             | grep -vE 'use[s]:\s+docker://[^#]*@sha256:[a-f0-9]{64}\s+#\s' \
-            | grep -vE 'use[s]:\s+[^#]*@[a-f0-9]{40}\s+#\s' \
-            | grep -vE 'use[s]:\s+(matrix-org|element-hq)' || true)
+            | grep -vE 'use[s]:\s+[^#]*@[a-f0-9]{40}\s+#\s' || true)
         if [ "$unpinned_actions" != "" ]; then
           echo "There are unpinned actions:"
           echo "$unpinned_actions"

--- a/newsfragments/308.internal.md
+++ b/newsfragments/308.internal.md
@@ -1,0 +1,1 @@
+Don't automatically trust matrix-org or element-hq GitHub actions.


### PR DESCRIPTION
After #305 we have no more floating tags/refs so don't allow them at all