### PR TITLE
matrix-rtc: rationalize names

### DIFF
--- a/charts/matrix-stack/configs/matrix-rtc/sfu/config.yaml.tpl
+++ b/charts/matrix-stack/configs/matrix-rtc/sfu/config.yaml.tpl
@@ -37,7 +37,7 @@ key_file: /secrets/{{ (printf "/secrets/%s"
       (include "element-io.ess-library.provided-secret-path" (
         dict "root" $root "context" (
           dict "secretPath" "matrixRTC.livekitAuth.keysYaml"
-              "defaultSecretName" (printf "%s-matrix-rtc-sfu-jwt" $root.Release.Name)
+              "defaultSecretName" (printf "%s-matrix-rtc-authorizer" $root.Release.Name)
               "defaultSecretKey" "LIVEKIT_KEYS_YAML"
               )
         ))) }}

--- a/charts/matrix-stack/templates/matrix-rtc/_helpers.tpl
+++ b/charts/matrix-stack/templates/matrix-rtc/_helpers.tpl
@@ -4,13 +4,24 @@ Copyright 2024 New Vector Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 
-{{- define "element-io.matrix-rtc-sfu-jwt.labels" -}}
+{{- define "element-io.matrix-rtc-ingress.labels" -}}
+{{- $root := .root -}}
+{{- with required "element-io.matrix-rtc.labels missing context" .context -}}
+{{ include "element-io.ess-library.labels.common" (dict "root" $root "context" .labels) }}
+app.kubernetes.io/component: matrix-rtc
+app.kubernetes.io/name: matrix-rtc
+app.kubernetes.io/instance: {{ $root.Release.Name }}-matrix-rtc
+app.kubernetes.io/version: {{ .image.tag }}
+{{- end }}
+{{- end }}
+
+{{- define "element-io.matrix-rtc-authorizer.labels" -}}
 {{- $root := .root -}}
 {{- with required "element-io.matrix-rtc.labels missing context" .context -}}
 {{ include "element-io.ess-library.labels.common" (dict "root" $root "context" .labels) }}
 app.kubernetes.io/component: matrix-rtc-authorizer
-app.kubernetes.io/name: matrix-rtc-sfu-jwt
-app.kubernetes.io/instance: {{ $root.Release.Name }}-matrix-rtc-sfu-jwt
+app.kubernetes.io/name: matrix-rtc-authorizer
+app.kubernetes.io/instance: {{ $root.Release.Name }}-matrix-rtc-authorizer
 app.kubernetes.io/version: {{ .image.tag }}
 {{- end }}
 {{- end }}
@@ -37,9 +48,9 @@ app.kubernetes.io/version: {{ .image.tag }}
 {{- end }}
 {{- end }}
 
-{{- define "element-io.matrix-rtc-sfu-jwt.env" }}
+{{- define "element-io.matrix-rtc-authorizer.env" }}
 {{- $root := .root -}}
-{{- with required "element-io.sfu-jwt.env missing context" .context -}}
+{{- with required "element-io.authorizer.env missing context" .context -}}
 {{- $resultEnv := dict -}}
 {{- range $envEntry := .extraEnv -}}
 {{- $_ := set $resultEnv $envEntry.name $envEntry.value -}}
@@ -49,7 +60,7 @@ app.kubernetes.io/version: {{ .image.tag }}
       (include "element-io.ess-library.provided-secret-path" (
         dict "root" $root "context" (
           dict "secretPath" "matrixRTC.livekitAuth.keysYaml"
-              "defaultSecretName" (printf "%s-matrix-rtc-sfu-jwt" $root.Release.Name)
+              "defaultSecretName" (printf "%s-matrix-rtc-authorizer" $root.Release.Name)
               "defaultSecretKey" "LIVEKIT_KEYS_YAML"
               )
         ))) }}
