### PR TITLE
Synapse: Make health listener resource name explicit

### DIFF
--- a/charts/matrix-stack/templates/synapse/_synapse_config.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_config.tpl
@@ -280,7 +280,7 @@ worker_listeners:
   type: http
   x_forwarded: false
   resources:
-  - names: []
+  - names: [health]
     compress: false
 
 {{- $enabledWorkers := (include "element-io.synapse.enabledWorkers" (dict "root" $root)) | fromJson }}

--- a/newsfragments/374.changed.md
+++ b/newsfragments/374.changed.md
@@ -1,0 +1,1 @@
+Synapse: Make health listener resource name explicit.


### PR DESCRIPTION
Technically an empty list does work as each listener will contain a health endpoint (except apparently not metrics). Being explicit though avoids confusion on what this particular listener is for.