### PR TITLE
Make it possible to manifest test sidecars properly

### DIFF
--- a/newsfragments/420.internal.md
+++ b/newsfragments/420.internal.md
@@ -1,0 +1,1 @@
+All varying of values for sidecars in manifest tests.

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -292,6 +292,19 @@ all_components_details = [
         has_ingress=False,
         has_extra_env=False,
         has_storage=True,
+        sidecars=(
+            SidecarDetails(
+                name="postgres-exporter",
+                helm_keys=("postgres", "postgresExporter"),
+                helm_keys_overrides={
+                    # No manifests of its own, so no labels to set
+                    PropertyType.Labels: None,
+                },
+                has_extra_env=False,
+                has_ingress=False,
+                has_service_monitor=False,
+            ),
+        ),
         paths_consistency_noqa=("/docker-entrypoint-initdb.d/init-ess-dbs.sh",),
         is_shared_component=True,
     ),

--- a/tests/manifests/test_element_web.py
+++ b/tests/manifests/test_element_web.py
@@ -9,7 +9,7 @@ import pytest
 
 @pytest.mark.parametrize("values_file", ["element-web-minimal-values.yaml"])
 @pytest.mark.asyncio_cooperative
-async def test_config_json_override(values, deployables_details, make_templates):
+async def test_config_json_override(values, make_templates):
     for template in await make_templates(values):
         if template["kind"] == "ConfigMap" and "element-web" in template["metadata"]["name"]:
             config_json = json.loads(template["data"]["config.json"])

