### PR TITLE
Matrix Authentication Service: migrate DB on init

### DIFF
--- a/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
@@ -161,6 +161,11 @@ spec:
           name: rendered-config
           subPath: config.yaml
           readOnly: true
+{{- range $secret := include "element-io.matrix-authentication-service.configSecrets" (dict "root" $ "context" .) | fromJsonArray }}
+        - mountPath: /secrets/{{ tpl $secret $ }}
+          name: "secret-{{ tpl $secret $ }}"
+          readOnly: true
+{{- end }}
       containers:
       - name: matrix-authentication-service
         args: ["server", "--no-migrate"]

--- a/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
@@ -135,9 +135,35 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
 {{- end }}
+      - name: database-migrate
+        args: ["database", "migrate"]
+{{- with .image -}}
+{{- if .digest }}
+        image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
+        imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
+{{- else }}
+        image: "{{ .registry }}/{{ .repository }}:{{ required "matrixAuthenticationService.image.tag is required if no digest" .tag }}"
+        imagePullPolicy: {{ .pullPolicy | default "Always" }}
+{{- end }}
+{{- end }}
+{{- with .containersSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+{{- end }}
+        env:
+        {{- include "element-io.matrix-authentication-service.env" (dict "root" $ "context" .) | nindent 10 }}
+{{- with .resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+{{- end }}
+        volumeMounts:
+        - mountPath: "/config.yaml"
+          name: rendered-config
+          subPath: config.yaml
+          readOnly: true
       containers:
       - name: matrix-authentication-service
-        args: ["server"]
+        args: ["server", "--no-migrate"]
 {{- with .image -}}
 {{- if .digest }}
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"

--- a/newsfragments/416.changed.md
+++ b/newsfragments/416.changed.md
@@ -1,0 +1,1 @@
+Matrix Authentication Service: perform database migration with an init container, instead of on the startup of the main container.


### PR DESCRIPTION
This moves the DB migration step to a dedicated init container, instead of doing it on startup of the main container which could potentially take long & fail liveness checks.

With that said, in practice we haven't seen a MAS deployment so large that its DB migration took long enough to fail liveness checks, so using an init container is more of a best-practice than a hard necessity.