### PR TITLE
Support extraEnv on every workload

### DIFF
--- a/charts/matrix-stack/source/haproxy.json
+++ b/charts/matrix-stack/source/haproxy.json
@@ -16,6 +16,9 @@
     "annotations": {
       "$ref": "file://common/workloadAnnotations.json"
     },
+    "extraEnv": {
+      "$ref": "file://common/extraEnv.json"
+    },
     "containersSecurityContext": {
       "$ref": "file://common/containersSecurityContext.json"
     },

--- a/charts/matrix-stack/source/init-secrets.json
+++ b/charts/matrix-stack/source/init-secrets.json
@@ -20,6 +20,9 @@
     "annotations": {
       "$ref": "file://common/workloadAnnotations.json"
     },
+    "extraEnv": {
+      "$ref": "file://common/extraEnv.json"
+    },
     "containersSecurityContext": {
       "$ref": "file://common/containersSecurityContext.json"
     },

--- a/charts/matrix-stack/source/postgres.json
+++ b/charts/matrix-stack/source/postgres.json
@@ -9,14 +9,14 @@
     "image": {
       "$ref": "file://common/image.json"
     },
-    "extraEnv": {
-      "$ref": "file://common/extraEnv.json"
-    },
     "postgresExporter": {
       "type": "object",
       "properties": {
         "image": {
           "$ref": "file://common/image.json"
+        },
+        "extraEnv": {
+          "$ref": "file://common/extraEnv.json"
         },
         "containersSecurityContext": {
           "$ref": "file://common/containersSecurityContext.json"
@@ -48,6 +48,9 @@
     },
     "annotations": {
       "$ref": "file://common/workloadAnnotations.json"
+    },
+    "extraEnv": {
+      "$ref": "file://common/extraEnv.json"
     },
     "containersSecurityContext": {
       "$ref": "file://common/containersSecurityContext.json"

--- a/charts/matrix-stack/source/synapse.json
+++ b/charts/matrix-stack/source/synapse.json
@@ -249,6 +249,9 @@
         "annotations": {
           "$ref": "file://common/workloadAnnotations.json"
         },
+        "extraEnv": {
+          "$ref": "file://common/extraEnv.json"
+        },
         "containersSecurityContext": {
           "$ref": "file://common/containersSecurityContext.json"
         },

--- a/charts/matrix-stack/templates/haproxy/deployment.yaml
+++ b/charts/matrix-stack/templates/haproxy/deployment.yaml
@@ -85,6 +85,10 @@ spec:
         securityContext:
           {{- toYaml . | nindent 10 }}
 {{- end }}
+{{- with .extraEnv }}
+        env:
+          {{- toYaml . | nindent 10 }}
+{{- end }}
         ports:
 {{- if $.Values.synapse.enabled }}
         - containerPort: 8008

--- a/charts/matrix-stack/templates/init-secrets/_helpers.tpl
+++ b/charts/matrix-stack/templates/init-secrets/_helpers.tpl
@@ -84,3 +84,20 @@ app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" $
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{- define "element-io.init-secrets.env" }}
+{{- $root := .root -}}
+{{- with required "element-io.init-secrets.env missing context" .context -}}
+{{- $resultEnv := dict -}}
+{{- range $envEntry := .extraEnv -}}
+{{- $_ := set $resultEnv $envEntry.name $envEntry.value -}}
+{{- end -}}
+{{- $overrideEnv := dict "NAMESPACE" $root.Release.Namespace
+-}}
+{{- $resultEnv := mustMergeOverwrite $resultEnv $overrideEnv -}}
+{{- range $key, $value := $resultEnv }}
+- name: {{ $key | quote }}
+  value: {{ $value | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/matrix-stack/templates/init-secrets/job.yaml
+++ b/charts/matrix-stack/templates/init-secrets/job.yaml
@@ -58,8 +58,7 @@ spec:
           {{- toYaml . | nindent 10 }}
 {{- end }}
         env:
-        - name: NAMESPACE
-          value: {{ $.Release.Namespace }}
+        {{- include "element-io.init-secrets.env" (dict "root" $ "context" .) | nindent 8 }}
         command:
         - "/matrix-tools"
         - "generate-secrets"

--- a/charts/matrix-stack/templates/postgres/_helpers.tpl
+++ b/charts/matrix-stack/templates/postgres/_helpers.tpl
@@ -122,6 +122,24 @@ true
 {{- end -}}
 {{- end -}}
 
+{{- define "element-io.postgres.exporter-env" }}
+{{- $root := .root -}}
+{{- with required "element-io.postgres.exporter-env missing context" .context -}}
+{{- $resultEnv := dict -}}
+{{- range $envEntry := .extraEnv -}}
+{{- $_ := set $resultEnv $envEntry.name $envEntry.value -}}
+{{- end -}}
+{{- $overrideEnv := dict "DATA_SOURCE_URI" "localhost?sslmode=disable"
+                         "DATA_SOURCE_USER" "postgres"
+-}}
+{{- $resultEnv := mustMergeOverwrite $resultEnv $overrideEnv -}}
+{{- range $key, $value := $resultEnv }}
+- name: {{ $key | quote }}
+  value: {{ $value | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 
 {{- define "element-io.postgres.configmap-data" -}}
 {{- $root := .root -}}

--- a/charts/matrix-stack/templates/postgres/statefulset.yaml
+++ b/charts/matrix-stack/templates/postgres/statefulset.yaml
@@ -191,10 +191,7 @@ spec:
         - name: metrics
           containerPort: 9187
         env:
-        - name: DATA_SOURCE_URI
-          value: "localhost?sslmode=disable"
-        - name: DATA_SOURCE_USER
-          value: "postgres"
+        {{- include "element-io.postgres.exporter-env" (dict "root" $ "context" .) | nindent 8 }}
         startupProbe:
           httpGet:
             path: /metrics

--- a/charts/matrix-stack/templates/synapse/redis_deployment.yaml
+++ b/charts/matrix-stack/templates/synapse/redis_deployment.yaml
@@ -58,6 +58,10 @@ spec:
         securityContext:
           {{- toYaml . | nindent 10 }}
 {{- end }}
+{{- with .extraEnv }}
+        env:
+          {{- toYaml . | nindent 10 }}
+{{- end }}
         ports:
         - containerPort: 6379
           name: redis

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -298,6 +298,25 @@
             "type": "string"
           }
         },
+        "extraEnv": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
         "containersSecurityContext": {
           "properties": {
             "allowPrivilegeEscalation": {
@@ -1961,6 +1980,25 @@
             "type": "string"
           }
         },
+        "extraEnv": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
         "containersSecurityContext": {
           "properties": {
             "allowPrivilegeEscalation": {
@@ -2986,25 +3024,6 @@
           },
           "additionalProperties": false
         },
-        "extraEnv": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "value"
-            ],
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "value": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        },
         "postgresExporter": {
           "type": "object",
           "properties": {
@@ -3048,6 +3067,25 @@
                 }
               },
               "additionalProperties": false
+            },
+            "extraEnv": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
             },
             "containersSecurityContext": {
               "properties": {
@@ -3219,6 +3257,25 @@
           "type": "object",
           "additionalProperties": {
             "type": "string"
+          }
+        },
+        "extraEnv": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
           }
         },
         "containersSecurityContext": {
@@ -6372,6 +6429,25 @@
               "type": "object",
               "additionalProperties": {
                 "type": "string"
+              }
+            },
+            "extraEnv": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
               }
             },
             "containersSecurityContext": {

--- a/newsfragments/421.changed.md
+++ b/newsfragments/421.changed.md
@@ -1,0 +1,1 @@
+Add extraEnv support to HAProxy, Synapse Redis, Postgres Exporter and Init Secrets so that all components support it.

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -65,7 +65,6 @@ class DeployableDetails(abc.ABC):
 
     has_db: bool = field(default=False, hash=False)
     has_image: bool = field(default=None, hash=False)  # type: ignore[assignment]
-    has_extra_env: bool = field(default=None, hash=False)  # type: ignore[assignment]
     has_ingress: bool = field(default=True, hash=False)
     has_workloads: bool = field(default=True, hash=False)
     has_service_monitor: bool = field(default=None, hash=False)  # type: ignore[assignment]
@@ -80,8 +79,6 @@ class DeployableDetails(abc.ABC):
             self.helm_keys = (self.name,)
         if self.has_image is None:
             self.has_image = self.has_workloads
-        if self.has_extra_env is None:
-            self.has_extra_env = self.has_workloads
         if self.has_service_monitor is None:
             self.has_service_monitor = self.has_workloads
         if self.has_topology_spread_constraints is None:
@@ -275,7 +272,6 @@ all_components_details = [
         helm_keys=("initSecrets",),
         has_image=False,
         has_ingress=False,
-        has_extra_env=False,
         has_service_monitor=False,
         has_topology_spread_constraints=False,
         is_shared_component=True,
@@ -283,14 +279,12 @@ all_components_details = [
     ComponentDetails(
         name="haproxy",
         has_ingress=False,
-        has_extra_env=False,
         is_shared_component=True,
         skip_path_consistency_for_files=("haproxy.cfg", "429.http", "path_map_file", "path_map_file_get"),
     ),
     ComponentDetails(
         name="postgres",
         has_ingress=False,
-        has_extra_env=False,
         has_storage=True,
         sidecars=(
             SidecarDetails(
@@ -300,7 +294,6 @@ all_components_details = [
                     # No manifests of its own, so no labels to set
                     PropertyType.Labels: None,
                 },
-                has_extra_env=False,
                 has_ingress=False,
                 has_service_monitor=False,
             ),
@@ -359,7 +352,6 @@ all_components_details = [
                 name="synapse-redis",
                 helm_keys=("synapse", "redis"),
                 has_ingress=False,
-                has_extra_env=False,
                 has_service_monitor=False,
                 has_topology_spread_constraints=False,
             ),
@@ -367,7 +359,7 @@ all_components_details = [
                 name="synapse-check-config-hook",
                 helm_keys=("synapse", "checkConfigHook"),
                 helm_keys_overrides={
-                    # has_extra_env but comes from synapse.extraEnv
+                    # has_workloads but comes from synapse.extraEnv
                     PropertyType.Env: None,
                     # has_workloads and so comes from synapse.image
                     PropertyType.Image: None,
@@ -375,7 +367,8 @@ all_components_details = [
                     PropertyType.PodSecurityContext: None,
                     # has_workloads and so tolerations but comes from synapse.tolerations
                     PropertyType.Tolerations: None,
-                    # has_workloads and so topologySpreadConstraints but comes from synapse.topologySpreadConstraints
+                    # has_topology_spread_constraints and so topologySpreadConstraints
+                    # but comes from synapse.topologySpreadConstraints
                     PropertyType.TopologySpreadConstraints: None,
                 },
                 has_ingress=False,

--- a/tests/manifests/test_pod_env.py
+++ b/tests/manifests/test_pod_env.py
@@ -5,34 +5,34 @@
 import pytest
 
 from . import DeployableDetails, PropertyType, values_files_to_test
-from .utils import iterate_deployables_parts
+from .utils import iterate_deployables_workload_parts, template_id
 
 extra_env = {"a_string": "a", "b_boolean": True, "c_integer": 1, "d_float": 1.1}
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_unique_env_name_in_containers(
-    deployables_details, values, make_templates, template_to_deployable_details
-):
+async def test_unique_env_name_in_containers(deployables_details, values, make_templates):
     def set_extra_env(deployable_details: DeployableDetails):
         deployable_details.set_helm_values(
             values, PropertyType.Env, [{"name": k, "value": str(v)} for k, v in extra_env.items()]
         )
 
-    iterate_deployables_parts(
-        deployables_details, set_extra_env, lambda deployable_details: deployable_details.has_extra_env
-    )
+    iterate_deployables_workload_parts(deployables_details, set_extra_env)
 
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "Job", "StatefulSet"]:
-            id = f"{template['kind']}/{template['metadata']['name']}"
             for container in template["spec"]["template"]["spec"]["containers"]:
                 env_keys = [env["name"] for env in container.get("env", [])]
-                assert len(env_keys) == len(set(env_keys)), f"Env keys are not unique: {id}, {env_keys}"
-                if template_to_deployable_details(template).has_extra_env:
-                    for key in extra_env:
-                        assert key in env_keys
+                assert len(env_keys) == len(set(env_keys)), (
+                    f"{template_id(template)} has container {container['name']} "
+                    "with env keys are not unique: {env_keys}"
+                )
+                for key in extra_env:
+                    assert key in env_keys, (
+                        f"{template_id(template)} has container {container['name']} "
+                        "that is missing some of the extra env that's being injected"
+                    )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -43,15 +43,13 @@ async def test_env_values_are_strings_in_containers(deployables_details, values,
             values, PropertyType.Env, [{"name": k, "value": str(v)} for k, v in extra_env.items()]
         )
 
-    iterate_deployables_parts(
-        deployables_details, set_extra_env, lambda deployable_details: deployable_details.has_extra_env
-    )
+    iterate_deployables_workload_parts(deployables_details, set_extra_env)
 
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "Job", "StatefulSet"]:
-            id = f"{template['kind']}/{template['metadata']['name']}"
             for container in template["spec"]["template"]["spec"]["containers"]:
                 for env in container.get("env", []):
                     assert type(env["value"]) is str, (
-                        f"{id} has container {container['name']} which has an non-string value: {env}"
+                        f"{template_id(template)} has container {container['name']} "
+                        "which has an non-string value: {env}"
                     )


### PR DESCRIPTION
We don't gain much from disallowing `extraEnv` on specific components, it just complicates our tests. Support it on all components so that we can test it on all components