### PR TITLE
enhance mount path detection with render-config

### DIFF
--- a/newsfragments/338.internal.md
+++ b/newsfragments/338.internal.md
@@ -1,0 +1,1 @@
+Enhance secrets path detection consistency with render-config containers.


### PR DESCRIPTION
- We need to filter only mounted subPath when looking in configMap content
- We need to look into the render-config container for source config maps