### PR TITLE
postgres password: generate only required passwords

### DIFF
--- a/charts/matrix-stack/ci/fragments/init-secrets-disabled.yaml
+++ b/charts/matrix-stack/ci/fragments/init-secrets-disabled.yaml
@@ -1,0 +1,6 @@
+# Copyright 2025 New Vector Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+initSecrets:
+  enabled: false

--- a/charts/matrix-stack/ci/matrix-authentication-service-postgres-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-postgres-secrets-externally-values.yaml
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-secrets-externally.yaml postgres-secrets-externally.yaml postgres-matrix-authentication-service-secrets-externally.yaml
+# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-secrets-externally.yaml postgres-secrets-externally.yaml postgres-matrix-authentication-service-secrets-externally.yaml init-secrets-disabled.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# initSecrets don't have any required properties to be set and defaults to enabled
 elementWeb:
+  enabled: false
+initSecrets:
   enabled: false
 matrixAuthenticationService:
   encryptionSecret:

--- a/charts/matrix-stack/ci/matrix-authentication-service-postgres-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-postgres-secrets-in-helm-values.yaml
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-secrets-externally.yaml postgres-secrets-in-helm.yaml postgres-matrix-authentication-service-secrets-in-helm.yaml
+# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-secrets-externally.yaml postgres-secrets-in-helm.yaml postgres-matrix-authentication-service-secrets-in-helm.yaml init-secrets-disabled.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# initSecrets don't have any required properties to be set and defaults to enabled
 elementWeb:
+  enabled: false
+initSecrets:
   enabled: false
 matrixAuthenticationService:
   encryptionSecret:

--- a/charts/matrix-stack/ci/synapse-postgres-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/synapse-postgres-secrets-externally-values.yaml
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: synapse-minimal.yaml synapse-secrets-externally.yaml postgres-secrets-externally.yaml postgres-synapse-secrets-externally.yaml
+# source_fragments: synapse-minimal.yaml synapse-secrets-externally.yaml postgres-secrets-externally.yaml postgres-synapse-secrets-externally.yaml init-secrets-disabled.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# initSecrets don't have any required properties to be set and defaults to enabled
 elementWeb:
+  enabled: false
+initSecrets:
   enabled: false
 matrixAuthenticationService:
   enabled: false

--- a/charts/matrix-stack/ci/synapse-postgres-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/synapse-postgres-secrets-in-helm-values.yaml
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: synapse-minimal.yaml synapse-secrets-in-helm.yaml postgres-secrets-in-helm.yaml postgres-synapse-secrets-in-helm.yaml
+# source_fragments: synapse-minimal.yaml synapse-secrets-in-helm.yaml postgres-secrets-in-helm.yaml postgres-synapse-secrets-in-helm.yaml init-secrets-disabled.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# initSecrets don't have any required properties to be set and defaults to enabled
 elementWeb:
+  enabled: false
+initSecrets:
   enabled: false
 matrixAuthenticationService:
   enabled: false

--- a/charts/matrix-stack/ci/well-known-minimal-values.yaml
+++ b/charts/matrix-stack/ci/well-known-minimal-values.yaml
@@ -2,11 +2,13 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: well-known-minimal.yaml
+# source_fragments: well-known-minimal.yaml init-secrets-disabled.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
+# postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
 elementWeb:
+  enabled: false
+initSecrets:
   enabled: false
 matrixAuthenticationService:
   enabled: false

--- a/charts/matrix-stack/templates/ess-library/_credentials.tpl
+++ b/charts/matrix-stack/templates/ess-library/_credentials.tpl
@@ -40,7 +40,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- else if $root.Values.initSecrets.enabled -}}
 {{- /* OK secret is generatable and initSecrets is on */ -}}
 {{- else -}}
-{{- fail (printf "initSecrets is disabled, but the Secret configuration at %s is not present" $secretPath) -}}
+{{- fail (printf "check-credential: initSecrets is disabled, but the Secret configuration at %s is not present" $secretPath) -}}
 {{- end -}}
 {{- end -}}
 {{- end }}