@@ -60,7 +71,7 @@ app.kubernetes.io/version: {{ .image.tag }}
         dict "root" $root "context" (
           dict "secretPath" "matrixRTC.livekitAuth.secret"
               "initSecretKey" "ELEMENT_CALL_LIVEKIT_SECRET"
-              "defaultSecretName" (printf "%s-matrix-rtc-sfu-jwt" $root.Release.Name)
+              "defaultSecretName" (printf "%s-matrix-rtc-authorizer" $root.Release.Name)
               "defaultSecretKey" "LIVEKIT_SECRET"
               )
         ))) }}
@@ -77,7 +88,7 @@ app.kubernetes.io/version: {{ .image.tag }}
 
 {{- define "element-io.matrix-rtc-sfu.env" }}
 {{- $root := .root -}}
-{{- with required "element-io.sfu-jwt missing context" .context -}}
+{{- with required "element-io.authorizer missing context" .context -}}
 {{- $resultEnv := dict -}}
 {{- range $envEntry := .extraEnv -}}
 {{- $_ := set $resultEnv $envEntry.name $envEntry.value -}}
@@ -89,15 +100,15 @@ app.kubernetes.io/version: {{ .image.tag }}
 {{- end -}}
 {{- end -}}
 
-{{- define "element-io.matrix-rtc-sfu-jwt.configSecrets" -}}
+{{- define "element-io.matrix-rtc-authorizer.configSecrets" -}}
 {{- $root := .root -}}
-{{- with required "element-io.matrix-rtc-sfu-jwt.configSecrets missing context" .context -}}
+{{- with required "element-io.matrix-rtc-authorizer.configSecrets missing context" .context -}}
 {{- $configSecrets := list -}}
 {{- if and $root.Values.initSecrets.enabled (include "element-io.init-secrets.generated-secrets" (dict "root" $root)) }}
 {{ $configSecrets = append $configSecrets (printf "%s-generated" $root.Release.Name) }}
 {{- end }}
 {{- if or ((.livekitAuth).keysYaml).value ((.livekitAuth).secret).value -}}
-{{ $configSecrets = append $configSecrets (printf "%s-matrix-rtc-sfu-jwt" $root.Release.Name) }}
+{{ $configSecrets = append $configSecrets (printf "%s-matrix-rtc-authorizer" $root.Release.Name) }}
 {{- end -}}
 {{- with ((.livekitAuth).keysYaml).secret -}}
 {{ $configSecrets = append $configSecrets (tpl . $root) }}

--- a/charts/matrix-stack/templates/matrix-rtc/ingress.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/ingress.yaml
@@ -10,11 +10,11 @@ kind: Ingress
 metadata:
 {{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress)) | nindent 2 }}
   labels:
-    {{- include "element-io.matrix-rtc-sfu-jwt.labels" (dict "root" $ "context" .) | nindent 4 }}
-  name: {{ $.Release.Name }}-matrix-rtc-sfu-jwt
+    {{- include "element-io.matrix-rtc-ingress.labels" (dict "root" $ "context" .) | nindent 4 }}
+  name: {{ $.Release.Name }}-matrix-rtc
   namespace: {{ $.Release.Namespace }}
 spec:
