### PR TITLE
Ensure pods have the same labels as their parents

### DIFF
--- a/charts/matrix-stack/templates/element-web/deployment.yaml
+++ b/charts/matrix-stack/templates/element-web/deployment.yaml
@@ -14,6 +14,8 @@ metadata:
 {{- end }}
   labels:
     {{- include "element-io.element-web.labels" (dict "root" $ "context" .) | nindent 4 }}
+    k8s.element.io/confighash: "{{( include "element-io.element-web.configmap-data" (dict "root" $ "context" .)) | sha1sum }}"
+    k8s.element.io/nginxhash: "{{ include "element-io.element-web.nginx-configmap-data" (dict "root" $) | sha1sum }}"
   name: {{ $.Release.Name }}-element-web
   namespace: {{ $.Release.Namespace }}
 spec:

--- a/charts/matrix-stack/templates/synapse/synapse_check_config_job_hook.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_check_config_job_hook.yaml
@@ -28,6 +28,20 @@ Hook Weights are
 {{- end }}
   labels:
     {{- include "element-io.synapse-check-config-hook.labels" (dict "root" $ "context" .checkConfigHook) | nindent 4 }}
+    k8s.element.io/configdatahash: "{{ include "element-io.synapse.configmap-data"  (dict "root" $ "context" $perProcessRoot) | sha1sum }}"
+    k8s.element.io/secretdatahash: "{{ include "element-io.synapse.secret-data"  (dict "root" $ "context" $perProcessRoot) | sha1sum }}"
+{{- range $index, $appservice := .appservices }}
+{{- if .configMap }}
+    k8s.element.io/as-registration-{{ $index }}-hash: "{{ (lookup "v1" "ConfigMap" $.Release.Namespace (tpl $appservice.configMap $)) | toJson | sha1sum }}"
+{{- else }}
+    k8s.element.io/as-registration-{{ $index }}-hash: "{{ (lookup "v1" "Secret" $.Release.Namespace (tpl $appservice.secret $)) | toJson | sha1sum }}"
+{{- end }}
+{{- end }}
+    {{ include "element-io.ess-library.postgres-label" (dict "root" $ "context" (dict
+                                                            "essPassword" "synapse"
+                                                            "postgresProperty" .postgres
+                                                            )
+                                        ) }}
 spec:
   backoffLimit: 0
   completionMode: NonIndexed

--- a/charts/matrix-stack/templates/synapse/synapse_statefulset.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_statefulset.yaml
@@ -28,6 +28,11 @@ metadata:
     k8s.element.io/as-registration-{{ $index }}-hash: "{{ (lookup "v1" "Secret" $.Release.Namespace (tpl $appservice.secret $)) | toJson | sha1sum }}"
 {{- end }}
 {{- end }}
+    {{ include "element-io.ess-library.postgres-label" (dict "root" $ "context" (dict
+                                                            "essPassword" "synapse"
+                                                            "postgresProperty" .postgres
+                                                            )
+                                        ) }}
   name: {{ $.Release.Name }}-synapse-{{ $processType }}
   namespace: {{ $.Release.Namespace }}
 spec:

--- a/newsfragments/379.changed.md
+++ b/newsfragments/379.changed.md
@@ -1,0 +1,1 @@
+Ensure that all managed Pods have the same labels as their parent Deployment/StatefulSet/Job (apart from the helm.sh/chart label).


### PR DESCRIPTION
i.e. `{Deployment,StatefulSet.Job}.metadata.labels` is the same as `spec.template.metadata.labels` with the exception of `helm.sh/chart` which must be missing from the Pod spec