@@ -57,7 +57,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   {{- if $root.Values.initSecrets.enabled -}}
   {{- printf "%s/%s" (printf "%s-generated" $root.Release.Name) $initSecretKey -}}
   {{- else -}}
-  {{- fail (printf "initSecrets is disabled, but the Secret configuration at %s is not present" $secretPath) -}}
+  {{- fail (printf "init-secret-path: initSecrets is disabled, but the Secret configuration at %s is not present" $secretPath) -}}
   {{- end -}}
 {{- else -}}
   {{- include "element-io.ess-library.provided-secret-path" (dict "root" $root "context" (dict "secretPath" $secretPath "defaultSecretName" $defaultSecretName "defaultSecretKey" $defaultSecretKey)) -}}
@@ -102,7 +102,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     {{- if $root.Values.initSecrets.enabled -}}
     {{- printf "%s/%s" (printf "%s-generated" $root.Release.Name) $initSecretKey -}}
     {{- else -}}
-    {{- fail (printf "initSecrets is disabled, but the Secret configuration at %s is not present" $componentPasswordPath) -}}
+    {{- fail (printf "postgres-secret-path: initSecrets is disabled, but the Secret configuration at %s is not present" $componentPasswordPath) -}}
     {{- end -}}
   {{- else -}}
     {{- include "element-io.ess-library.provided-secret-path" (dict
@@ -154,7 +154,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   {{- if $root.Values.initSecrets.enabled -}}
   {{- printf "%s-generated" $root.Release.Name -}}
   {{- else -}}
-  {{- fail (printf "initSecrets is disabled, but the Secret configuration at %s is not present" $componentPasswordPath) -}}
+  {{- fail (printf "postgres-secret-name: initSecrets is disabled, but the Secret configuration at %s is not present" $componentPasswordPath) -}}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/matrix-stack/templates/postgres/_postgres_secret.tpl
+++ b/charts/matrix-stack/templates/postgres/_postgres_secret.tpl
@@ -28,10 +28,12 @@ data:
 {{- end }}
 {{- end }}
 {{- range $key := (.essPasswords | keys | uniq | sortAlpha) }}
+{{- if (index $root.Values $key).enabled }}
 {{- include "element-io.ess-library.check-credential" (dict "root" $root "context" (dict "secretPath" (printf "postgres.essPasswords.%s" $key) "initIfAbsent" true)) }}
 {{- $prop := index $root.Values.postgres.essPasswords $key }}
 {{- with $prop.value }}
   ESS_PASSWORD_{{ $key | upper }}: {{ .| b64enc }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/newsfragments/342.fixed.md
+++ b/newsfragments/342.fixed.md
@@ -1,0 +1,1 @@
+Postgres password: Generate only required passwords.


### PR DESCRIPTION
Without the fix, the new CI values discovered : 
```

engine.go:227: [INFO] Fail: check-credential: initSecrets is disabled, but the Secret configuration at postgres.essPasswords.synapse is not present
engine.go:227: [INFO] Fail: check-credential: initSecrets is disabled, but the Secret configuration at postgres.essPasswords.synapse is not present
engine.go:227: [INFO] Fail: check-credential: initSecrets is disabled, but the Secret configuration at postgres.essPasswords.synapse is not present
engine.go:227: [INFO] Fail: check-credential: initSecrets is disabled, but the Secret configuration at postgres.essPasswords.synapse is not present
engine.go:227: [INFO] Fail: check-credential: initSecrets is disabled, but the Secret configuration at postgres.essPasswords.matrixAuthenticationService is not present
engine.go:227: [INFO] Fail: check-credential: initSecrets is disabled, but the Secret configuration at postgres.essPasswords.matrixAuthenticationService is not present
engine.go:227: [INFO] Fail: check-credential: initSecrets is disabled, but the Secret configuration at postgres.essPasswords.matrixAuthenticationService is not present
engine.go:227: [INFO] Fail: check-credential: initSecrets is disabled, but the Secret configuration at postgres.essPasswords.matrixAuthenticationService is not present
```