### PR TITLE
synapse: fix APPLICATION_NAME template

### DIFF
--- a/charts/matrix-stack/templates/synapse/_helpers.tpl
+++ b/charts/matrix-stack/templates/synapse/_helpers.tpl
@@ -165,6 +165,6 @@ app.kubernetes.io/version: {{ .image.tag }}
     }}
 - name: APPLICATION_NAME
   value: >-
-    {{ printf "{{ hostname | replace \"-synapse-\" \"\" }}" }}
+    {{ printf "{{ hostname | replace \"-synapse-\" \"\" | replace \"%s\" \"\" }}" $root.Release.Name }}
 {{- end }}
 {{- end }}

--- a/newsfragments/345.fixed.md
+++ b/newsfragments/345.fixed.md
@@ -1,0 +1,1 @@
+Synapse: Fix the Release name was not stripped from worker name.


### PR DESCRIPTION
Minor template issue but could case persisters to loop replicate requests to themselves.