### PR TITLE
Enforce label naming consistency

### DIFF
--- a/charts/matrix-stack/templates/element-web/deployment.yaml
+++ b/charts/matrix-stack/templates/element-web/deployment.yaml
@@ -14,8 +14,8 @@ metadata:
 {{- end }}
   labels:
     {{- include "element-io.element-web.labels" (dict "root" $ "context" .) | nindent 4 }}
-    k8s.element.io/confighash: "{{( include "element-io.element-web.configmap-data" (dict "root" $ "context" .)) | sha1sum }}"
-    k8s.element.io/nginxhash: "{{ include "element-io.element-web.nginx-configmap-data" (dict "root" $) | sha1sum }}"
+    k8s.element.io/element-web-config-hash: "{{( include "element-io.element-web.configmap-data" (dict "root" $ "context" .)) | sha1sum }}"
+    k8s.element.io/nginx-config-hash: "{{ include "element-io.element-web.nginx-configmap-data" (dict "root" $) | sha1sum }}"
   name: {{ $.Release.Name }}-element-web
   namespace: {{ $.Release.Namespace }}
 spec:
@@ -32,8 +32,8 @@ spec:
     metadata:
       labels:
         {{- include "element-io.element-web.labels" (dict "root" $ "context" (dict "image" .image "labels" .labels "withChartVersion" false)) | nindent 8 }}
