### PR TITLE
MAS: Fix EX login

### DIFF
--- a/charts/matrix-stack/configs/matrix-authentication-service/config.yaml.tpl
+++ b/charts/matrix-stack/configs/matrix-authentication-service/config.yaml.tpl
@@ -70,6 +70,7 @@ policy:
     client_registration:
       allow_host_mismatch: false
       allow_insecure_uris: false
+      allow_missing_contacts: true
 
 {{- if $root.Values.synapse.enabled }}
 clients:

--- a/newsfragments/232.fixed.md
+++ b/newsfragments/232.fixed.md
@@ -1,0 +1,1 @@
+Fix Element X login against MAS-enabled deployments.


### PR DESCRIPTION
EX started failing to login against MAS due to recent OIDC MSC changes with error `denied by the policy: [Violation { msg: "missing contacts", field: None }]`.