-{{- include "element-io.ess-library.ingress.tls" (dict "root" $ "context" (dict "ingress" .ingress "ingressName" "matrix-rtc-sfu-jwt")) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.tls" (dict "root" $ "context" (dict "ingress" .ingress "ingressName" "matrix-rtc")) | nindent 2 }}
 {{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.className) | nindent 2 }}
   rules:
   - host: {{ (tpl .ingress.host $) | quote }}
@@ -24,7 +24,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: "{{ $.Release.Name }}-matrix-rtc-sfu-jwt"
+            name: "{{ $.Release.Name }}-matrix-rtc-authorizer"
             port:
               name: http
 {{ if .sfu.enabled }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
@@ -71,7 +71,7 @@ spec:
                     "context" (dict
                       "secretPath" "matrixRTC.livekitAuth.secret"
                       "initSecretKey" "ELEMENT_CALL_LIVEKIT_SECRET"
-                      "defaultSecretName" (printf "%s-matrix-rtc-sfu-jwt" $.Release.Name)
+                      "defaultSecretName" (printf "%s-matrix-rtc-authorizer" $.Release.Name)
                       "defaultSecretKey" "LIVEKIT_SECRET"
                       )
                     )
@@ -96,7 +96,7 @@ spec:
         - mountPath: /conf
           name: rendered-config
           readOnly: false
-{{- range $secret := include "element-io.matrix-rtc-sfu-jwt.configSecrets" (dict "root" $ "context" $.Values.matrixRTC) | fromJsonArray }}
+{{- range $secret := include "element-io.matrix-rtc-authorizer.configSecrets" (dict "root" $ "context" $.Values.matrixRTC) | fromJsonArray }}
         - mountPath: /secrets/{{ tpl $secret $ }}
           name: "secret-{{ tpl $secret $ }}"
           readOnly: true
@@ -192,7 +192,7 @@ spec:
           name: plain-config
           subPath: config.yaml
       volumes:
-{{- range $secret := include "element-io.matrix-rtc-sfu-jwt.configSecrets" (dict "root" $ "context" $.Values.matrixRTC) | fromJsonArray }}
+{{- range $secret := include "element-io.matrix-rtc-authorizer.configSecrets" (dict "root" $ "context" $.Values.matrixRTC) | fromJsonArray }}
       - secret:
           secretName: {{ tpl $secret $ }}
         name: secret-{{ tpl $secret $ }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_deployment.yaml
@@ -14,14 +14,14 @@ metadata:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   labels:
-    {{- include "element-io.matrix-rtc-sfu-jwt.labels" (dict "root" $ "context" .) | nindent 4 }}
-  name: {{ $.Release.Name }}-matrix-rtc-sfu-jwt
+    {{- include "element-io.matrix-rtc-authorizer.labels" (dict "root" $ "context" .) | nindent 4 }}
+  name: {{ $.Release.Name }}-matrix-rtc-authorizer
   namespace: {{ $.Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/instance: {{ $.Release.Name }}-matrix-rtc-sfu-jwt
+      app.kubernetes.io/instance: {{ $.Release.Name }}-matrix-rtc-authorizer
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -30,7 +30,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "element-io.matrix-rtc-sfu-jwt.labels" (dict "root" $ "context" .) | nindent 8 }}
+        {{- include "element-io.matrix-rtc-authorizer.labels" (dict "root" $ "context" .) | nindent 8 }}
 {{- with .annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
@@ -40,9 +40,9 @@ spec:
       hostAliases:
         {{- tpl (toYaml . | nindent 8) $ }}
 {{- end }}
-{{- include "element-io.ess-library.pods.commonSpec" (dict "root" $ "context" (dict "componentValues" . "key" "matrix-rtc-sfu-jwt" "deployment" true)) | nindent 6 }}
+{{- include "element-io.ess-library.pods.commonSpec" (dict "root" $ "context" (dict "componentValues" . "key" "matrix-rtc-authorizer" "deployment" true)) | nindent 6 }}
       containers:
-      - name: sfu-jwt
+      - name: authorizer
 {{- with .image -}}
 {{- if .digest }}
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
@@ -57,7 +57,7 @@ spec:
           {{- toYaml . | nindent 10 }}
 {{- end }}
         env:
-          {{- include "element-io.matrix-rtc-sfu-jwt.env" (dict "root" $ "context" .) | nindent 8 }}
+          {{- include "element-io.matrix-rtc-authorizer.env" (dict "root" $ "context" .) | nindent 8 }}
         ports:
         - containerPort: 8080
           name: http
@@ -79,13 +79,13 @@ spec:
           {{- toYaml . | nindent 10 }}
 {{- end }}
         volumeMounts:
-{{- range $secret := include "element-io.matrix-rtc-sfu-jwt.configSecrets" (dict "root" $ "context" $.Values.matrixRTC) | fromJsonArray }}
+{{- range $secret := include "element-io.matrix-rtc-authorizer.configSecrets" (dict "root" $ "context" $.Values.matrixRTC) | fromJsonArray }}
         - mountPath: /secrets/{{ tpl $secret $ }}
           name: "secret-{{ tpl $secret $ }}"
           readOnly: true
 {{- end }}
       volumes:
-{{- range $secret := include "element-io.matrix-rtc-sfu-jwt.configSecrets" (dict "root" $ "context" $.Values.matrixRTC) | fromJsonArray }}
+{{- range $secret := include "element-io.matrix-rtc-authorizer.configSecrets" (dict "root" $ "context" $.Values.matrixRTC) | fromJsonArray }}
       - secret:
           secretName: {{ tpl $secret $ }}
         name: secret-{{ tpl $secret $ }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_secret.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_secret.yaml
@@ -9,10 +9,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $.Release.Name }}-matrix-rtc-sfu-jwt
+  name: {{ $.Release.Name }}-matrix-rtc-authorizer
   namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "element-io.matrix-rtc-sfu-jwt.labels" (dict "root" $ "context" .) | nindent 4 }}
+    {{- include "element-io.matrix-rtc-authorizer.labels" (dict "root" $ "context" .) | nindent 4 }}
 type: Opaque
 data:
 {{- if not .keysYaml }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_service.yaml
@@ -10,8 +10,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{- include "element-io.matrix-rtc-sfu-jwt.labels" (dict "root" $ "context" .) | nindent 4 }}
-  name: {{ $.Release.Name }}-matrix-rtc-sfu-jwt
+    {{- include "element-io.matrix-rtc-authorizer.labels" (dict "root" $ "context" .) | nindent 4 }}
+  name: {{ $.Release.Name }}-matrix-rtc-authorizer
   namespace: {{ $.Release.Namespace }}
 spec:
   type: ClusterIP
@@ -20,6 +20,6 @@ spec:
     port: 8080
     targetPort: http
   selector:
-    app.kubernetes.io/instance: "{{ $.Release.Name }}-matrix-rtc-sfu-jwt"
+    app.kubernetes.io/instance: "{{ $.Release.Name }}-matrix-rtc-authorizer"
 {{- end -}}
 {{- end -}}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_service_monitor.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_service_monitor.yaml
@@ -12,8 +12,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    {{- include "element-io.matrix-rtc-sfu-jwt.labels" (dict "root" $ "context" .) | nindent 4 }}
-  name: {{ $.Release.Name }}-matrix-rtc-sfu-jwt
+    {{- include "element-io.matrix-rtc-authorizer.labels" (dict "root" $ "context" .) | nindent 4 }}
+  name: {{ $.Release.Name }}-matrix-rtc-authorizer
   namespace: {{ $.Release.Namespace }}
 spec:
   endpoints:
@@ -23,7 +23,7 @@ spec:
     matchLabels:
       app.kubernetes.io/part-of: matrix-stack
       app.kubernetes.io/component: matrix-rtc-authorizer
-      app.kubernetes.io/instance: {{ $.Release.Name }}-matrix-rtc-sfu-jwt
+      app.kubernetes.io/instance: {{ $.Release.Name }}-matrix-rtc-authorizer
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_serviceaccount.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_serviceaccount.yaml
@@ -6,6 +6,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 {{- with $.Values.matrixRTC -}}
 {{- if .enabled -}}
-{{- include "element-io.ess-library.serviceAccount" (dict "root" $ "context" (dict "componentValues" . "key" "matrix-rtc-sfu-jwt")) }}
+{{- include "element-io.ess-library.serviceAccount" (dict "root" $ "context" (dict "componentValues" . "key" "matrix-rtc-authorizer")) }}
 {{- end -}}
 {{- end -}}

--- a/tests/integration/test_element_call.py
+++ b/tests/integration/test_element_call.py
@@ -31,7 +31,7 @@ async def test_element_call_livekit_jwt(ingress_ready, users, generated_data: ES
         "device_id": "something",
     }
 
-    await ingress_ready("matrix-rtc-sfu-jwt")
+    await ingress_ready("matrix-rtc")
     await ingress_ready("well-known")
     livekit_jwt = await aiohttp_post_json(
         f"https://mrtc.{generated_data.server_name}/sfu/get",

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -39,7 +39,6 @@ class DeployableDetails(abc.ABC):
     has_db: bool = field(default=False, hash=False)
     has_image: bool | None = field(default=None, hash=False)
     has_ingress: bool = field(default=True, hash=False)
-    uses_shared_ingress: bool = field(default=False, hash=False)
     has_workloads: bool = field(default=True, hash=False)
     has_service_monitor: bool = field(default=True, hash=False)
 
@@ -177,12 +176,9 @@ all_components_details = [
         is_shared_component=True,
     ),
     ComponentDetails(
-        name="matrix-rtc-sfu-jwt",
-        value_file_prefix="matrix-rtc",
+        name="matrix-rtc",
         helm_key="matrixRTC",
-        sub_components=[
-            SubComponentDetails(name="matrix-rtc-sfu", helm_key="sfu", has_ingress=False, uses_shared_ingress=True)
-        ],
+        sub_components=[SubComponentDetails(name="matrix-rtc-sfu", helm_key="sfu", has_ingress=False)],
         shared_component_names=["init-secrets"],
     ),
     ComponentDetails(
@@ -269,8 +265,8 @@ _multi_component_values_files_to_base_components_names: dict[str, list[str]] = {
         "synapse",
     ],
     "matrix-authentication-service-synapse-secrets-in-helm-values.yaml": ["matrix-authentication-service", "synapse"],
-    "matrix-rtc-external-livekit-secrets-in-helm-values.yaml": ["matrix-rtc-sfu-jwt"],
-    "matrix-rtc-external-livekit-secrets-externally-values.yaml": ["matrix-rtc-sfu-jwt"],
+    "matrix-rtc-external-livekit-secrets-in-helm-values.yaml": ["matrix-rtc"],
+    "matrix-rtc-external-livekit-secrets-externally-values.yaml": ["matrix-rtc"],
 }
 
 

--- a/tests/manifests/test_ingresses.py
+++ b/tests/manifests/test_ingresses.py
@@ -22,10 +22,8 @@ async def test_has_ingress(templates, template_to_deployable_details):
         if template["kind"] == "Ingress":
             seen_deployables_with_ingresses.add(deployable_details)
 
-    for seen_deployable in seen_deployables:
-        assert seen_deployable.has_ingress or seen_deployable.uses_shared_ingress == (
-            seen_deployable in seen_deployables_with_ingresses
-        )
+    for seen_deployable in seen_deployables_with_ingresses:
+        assert seen_deployable.has_ingress
 
 
 @pytest.mark.parametrize("values_file", values_files_with_ingresses)
@@ -320,7 +318,7 @@ async def test_ingress_certManager_clusterissuer(make_templates, values):
             )
             assert template["metadata"]["annotations"]["cert-manager.io/cluster-issuer"] == "cluster-issuer-name"
             assert template["spec"]["tls"][0]["secretName"] == f"{template['metadata']['name']}-certmanager-tls", (
-                f"Ingress {template['name']} does not have correct secret name for cert-manager tls"
+                f"Ingress {template['metadata']['name']} does not have correct secret name for cert-manager tls"
             )
 
 
@@ -335,7 +333,7 @@ async def test_ingress_certManager_issuer(make_templates, values):
             )
             assert template["metadata"]["annotations"]["cert-manager.io/issuer"] == "issuer-name"
             assert template["spec"]["tls"][0]["secretName"] == f"{template['metadata']['name']}-certmanager-tls", (
-                f"Ingress {template['name']} does not have correct secret name for cert-manager tls"
+                f"Ingress {template['metadata']['name']} does not have correct secret name for cert-manager tls"
             )
 
 


### PR DESCRIPTION
 - Rename `sfu-jwt` to `sfu-authorizer`
 - Remove the ci values override mechanism in the manifest tests
 - Fix the matrix-rtc ingress labels