-        k8s.element.io/confighash: "{{( include "element-io.element-web.configmap-data" (dict "root" $ "context" .)) | sha1sum }}"
-        k8s.element.io/nginxhash: "{{ include "element-io.element-web.nginx-configmap-data" (dict "root" $) | sha1sum }}"
+        k8s.element.io/element-web-config-hash: "{{( include "element-io.element-web.configmap-data" (dict "root" $ "context" .)) | sha1sum }}"
+        k8s.element.io/nginx-config-hash: "{{ include "element-io.element-web.nginx-configmap-data" (dict "root" $) | sha1sum }}"
 {{- with .annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/matrix-stack/templates/ess-library/_labels.tpl
+++ b/charts/matrix-stack/templates/ess-library/_labels.tpl
@@ -36,7 +36,7 @@ app.kubernetes.io/part-of: matrix-stack
 {{- with required "element-io.ess-library.postgres-label requires context" .context -}}
 {{- $essPassword := required "element-io.ess-library.postgres-label context missing essPassword" .essPassword -}}
 {{- $postgresProperty := required "elment-io.ess-library.postgres-label context missing postgresProperty" .postgresProperty -}}
-k8s.element.io/postgresPasswordHash: {{ if $postgresProperty -}}
+k8s.element.io/postgres-password-hash: {{ if $postgresProperty -}}
     {{- if $postgresProperty.password.value -}}
     {{- $postgresProperty.password.value | sha1sum -}}
     {{- else -}}

--- a/charts/matrix-stack/templates/haproxy/deployment.yaml
+++ b/charts/matrix-stack/templates/haproxy/deployment.yaml
@@ -16,12 +16,12 @@ metadata:
 {{- end }}
   labels:
     {{- include "element-io.haproxy.labels" (dict "root" $ "context" .) | nindent 4 }}
-    k8s.element.io/confighash: "{{ include "element-io.haproxy.configmap-data" (dict "root" $ "context" .) | sha1sum }}"
+    k8s.element.io/shared-haproxy-config-hash: "{{ include "element-io.haproxy.configmap-data" (dict "root" $ "context" .) | sha1sum }}"
 {{- if $.Values.synapse.enabled }}
-    k8s.element.io/synapsehash: "{{ include "element-io.synapse-haproxy.configmap-data" (dict "root" $) | sha1sum }}"
+    k8s.element.io/synapse-haproxy-config-hash: "{{ include "element-io.synapse-haproxy.configmap-data" (dict "root" $) | sha1sum }}"
 {{- end }}
 {{- if $.Values.wellKnownDelegation.enabled }}
-    k8s.element.io/wellknowndelegationhash: {{ include "element-io.well-known-delegation.configmap-data" (dict "root" $ "context" $.Values.wellKnownDelegation) | sha1sum }}
+    k8s.element.io/wellknowndelegation-haproxy-config-hash: {{ include "element-io.well-known-delegation.configmap-data" (dict "root" $ "context" $.Values.wellKnownDelegation) | sha1sum }}
 {{- end }}
   name: {{ $.Release.Name }}-haproxy
   namespace: {{ $.Release.Namespace }}
@@ -39,12 +39,12 @@ spec:
     metadata:
       labels:
         {{- include "element-io.haproxy.labels" (dict "root" $ "context" (dict "image" .image "labels" .labels "withChartVersion" false)) | nindent 8 }}
-        k8s.element.io/confighash: {{ include "element-io.haproxy.configmap-data" (dict "root" $ "context" .) | sha1sum }}
+        k8s.element.io/shared-haproxy-config-hash: {{ include "element-io.haproxy.configmap-data" (dict "root" $ "context" .) | sha1sum }}
 {{- if $.Values.synapse.enabled }}
-        k8s.element.io/synapsehash: {{ include "element-io.synapse-haproxy.configmap-data" (dict "root" $) | sha1sum }}
+        k8s.element.io/synapse-haproxy-config-hash: {{ include "element-io.synapse-haproxy.configmap-data" (dict "root" $) | sha1sum }}
 {{- end }}
 {{- if $.Values.wellKnownDelegation.enabled }}
-        k8s.element.io/wellknowndelegationhash: {{ include "element-io.well-known-delegation.configmap-data" (dict "root" $ "context" $.Values.wellKnownDelegation) | sha1sum }}
+        k8s.element.io/wellknowndelegation-haproxy-config-hash: {{ include "element-io.well-known-delegation.configmap-data" (dict "root" $ "context" $.Values.wellKnownDelegation) | sha1sum }}
 {{- end }}
 {{- with .annotations }}
       annotations:

--- a/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
@@ -15,8 +15,8 @@ metadata:
 {{- end }}
   labels:
     {{- include "element-io.matrix-authentication-service.labels" (dict "root" $ "context" .) | nindent 4 }}
-    k8s.element.io/confighash: {{ include "element-io.matrix-authentication-service.configmap-data" (dict "root" $ "context" .) | sha1sum }}
-    k8s.element.io/secrethash: {{ include "element-io.matrix-authentication-service.secret-data" (dict "root" $ "context" .) | sha1sum }}
+    k8s.element.io/matrix-authentication-service-config-hash: {{ include "element-io.matrix-authentication-service.configmap-data" (dict "root" $ "context" .) | sha1sum }}
+    k8s.element.io/matrix-authentication-service-secret-hash: {{ include "element-io.matrix-authentication-service.secret-data" (dict "root" $ "context" .) | sha1sum }}
     {{ include "element-io.ess-library.postgres-label" (dict "root" $ "context" (dict
                                                             "essPassword" "matrixAuthenticationService"
                                                             "postgresProperty" .postgres
@@ -38,8 +38,8 @@ spec:
     metadata:
       labels:
         {{- include "element-io.matrix-authentication-service.labels" (dict "root" $ "context" (dict "image" .image "labels" .labels "withChartVersion" false)) | nindent 8 }}
-        k8s.element.io/confighash: "{{ include "element-io.matrix-authentication-service.configmap-data" (dict "root" $ "context" .) | sha1sum }}"
-        k8s.element.io/secrethash: "{{ include "element-io.matrix-authentication-service.secret-data" (dict "root" $ "context" .) | sha1sum }}"
+        k8s.element.io/matrix-authentication-service-config-hash: "{{ include "element-io.matrix-authentication-service.configmap-data" (dict "root" $ "context" .) | sha1sum }}"
+        k8s.element.io/matrix-authentication-service-secret-hash: "{{ include "element-io.matrix-authentication-service.secret-data" (dict "root" $ "context" .) | sha1sum }}"
         {{ include "element-io.ess-library.postgres-label" (dict "root" $ "context" (dict
                                                                 "essPassword" "matrixAuthenticationService"
                                                                 "postgresProperty" .postgres

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
@@ -17,7 +17,7 @@ metadata:
 {{- end }}
   labels:
     {{- include "element-io.matrix-rtc-sfu.labels" (dict "root" $ "context" .) | nindent 4 }}
-    k8s.element.io/confighash: {{ include "element-io.matrix-rtc-sfu.configmap-data" (dict "root" $ "context" .) | sha1sum }}
+    k8s.element.io/matrix-rtc-sfu-config-hash: {{ include "element-io.matrix-rtc-sfu.configmap-data" (dict "root" $ "context" .) | sha1sum }}
   name: {{ $.Release.Name }}-matrix-rtc-sfu
   namespace: {{ $.Release.Namespace }}
 spec:
@@ -34,7 +34,7 @@ spec:
     metadata:
       labels:
         {{- include "element-io.matrix-rtc-sfu.labels" (dict "root" $ "context" (dict "image" .image "labels" .labels "withChartVersion" false)) | nindent 8 }}
-        k8s.element.io/confighash: {{ include "element-io.matrix-rtc-sfu.configmap-data" (dict "root" $ "context" .) | sha1sum }}
+        k8s.element.io/matrix-rtc-sfu-config-hash: {{ include "element-io.matrix-rtc-sfu.configmap-data" (dict "root" $ "context" .) | sha1sum }}
 {{- with .annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_deployment.yaml
@@ -15,7 +15,7 @@ metadata:
 {{- end }}
   labels:
     {{- include "element-io.matrix-rtc-authorizer.labels" (dict "root" $ "context" .) | nindent 4 }}
-    k8s.element.io/secrethash: {{ include "element-io.matrix-rtc-authorizer.secret-data" (dict "root" $ "context" .) | sha1sum }}
+    k8s.element.io/matrix-rtc-authorizer-secret-hash: {{ include "element-io.matrix-rtc-authorizer.secret-data" (dict "root" $ "context" .) | sha1sum }}
   name: {{ $.Release.Name }}-matrix-rtc-authorizer
   namespace: {{ $.Release.Namespace }}
 spec:
@@ -32,7 +32,7 @@ spec:
     metadata:
       labels:
         {{- include "element-io.matrix-rtc-authorizer.labels" (dict "root" $ "context" (dict "image" .image "labels" .labels "withChartVersion" false)) | nindent 8 }}
-        k8s.element.io/secrethash: {{ include "element-io.matrix-rtc-authorizer.secret-data" (dict "root" $ "context" .) | sha1sum }}
+        k8s.element.io/matrix-rtc-authorizer-secret-hash: {{ include "element-io.matrix-rtc-authorizer.secret-data" (dict "root" $ "context" .) | sha1sum }}
 {{- with .annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/matrix-stack/templates/postgres/statefulset.yaml
+++ b/charts/matrix-stack/templates/postgres/statefulset.yaml
@@ -10,12 +10,12 @@ kind: StatefulSet
 metadata:
   labels:
     {{- include "element-io.postgres.labels" (dict "root" $ "context" .) | nindent 4 }}
+    k8s.element.io/postgres-secret-hash: "{{ include "element-io.postgres.secret-data" (dict "root" $ "context" .) | sha1sum }}"
+    k8s.element.io/postgres-config-hash: "{{ include "element-io.postgres.configmap-data" (dict "root" $ "context" .) | sha1sum }}"
   name: {{ $.Release.Name }}-postgres
   namespace: {{ $.Release.Namespace }}
-  annotations:
-    k8s.element.io/secrethash: "{{ include "element-io.postgres.secret-data" (dict "root" $ "context" .) | sha1sum }}"
-    k8s.element.io/confighash: "{{ include "element-io.postgres.configmap-data" (dict "root" $ "context" .) | sha1sum }}"
 {{- with .annotations }}
+  annotations:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 spec:
@@ -30,10 +30,10 @@ spec:
     metadata:
       labels:
         {{- include "element-io.postgres.labels" (dict "root" $ "context" (dict "image" .image "labels" .labels "withChartVersion" false)) | nindent 8 }}
-      annotations:
-        k8s.element.io/secrethash: "{{ include "element-io.postgres.secret-data" (dict "root" $ "context" .) | sha1sum }}"
-        k8s.element.io/confighash: "{{ include "element-io.postgres.configmap-data" (dict "root" $ "context" .) | sha1sum }}"
+        k8s.element.io/postgres-secret-hash: "{{ include "element-io.postgres.secret-data" (dict "root" $ "context" .) | sha1sum }}"
+        k8s.element.io/postgres-config-hash: "{{ include "element-io.postgres.configmap-data" (dict "root" $ "context" .) | sha1sum }}"
 {{- with .annotations }}
+      annotations:
         {{- toYaml . | nindent 8 }}
 {{- end }}
     spec:

--- a/charts/matrix-stack/templates/synapse/_synapse_pod.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_pod.tpl
@@ -18,8 +18,8 @@ template:
 {{- else }}
       {{- include "element-io.synapse.process.labels" (dict "root" $root "context" (dict "image" .image "labels" .labels "withChartVersion" false "isHook" $isHook "processType" $processType)) | nindent 6 }}
 {{- end }}
-      k8s.element.io/configdatahash: "{{ include "element-io.synapse.configmap-data"  (dict "root" $root "context" .) | sha1sum }}"
-      k8s.element.io/secretdatahash: "{{ include "element-io.synapse.secret-data"  (dict "root" $root "context" .) | sha1sum }}"
+      k8s.element.io/synapse-config-hash: "{{ include "element-io.synapse.configmap-data"  (dict "root" $root "context" .) | sha1sum }}"
+      k8s.element.io/synapse-secret-hash: "{{ include "element-io.synapse.secret-data"  (dict "root" $root "context" .) | sha1sum }}"
 {{- range $index, $appservice := .appservices }}
 {{- if .configMap }}
       k8s.element.io/as-registration-{{ $index }}-hash: "{{ (lookup "v1" "ConfigMap" $root.Release.Namespace (tpl $appservice.configMap $root)) | toJson | sha1sum }}"

--- a/charts/matrix-stack/templates/synapse/redis_deployment.yaml
+++ b/charts/matrix-stack/templates/synapse/redis_deployment.yaml
@@ -17,7 +17,7 @@ metadata:
 {{- end }}
   labels:
     {{- include "element-io.synapse-redis.labels" (dict "root" $ "context" (dict "image" .image "labels" .labels)) | nindent 4 }}
-    k8s.element.io/confighash: "{{ include "element-io.synapse-redis.configmap-data" (dict "root" $) | sha1sum }}"
+    k8s.element.io/redis-config-hash: "{{ include "element-io.synapse-redis.configmap-data" (dict "root" $) | sha1sum }}"
   name: {{ $.Release.Name }}-synapse-redis
   namespace: {{ $.Release.Namespace }}
 spec:
@@ -34,7 +34,7 @@ spec:
     metadata:
       labels:
         {{- include "element-io.synapse-redis.labels" (dict "root" $ "context" (dict "image" .image "labels" .labels "withChartVersion" false)) | nindent 8 }}
-        k8s.element.io/confighash: "{{ include "element-io.synapse-redis.configmap-data" (dict "root" $) | sha1sum }}"
+        k8s.element.io/redis-config-hash: "{{ include "element-io.synapse-redis.configmap-data" (dict "root" $) | sha1sum }}"
 {{- with .annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/matrix-stack/templates/synapse/synapse_check_config_job_hook.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_check_config_job_hook.yaml
@@ -28,8 +28,8 @@ Hook Weights are
 {{- end }}
   labels:
     {{- include "element-io.synapse-check-config-hook.labels" (dict "root" $ "context" .checkConfigHook) | nindent 4 }}
-    k8s.element.io/configdatahash: "{{ include "element-io.synapse.configmap-data"  (dict "root" $ "context" $perProcessRoot) | sha1sum }}"
-    k8s.element.io/secretdatahash: "{{ include "element-io.synapse.secret-data"  (dict "root" $ "context" $perProcessRoot) | sha1sum }}"
+    k8s.element.io/synapse-config-hash: "{{ include "element-io.synapse.configmap-data"  (dict "root" $ "context" $perProcessRoot) | sha1sum }}"
+    k8s.element.io/synapse-secret-hash: "{{ include "element-io.synapse.secret-data"  (dict "root" $ "context" $perProcessRoot) | sha1sum }}"
 {{- range $index, $appservice := .appservices }}
 {{- if .configMap }}
     k8s.element.io/as-registration-{{ $index }}-hash: "{{ (lookup "v1" "ConfigMap" $.Release.Namespace (tpl $appservice.configMap $)) | toJson | sha1sum }}"

--- a/charts/matrix-stack/templates/synapse/synapse_statefulset.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_statefulset.yaml
@@ -19,8 +19,8 @@ metadata:
 {{- end }}
   labels:
     {{- include "element-io.synapse.process.labels" (dict "root" $ "context" $perProcessRoot) | nindent 4 }}
-    k8s.element.io/configdatahash: "{{ include "element-io.synapse.configmap-data"  (dict "root" $ "context" $perProcessRoot) | sha1sum }}"
-    k8s.element.io/secretdatahash: "{{ include "element-io.synapse.secret-data"  (dict "root" $ "context" $perProcessRoot) | sha1sum }}"
+    k8s.element.io/synapse-config-hash: "{{ include "element-io.synapse.configmap-data"  (dict "root" $ "context" $perProcessRoot) | sha1sum }}"
+    k8s.element.io/synapse-secret-hash: "{{ include "element-io.synapse.secret-data"  (dict "root" $ "context" $perProcessRoot) | sha1sum }}"
 {{- range $index, $appservice := .appservices }}
 {{- if .configMap }}
     k8s.element.io/as-registration-{{ $index }}-hash: "{{ (lookup "v1" "ConfigMap" $.Release.Namespace (tpl $appservice.configMap $)) | toJson | sha1sum }}"

--- a/newsfragments/380.changed.1.md
+++ b/newsfragments/380.changed.1.md
@@ -1,0 +1,1 @@
+Enforce a common format for k8s.element.io labels across components.

--- a/newsfragments/380.changed.md
+++ b/newsfragments/380.changed.md
@@ -1,0 +1,1 @@
+Move Postgres config/secret hashes to labels for consistency with all other components.

--- a/tests/manifests/test_annotations.py
+++ b/tests/manifests/test_annotations.py
@@ -1,0 +1,29 @@
+# Copyright 2025 New Vector Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+
+import pytest
+
+from . import values_files_to_test
+from .utils import template_id
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_annotations_dont_contain_things_that_should_be_labels(templates):
+    for template in templates:
+        annotations = template["metadata"].get("annotations", {})
+        our_annotations = [key for key in annotations if "k8s.element.io" in key]
+        assert len(our_annotations) == 0, (
+            f"{template_id(template)} has {our_annotations=}. "
+            "We should consistently use labels for k8s.element.io things"
+        )
+
+        if template["kind"] in ["Deployment", "Job", "StatefulSet"]:
+            pod_annotations = template["metadata"].get("annotations", {})
+            our_pod_annotations = [key for key in pod_annotations if "k8s.element.io" in key]
+            assert len(our_pod_annotations) == 0, (
+                f"{template_id(template)} has {our_pod_annotations=} in its Pod spec. "
+                "We should consistently use labels for k8s.element.io things"
+            )


### PR DESCRIPTION
Before:
```sh
$ ack k8s.element.io charts | sed 's/.*k8s/k8s/' | sed 's/: .*//' | sort | uniq -c
      6 k8s.element.io/as-registration-{{ $index }}-hash
      3 k8s.element.io/configdatahash
     12 k8s.element.io/confighash
      2 k8s.element.io/nginxhash
      1 k8s.element.io/postgresPasswordHash
      3 k8s.element.io/secretdatahash
      6 k8s.element.io/secrethash
      2 k8s.element.io/synapsehash
      5 k8s.element.io/synapse-instance
      2 k8s.element.io/target-instance
      2 k8s.element.io/target-name
      2 k8s.element.io/wellknowndelegationhash
```

After:
```sh
ack k8s.element.io charts | sed 's/.*k8s/k8s/' | sed 's/: .*//' | sort | uniq -c
      6 k8s.element.io/as-registration-{{ $index }}-hash
      2 k8s.element.io/element-web-config-hash
      2 k8s.element.io/matrix-authentication-service-config-hash
      2 k8s.element.io/matrix-authentication-service-secret-hash
      2 k8s.element.io/matrix-rtc-authorizer-secret-hash
      2 k8s.element.io/matrix-rtc-sfu-config-hash
      2 k8s.element.io/nginx-config-hash
      2 k8s.element.io/postgres-config-hash
      1 k8s.element.io/postgres-password-hash
      2 k8s.element.io/postgres-secret-hash
      2 k8s.element.io/redis-config-hash
      2 k8s.element.io/shared-haproxy-config-hash
      3 k8s.element.io/synapse-config-hash
      2 k8s.element.io/synapse-haproxy-config-hash
      5 k8s.element.io/synapse-instance
      3 k8s.element.io/synapse-secret-hash
      2 k8s.element.io/target-instance
      2 k8s.element.io/target-name
      2 k8s.element.io/wellknowndelegation-haproxy-config-hash
```

Different components had different ideas about how to do their labelling. We should enforce a consistency pattern across all components