### PR TITLE
Matrix-Tools: Stricter rendered file permissions

### DIFF
--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -13,7 +13,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 ## The matrix-tools image, used in multiple components
 matrixTools:
-{{ image(registry="ghcr.io", repository="element-hq/ess-helm/matrix-tools", tag="0.3.2") | indent(2) }}
+{{ image(registry="ghcr.io", repository="element-hq/ess-helm/matrix-tools", tag="0.3.3") | indent(2) }}
 
 ## CertManager Issuer to configure by default automatically on all ingresses
 ## If configured, the chart will automatically generate the tlsSecret name for all ingresses

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -20,7 +20,7 @@ matrixTools:
 
     ## The tag of the container image to use.
     ## Defaults to the Chart's appVersion if not set
-    tag: "0.3.2"
+    tag: "0.3.3"
 
     ## Container digest to use. Used to pull the image instead of the image tag / Chart appVersion if set
     # digest:

--- a/matrix-tools/cmd/main.go
+++ b/matrix-tools/cmd/main.go
@@ -89,7 +89,7 @@ func main() {
 		if os.Getenv("DEBUG_RENDERING") == "1" {
 			fmt.Println(string(outputYAML))
 		}
-		err = os.WriteFile(options.Output, outputYAML, 0644)
+		err = os.WriteFile(options.Output, outputYAML, 0440)
 		if err != nil {
 			fmt.Println("Error writing to file:", err)
 			os.Exit(1)

--- a/newsfragments/350.fixed.md
+++ b/newsfragments/350.fixed.md
@@ -1,0 +1,1 @@
+matrix-tools: Fix rendered file permissions, from 664 to 440.


### PR DESCRIPTION
Required for Matrix-RTC SFU to stop complaining about others permissions : 
`2025-04-04T15:48:02.942538481Z stdout F key file others permissions must be set to 0`