--- a/tests/manifests/test_labels.py
+++ b/tests/manifests/test_labels.py
@@ -66,7 +66,10 @@ async def test_templates_have_postgres_hash_label(release_name, templates, value
                 continue
 
             assert "k8s.element.io/postgres-password-hash" in labels, f"{id} does not have postgres password hash label"
-            helm_key = deployable_details.helm_key
+            assert (
+                len(deployable_details.helm_keys) == 1
+            )  # We currently assume that Postgres is for top-level components only
+            helm_key = deployable_details.helm_keys[0]
             values_fragment = deployable_details.get_helm_values_fragment(values)
             if values_fragment.get("postgres", {}).get("password", {}).get("value", None):
                 expected = deployable_details.get_helm_values_fragment(values)["postgres"]["password"]["value"]

--- a/tests/manifests/test_labels.py
+++ b/tests/manifests/test_labels.py
@@ -7,7 +7,7 @@ from hashlib import sha1
 
 import pytest
 
-from . import secret_values_files_to_test, values_files_to_test
+from . import PropertyType, secret_values_files_to_test, values_files_to_test
 from .utils import template_id
 
 
@@ -70,12 +70,12 @@ async def test_templates_have_postgres_hash_label(release_name, templates, value
                 len(deployable_details.helm_keys) == 1
             )  # We currently assume that Postgres is for top-level components only
             helm_key = deployable_details.helm_keys[0]
-            values_fragment = deployable_details.get_helm_values_fragment(values)
-            if values_fragment.get("postgres", {}).get("password", {}).get("value", None):
-                expected = deployable_details.get_helm_values_fragment(values)["postgres"]["password"]["value"]
-            elif values_fragment.get("postgres", {}).get("password", {}).get("secret", None):
-                secret_name = deployable_details.get_helm_values_fragment(values)["postgres"]["password"]["secret"]
-                expected = f"{secret_name}-{values_fragment['postgres']['password']['secretKey']}"
+            values_fragment = deployable_details.get_helm_values(values, PropertyType.Postgres)
+            if values_fragment.get("password", {}).get("value", None):
+                expected = values_fragment["password"]["value"]
+            elif values_fragment.get("password", {}).get("secret", None):
+                secret_name = values_fragment["password"]["secret"]
+                expected = f"{secret_name}-{values_fragment['password']['secretKey']}"
             elif values["postgres"].get("essPasswords", {}).get(helm_key, {}).get("value", None):
                 expected = values["postgres"]["essPasswords"][helm_key]["value"]
             elif values["postgres"].get("essPasswords", {}).get(helm_key, {}).get("secret", None):

--- a/tests/manifests/test_matrix_authentication_service.py
+++ b/tests/manifests/test_matrix_authentication_service.py
@@ -7,7 +7,7 @@ import pytest
 
 @pytest.mark.parametrize("values_file", ["matrix-authentication-service-minimal-values.yaml"])
 @pytest.mark.asyncio_cooperative
-async def test_matrix_authentication_service_env_overrides(values, deployables_details, make_templates):
+async def test_matrix_authentication_service_env_overrides(values, make_templates):
     for template in await make_templates(values):
         if "matrix-authentication-service" in template["metadata"]["name"] and template["kind"] == "Deployment":
             env = {e["name"]: e["value"] for e in template["spec"]["template"]["spec"]["containers"][0]["env"]}

--- a/tests/manifests/test_matrix_rtc.py
+++ b/tests/manifests/test_matrix_rtc.py
@@ -8,7 +8,7 @@ import yaml
 
 @pytest.mark.parametrize("values_file", ["matrix-rtc-minimal-values.yaml"])
 @pytest.mark.asyncio_cooperative
-async def test_log_level_overrides(values, deployables_details, make_templates):
+async def test_log_level_overrides(values, make_templates):
     for template in await make_templates(values):
         if (
             template["kind"] == "ConfigMap"

--- a/tests/manifests/test_pod_env.py
+++ b/tests/manifests/test_pod_env.py
@@ -4,15 +4,10 @@
 
 import pytest
 
-from . import values_files_to_test
-from .utils import iterate_deployables_workload_parts
+from . import DeployableDetails, PropertyType, values_files_to_test
+from .utils import iterate_deployables_parts
 
 extra_env = {"a_string": "a", "b_boolean": True, "c_integer": 1, "d_float": 1.1}
-
-
-def set_extra_env(values_fragment, deployable_details):
-    if deployable_details.has_extra_env:
-        values_fragment["extraEnv"] = [{"name": k, "value": str(v)} for k, v in extra_env.items()]
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -20,7 +15,15 @@ def set_extra_env(values_fragment, deployable_details):
 async def test_unique_env_name_in_containers(
     deployables_details, values, make_templates, template_to_deployable_details
 ):
-    iterate_deployables_workload_parts(deployables_details, values, set_extra_env)
+    def set_extra_env(deployable_details: DeployableDetails):
+        deployable_details.set_helm_values(
+            values, PropertyType.Env, [{"name": k, "value": str(v)} for k, v in extra_env.items()]
+        )
+
+    iterate_deployables_parts(
+        deployables_details, set_extra_env, lambda deployable_details: deployable_details.has_extra_env
+    )
+
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "Job", "StatefulSet"]:
             id = f"{template['kind']}/{template['metadata']['name']}"
@@ -35,7 +38,15 @@ async def test_unique_env_name_in_containers(
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_env_values_are_strings_in_containers(deployables_details, values, make_templates):
-    iterate_deployables_workload_parts(deployables_details, values, set_extra_env)
+    def set_extra_env(deployable_details: DeployableDetails):
+        deployable_details.set_helm_values(
+            values, PropertyType.Env, [{"name": k, "value": str(v)} for k, v in extra_env.items()]
+        )
+
+    iterate_deployables_parts(
+        deployables_details, set_extra_env, lambda deployable_details: deployable_details.has_extra_env
+    )
+
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "Job", "StatefulSet"]:
             id = f"{template['kind']}/{template['metadata']['name']}"

--- a/tests/manifests/test_pod_pull_secrets.py
+++ b/tests/manifests/test_pod_pull_secrets.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from . import values_files_to_test
+from . import PropertyType, values_files_to_test
 from .utils import iterate_deployables_image_parts
 
 
@@ -35,9 +35,8 @@ async def test_local_pull_secrets(deployables_details, values, base_values, make
     values.setdefault("matrixTools", {}).setdefault("image", {})["pullSecrets"] = [{"name": "matrix-tools-secret"}]
     iterate_deployables_image_parts(
         deployables_details,
-        values,
-        lambda values_fragment, deployable_details: values_fragment.setdefault(
-            "image", {"pullSecrets": [{"name": "local-secret"}]}
+        lambda deployable_details: deployable_details.set_helm_values(
+            values, PropertyType.Image, {"pullSecrets": [{"name": "local-secret"}]}
         ),
     )
 

--- a/tests/manifests/test_pod_securityContext.py
+++ b/tests/manifests/test_pod_securityContext.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from . import values_files_to_test
+from . import PropertyType, values_files_to_test
 from .utils import iterate_deployables_workload_parts
 
 
@@ -41,9 +41,8 @@ async def test_sets_nonRoot_uids_gids_in_pod_securityContext_by_default(template
 async def test_can_nuke_pod_securityContext_ids(deployables_details, values, make_templates):
     iterate_deployables_workload_parts(
         deployables_details,
-        values,
-        lambda values_fragment, deployable_details: values_fragment.setdefault(
-            "podSecurityContext", {"runAsUser": None, "runAsGroup": None, "fsGroup": None}
+        lambda deployable_details: deployable_details.set_helm_values(
+            values, PropertyType.PodSecurityContext, {"runAsUser": None, "runAsGroup": None, "fsGroup": None}
         ),
     )
 
@@ -88,9 +87,8 @@ async def test_sets_seccompProfile_in_pod_securityContext_by_default(templates):
 async def test_can_nuke_pod_securityContext_seccompProfile(deployables_details, values, make_templates):
     iterate_deployables_workload_parts(
         deployables_details,
-        values,
-        lambda values_fragment, deployable_details: values_fragment.setdefault(
-            "podSecurityContext", {"seccompProfile": None}
+        lambda deployable_details: deployable_details.set_helm_values(
+            values, PropertyType.PodSecurityContext, {"seccompProfile": None}
         ),
     )
 

--- a/tests/manifests/test_postgres.py
+++ b/tests/manifests/test_postgres.py
@@ -7,7 +7,7 @@ import pytest
 
 @pytest.mark.parametrize("values_file", ["synapse-minimal-values.yaml"])
 @pytest.mark.asyncio_cooperative
-async def test_postgres_env_overrides(values, deployables_details, make_templates):
+async def test_postgres_env_overrides(values, make_templates):
     for template in await make_templates(values):
         if "postgres" in template["metadata"]["name"] and template["kind"] == "StatefulSet":
             env = {e["name"]: e["value"] for e in template["spec"]["template"]["spec"]["containers"][0]["env"]}

--- a/tests/manifests/test_synapse.py
+++ b/tests/manifests/test_synapse.py
@@ -101,7 +101,7 @@ async def test_max_upload_size_annotation_component_ingressType(values, deployab
 
 @pytest.mark.parametrize("values_file", ["synapse-minimal-values.yaml"])
 @pytest.mark.asyncio_cooperative
-async def test_log_level_overrides(values, deployables_details, make_templates):
+async def test_log_level_overrides(values, make_templates):
     for template in await make_templates(values):
         if (
             template["kind"] == "ConfigMap"

--- a/tests/manifests/test_synapse.py
+++ b/tests/manifests/test_synapse.py
@@ -2,12 +2,11 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-from typing import Any
 
 import pytest
 import yaml
 
-from . import DeployableDetails
+from . import DeployableDetails, PropertyType
 from .utils import iterate_deployables_ingress_parts
 
 
@@ -86,14 +85,14 @@ async def test_max_upload_size_annotation_global_ingressType(values, make_templa
 @pytest.mark.parametrize("values_file", ["synapse-minimal-values.yaml"])
 @pytest.mark.asyncio_cooperative
 async def test_max_upload_size_annotation_component_ingressType(values, deployables_details, make_templates):
-    def set_ingress_type(values_fragment: dict[str, Any], deployable_details: DeployableDetails):
-        values_fragment.setdefault("ingress", {})["controllerType"] = "ingress-nginx"
+    def set_ingress_type(deployable_details: DeployableDetails):
+        deployable_details.set_helm_values(values, PropertyType.Ingress, {"controllerType": "ingress-nginx"})
 
     for template in await make_templates(values):
         if template["kind"] == "Ingress":
             assert "nginx.ingress.kubernetes.io/proxy-body-size" not in template["metadata"].get("annotations", {})
 
-    iterate_deployables_ingress_parts(deployables_details, values, set_ingress_type)
+    iterate_deployables_ingress_parts(deployables_details, set_ingress_type)
 
     for template in await make_templates(values):
         if template["kind"] == "Ingress":

--- a/tests/manifests/test_tolerations.py
+++ b/tests/manifests/test_tolerations.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from . import values_files_to_test
+from . import PropertyType, values_files_to_test
 from .utils import iterate_deployables_workload_parts
 
 specific_toleration = {
@@ -39,9 +39,8 @@ async def test_no_tolerations_by_default(templates):
 async def test_all_components_and_sub_components_render_tolerations(deployables_details, values, make_templates):
     iterate_deployables_workload_parts(
         deployables_details,
-        values,
-        lambda values_fragment, deployable_details: values_fragment.setdefault("tolerations", []).append(
-            specific_toleration
+        lambda deployable_details: deployable_details.set_helm_values(
+            values, PropertyType.Tolerations, [specific_toleration]
         ),
     )
 
@@ -75,9 +74,8 @@ async def test_global_tolerations_render(values, make_templates):
 async def test_merges_global_and_specific_tolerations(deployables_details, values, make_templates):
     iterate_deployables_workload_parts(
         deployables_details,
-        values,
-        lambda values_fragment, deployable_details: values_fragment.setdefault("tolerations", []).append(
-            specific_toleration
+        lambda deployable_details: deployable_details.set_helm_values(
+            values, PropertyType.Tolerations, [specific_toleration]
         ),
     )
 

--- a/tests/manifests/test_well_known_delegation.py
+++ b/tests/manifests/test_well_known_delegation.py
@@ -4,11 +4,10 @@
 
 import json
 import re
-from typing import Any
 
 import pytest
 
-from . import DeployableDetails
+from . import DeployableDetails, PropertyType
 from .utils import iterate_deployables_ingress_parts
 
 msc_2965_authentication = {
@@ -166,8 +165,8 @@ async def test_dot_path_global_ingressType(values, make_templates):
 @pytest.mark.parametrize("values_file", ["well-known-minimal-values.yaml"])
 @pytest.mark.asyncio_cooperative
 async def test_dot_path_component_ingressType(deployables_details, values, make_templates):
-    def set_ingress_type(values_fragment: dict[str, Any], deployable_details: DeployableDetails):
-        values_fragment.setdefault("ingress", {})["controllerType"] = "ingress-nginx"
+    def set_ingress_type(deployable_details: DeployableDetails):
+        deployable_details.set_helm_values(values, PropertyType.Ingress, {"controllerType": "ingress-nginx"})
 
     for template in await make_templates(values):
         if template["kind"] == "Ingress":
@@ -175,7 +174,7 @@ async def test_dot_path_component_ingressType(deployables_details, values, make_
                 if path["path"].startswith("/.well-known"):
                     assert path["pathType"] == "Prefix"
 
-    iterate_deployables_ingress_parts(deployables_details, values, set_ingress_type)
+    iterate_deployables_ingress_parts(deployables_details, set_ingress_type)
 
     for template in await make_templates(values):
         if template["kind"] == "Ingress":

--- a/tests/manifests/utils.py
+++ b/tests/manifests/utils.py
@@ -217,58 +217,41 @@ def make_templates(chart: pyhelm3.Chart, release_name: str):
 
 def iterate_deployables_parts(
     deployables_details: tuple[DeployableDetails],
-    values: dict[str, Any],
-    visitor: Callable[[dict[str, Any], DeployableDetails], None],
+    visitor: Callable[[DeployableDetails], None],
     if_condition: Callable[[DeployableDetails], bool],
-    ignore_uses_parent_properties: bool = False,
 ):
     for deployable_details in deployables_details:
-        if deployable_details.should_visit_with_values(if_condition, ignore_uses_parent_properties):
-            visitor(deployable_details.get_helm_values_fragment(values), deployable_details)
+        if if_condition(deployable_details):
+            visitor(deployable_details)
 
 
 def iterate_deployables_workload_parts(
     deployables_details: tuple[DeployableDetails],
-    values: dict[str, Any],
-    visitor: Callable[[dict[str, Any], DeployableDetails], None],
-    ignore_uses_parent_properties: bool = False,
+    visitor: Callable[[DeployableDetails], None],
 ):
-    iterate_deployables_parts(
-        deployables_details,
-        values,
-        visitor,
-        lambda deployable_details: deployable_details.has_workloads,
-        ignore_uses_parent_properties,
-    )
+    iterate_deployables_parts(deployables_details, visitor, lambda deployable_details: deployable_details.has_workloads)
 
 
 def iterate_deployables_image_parts(
     deployables_details: tuple[DeployableDetails],
-    values: dict[str, Any],
-    visitor: Callable[[dict[str, Any], DeployableDetails], None],
+    visitor: Callable[[DeployableDetails], None],
 ):
-    iterate_deployables_parts(
-        deployables_details, values, visitor, lambda deployable_details: deployable_details.has_image
-    )
+    iterate_deployables_parts(deployables_details, visitor, lambda deployable_details: deployable_details.has_image)
 
 
 def iterate_deployables_ingress_parts(
     deployables_details: tuple[DeployableDetails],
-    values: dict[str, Any],
-    visitor: Callable[[dict[str, Any], DeployableDetails], None],
+    visitor: Callable[[DeployableDetails], None],
 ):
-    iterate_deployables_parts(
-        deployables_details, values, visitor, lambda deployable_details: deployable_details.has_ingress
-    )
+    iterate_deployables_parts(deployables_details, visitor, lambda deployable_details: deployable_details.has_ingress)
 
 
 def iterate_deployables_service_monitor_parts(
     deployables_details: tuple[DeployableDetails],
-    values: dict[str, Any],
-    visitor: Callable[[dict[str, Any], DeployableDetails], None],
+    visitor: Callable[[DeployableDetails], None],
 ):
     iterate_deployables_parts(
-        deployables_details, values, visitor, lambda deployable_details: deployable_details.has_service_monitor
+        deployables_details, visitor, lambda deployable_details: deployable_details.has_service_monitor
     )
 
 


### PR DESCRIPTION
We want to be able to test properties about sidecars after varying their properties. This means that they need to be sub-classes of `DeployableDetails` so that the various `iterate_deployables_(foo_)?parts` methods can work on them. We also have situations where sub-component or sidecar has e.g. env/images but they aren't controllable through its own properties (the check config hook having properties from Synapse) or might not be in quite the expected place. Given a `iterate_deployables_(foo_)?parts` visitor can & does modify multiple different properties (e.g. `serviceMonitors` and `labels`), we can't push that logic down into every test, so we have to unify the setting of properties inside `DeployableDetails`.

We can use the same mechanism to get rid of the awkward `uses_parent_properties` + `ignore_uses_parent_properties` - a deployable can say that it doesn't support setting a specific property now.