### PR TITLE
Small manifest test fixes

### DIFF
--- a/newsfragments/418.internal.md
+++ b/newsfragments/418.internal.md
@@ -1,0 +1,1 @@
+Fix ServiceAccount manifest being unreliable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ select = [
     "SIM",
     # isort
     "I",
+    # flake8-pytest-style
+    "PT",
 ]
 
 [tool.towncrier]

--- a/tests/integration/fixtures/cluster.py
+++ b/tests/integration/fixtures/cluster.py
@@ -78,13 +78,13 @@ async def cluster():
 
 @pytest.fixture(scope="session")
 async def helm_client(cluster):
-    yield pyhelm3.Client(kubeconfig=cluster.kubeconfig, kubecontext=cluster.context)
+    return pyhelm3.Client(kubeconfig=cluster.kubeconfig, kubecontext=cluster.context)
 
 
 @pytest.fixture(scope="session")
 async def kube_client(cluster):
     kube_config = KubeConfig.from_file(cluster.kubeconfig)
-    yield AsyncClient(config=kube_config)
+    return AsyncClient(config=kube_config)
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -36,7 +36,7 @@ class DeployableDetails(abc.ABC):
     value_file_prefix: str | None = field(default=None, hash=False)
     helm_key: str = field(default=None, hash=False)  # type: ignore[assignment]
 
-    has_db: bool = field(default=False, hash=False)  # type: ignore[assignment]
+    has_db: bool = field(default=False, hash=False)
     has_image: bool = field(default=None, hash=False)  # type: ignore[assignment]
     has_extra_env: bool = field(default=None, hash=False)  # type: ignore[assignment]
     has_ingress: bool = field(default=True, hash=False)

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -65,7 +65,7 @@ class DeployableDetails(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def owns_manifest_named(seflf, manifest_name: str) -> bool:
+    def owns_manifest_named(self, manifest_name: str) -> bool:
         pass
 
     @abc.abstractmethod

--- a/tests/manifests/test_matrix_rtc.py
+++ b/tests/manifests/test_matrix_rtc.py
@@ -18,7 +18,8 @@ async def test_log_level_overrides(values, deployables_details, make_templates):
             log_yaml = yaml.safe_load(template["data"]["config.yaml"])
             use_external_ip = log_yaml["rtc"]["use_external_ip"]
             tcp_port = log_yaml["rtc"]["tcp_port"]
-            assert type(use_external_ip) is bool and use_external_ip
+            assert type(use_external_ip) is bool
+            assert use_external_ip
             assert tcp_port == 30881
             break
     else:
@@ -42,7 +43,8 @@ async def test_log_level_overrides(values, deployables_details, make_templates):
             log_yaml = yaml.safe_load(template["data"]["config.yaml"])
             use_external_ip = log_yaml["rtc"]["use_external_ip"]
             tcp_port = log_yaml["rtc"]["tcp_port"]
-            assert type(use_external_ip) is bool and not use_external_ip
+            assert type(use_external_ip) is bool
+            assert not use_external_ip
             assert tcp_port == 32001
             break
     else:

--- a/tests/manifests/test_pod_pull_secrets.py
+++ b/tests/manifests/test_pod_pull_secrets.py
@@ -70,7 +70,7 @@ async def test_local_pull_secrets(deployables_details, values, base_values, make
                 assert len(template["spec"]["template"]["spec"]["imagePullSecrets"]) == 2, (
                     f"Expected {id} to have 2 image pull secrets"
                 )
-                assert "matrix-tools-secret" in secret_names and "global-secret" in secret_names, (
+                assert set(secret_names) == set(["matrix-tools-secret", "global-secret"]), (
                     f"Expected {id} to have image pull secret names: local-secret, global-secret, "
                     f"got {','.join(secret_names)}"
                 )
@@ -80,7 +80,7 @@ async def test_local_pull_secrets(deployables_details, values, base_values, make
                     f"Expected {id} to have 3 image pull secrets"
                 )
 
-                assert "matrix-tools-secret" in secret_names, (
+                assert set(secret_names) == set(["matrix-tools-secret", "local-secret", "global-secret"]), (
                     f"Expected {id} to have image pull secret names: "
                     f"local-secret, global-secret, matrix-tools-secret, got {','.join(secret_names)}"
                 )
@@ -88,7 +88,7 @@ async def test_local_pull_secrets(deployables_details, values, base_values, make
                 assert len(template["spec"]["template"]["spec"]["imagePullSecrets"]) == 2, (
                     f"Expected {id} to have 2 image pull secrets"
                 )
-                assert "local-secret" in secret_names and "global-secret" in secret_names, (
+                assert set(secret_names) == set(["local-secret", "global-secret"]), (
                     f"Expected {id} to have image pull secret names: local-secret, global-secret, "
                     f"got {','.join(secret_names)}"
                 )

--- a/tests/manifests/test_serviceaccounts.py
+++ b/tests/manifests/test_serviceaccounts.py
@@ -99,7 +99,7 @@ async def test_does_not_create_serviceaccounts_if_configured_not_to(deployables_
             continue
 
         values_to_modify = copy.deepcopy(values)
-        disable_service_account(deployable_details.get_helm_values_fragment(values))
+        disable_service_account(deployable_details.get_helm_values_fragment(values_to_modify))
 
         workloads_by_id = {}
         serviceaccount_names = set()

--- a/tests/manifests/utils.py
+++ b/tests/manifests/utils.py
@@ -32,7 +32,7 @@ async def helm_client():
     return pyhelm3.Client()
 
 
-@pytest.fixture()
+@pytest.fixture
 async def temp_chart(helm_client):
     with tempfile.TemporaryDirectory() as tmpdirname:
         shutil.copytree("charts/matrix-stack", Path(tmpdirname) / "matrix-stack")
@@ -44,7 +44,7 @@ async def chart(helm_client: pyhelm3.Client):
     return await helm_client.get_chart("charts/matrix-stack")
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def deployables_details(values_file) -> tuple[DeployableDetails, ...]:
     return values_files_to_deployables_details[values_file]
 
@@ -54,7 +54,7 @@ def base_values() -> dict[str, Any]:
     return yaml.safe_load(Path("charts/matrix-stack/values.yaml").read_text("utf-8"))
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def values(values_file) -> dict[str, Any]:
     if values_file not in values_cache:
         v = yaml.safe_load((Path("charts/matrix-stack/ci") / values_file).read_text("utf-8"))
@@ -69,12 +69,12 @@ def values(values_file) -> dict[str, Any]:
     return copy.deepcopy(values_cache[values_file])
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 async def templates(chart: pyhelm3.Chart, release_name: str, values: dict[str, Any]):
     return await helm_template(chart, release_name, values)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def other_secrets(release_name, values, templates):
     return list(generated_secrets(release_name, values, templates)) + list(external_secrets(release_name, values))
 


### PR DESCRIPTION
The final commit (the ServiceAccount manifest test change) is the most important here as it makes the test dependent on the order of `DeployableDetails`