### PR TITLE
artifacthub: fix regex + package url / repo ID

### DIFF
--- a/artifacthub-repo.yaml
+++ b/artifacthub-repo.yaml
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-repositoryID: f900b890-eb67-4328-9100-336301f7cefe
+repositoryID: 6a910e71-6940-45a6-9d63-07ec0080aa55
 owners:
   - name: Element Server Products Team
     email: onprem-support@element.io
 ignore:
   - name: matrix-stack
-    version: "[0-9]+\\.[0-9]+\\.[0-9]+.+"
+    version: "[0-9]+\\.[0-9]+\\.[0-9]+-sha.+"

--- a/artifacthub-repo.yaml
+++ b/artifacthub-repo.yaml
@@ -8,4 +8,4 @@ owners:
     email: onprem-support@element.io
 ignore:
   - name: matrix-stack
-    version: "[0-9]+\\.[0-9]+\\.[0-9]+\\..+"
+    version: "[0-9]+\\.[0-9]+\\.[0-9]+.+"

--- a/artifacthub-repo.yaml
+++ b/artifacthub-repo.yaml
@@ -8,4 +8,4 @@ owners:
     email: onprem-support@element.io
 ignore:
   - name: matrix-stack
-    version: "[0-9]+\\.[0-9]+\\.[0-9]+-sha.+"
+    version: "[0-9]+\\.[0-9]+\\.[0-9]+-(sha.+|dev)"

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -22,7 +22,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 - The GitHub repository [values files](https://github.com/element-hq/ess-helm/blob/main/charts/matrix-stack/values.yaml).
 - The chart [README](https://github.com/element-hq/ess-helm/blob/main/charts/matrix-stack/README.md).
-- [Artifacthub.io](https://artifacthub.io/packages/helm/element/matrix-stack).
+- [Artifacthub.io](https://artifacthub.io/packages/helm/element-server-suite-community/matrix-stack).
 
 Configuration samples are available [in the GitHub repository](https://github.com/element-hq/ess-helm/tree/main/charts/matrix-stack/ci).
 

--- a/newsfragments/334.internal.md
+++ b/newsfragments/334.internal.md
@@ -1,0 +1,1 @@
+Fix artifacthub chart versions list.


### PR DESCRIPTION
https://artifacthub.io/packages/helm/element-server-suite-community/matrix-stack

This fixes the exclusion of all dev versions : 

![image](https://github.com/user-attachments/assets/9a52b898-ed00-4ed1-ab8a-0cc8f3fec1ea)
