### PR TITLE
Synapse: Add trailing slash to public_baseurl

### DIFF
--- a/charts/matrix-stack/templates/synapse/_synapse_config.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_config.tpl
@@ -17,7 +17,7 @@ require_auth_for_profile_requests: true
 {{- $root := .root -}}
 {{- with required "element-io.synapse.config.shared-overrides missing context" .context -}}
 {{- $isHook := required "element-io.synapse.config.shared-overrides requires context.isHook" .isHook -}}
-public_baseurl: https://{{ .ingress.host }}
+public_baseurl: https://{{ .ingress.host }}/
 server_name: {{ required "Synapse requires serverName set" $root.Values.serverName }}
 signing_key_path: /secrets/{{
   include "element-io.ess-library.init-secret-path" (

--- a/newsfragments/375.changed.md
+++ b/newsfragments/375.changed.md
@@ -1,0 +1,1 @@
+Synapse: Add trailing slash to public_baseurl.


### PR DESCRIPTION
This is added by Synapse internally (https://github.com/element-hq/synapse/blob/develop/synapse/config/server.py#L329-L337) but we can be explicit here in our config to match Synapse documentation config examples.