### PR TITLE
Replace initialDelaySeconds with startup probes

### DIFF
--- a/charts/matrix-stack/source/element-web.yaml.j2
+++ b/charts/matrix-stack/source/element-web.yaml.j2
@@ -32,4 +32,4 @@ replicas: 1
 {{- sub_schema_values.topologySpreadConstraints() }}
 {{- sub_schema_values.probe("liveness") }}
 {{- sub_schema_values.probe("readiness", periodSeconds=3) }}
-{{- sub_schema_values.probe("startup", initialDelaySeconds=2, periodSeconds=3) }}
+{{- sub_schema_values.probe("startup", failureThreshold=4, periodSeconds=3) }}

--- a/charts/matrix-stack/source/haproxy.yaml.j2
+++ b/charts/matrix-stack/source/haproxy.yaml.j2
@@ -18,8 +18,8 @@ replicas: 1
 {{- sub_schema_values.serviceMonitors() }}
 {{- sub_schema_values.tolerations() }}
 {{- sub_schema_values.topologySpreadConstraints() }}
-{{- sub_schema_values.probe("liveness", initialDelaySeconds=10, timeoutSeconds=5) }}
-{{- sub_schema_values.probe("readiness", initialDelaySeconds=20, timeoutSeconds=5) }}
+{{- sub_schema_values.probe("liveness", timeoutSeconds=5) }}
+{{- sub_schema_values.probe("readiness", timeoutSeconds=5) }}
 # The failureThreshold here is tweaked towards Synapse being ready
 # If Synapse isn't being deployed, unsetting this or setting it to 3 maybe more appropriate
 {{- sub_schema_values.probe("startup", failureThreshold=150, periodSeconds=2) }}

--- a/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
+++ b/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
@@ -44,4 +44,4 @@ privateKeys:
 {{ sub_schema_values.extraEnv() }}
 {{ sub_schema_values.probe("liveness") }}
 {{ sub_schema_values.probe("readiness") }}
-{{ sub_schema_values.probe("startup", initialDelaySeconds=5) }}
+{{ sub_schema_values.probe("startup", failureThreshold=4) }}

--- a/charts/matrix-stack/source/postgres.yaml.j2
+++ b/charts/matrix-stack/source/postgres.yaml.j2
@@ -1,5 +1,5 @@
 {#
-Copyright 2024 New Vector Ltd
+Copyright 2024-2025 New Vector Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 #}
@@ -32,6 +32,6 @@ essPasswords:
 {{- sub_schema_values.serviceMonitors() }}
 {{- sub_schema_values.tolerations() }}
 {{- sub_schema_values.topologySpreadConstraints() }}
-{{- sub_schema_values.probe("liveness", initialDelaySeconds=45, timeoutSeconds=2) }}
-{{- sub_schema_values.probe("readiness", initialDelaySeconds=15, timeoutSeconds=2) }}
-{{- sub_schema_values.probe("startup") }}
+{{- sub_schema_values.probe("liveness", timeoutSeconds=2) }}
+{{- sub_schema_values.probe("readiness", timeoutSeconds=2) }}
+{{- sub_schema_values.probe("startup", failureThreshold=8) }}

--- a/charts/matrix-stack/source/synapse.yaml.j2
+++ b/charts/matrix-stack/source/synapse.yaml.j2
@@ -1,5 +1,5 @@
 {#
-Copyright 2024 New Vector Ltd
+Copyright 2024-2025 New Vector Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 #}
@@ -113,6 +113,6 @@ redis:
 {{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='50Mi') | indent(2) }}
 {{- sub_schema_values.serviceAccount() | indent(2) }}
 {{- sub_schema_values.tolerations() | indent(2) }}
-{{- sub_schema_values.probe("liveness", initialDelaySeconds=15) | indent(2) }}
-{{- sub_schema_values.probe("readiness", initialDelaySeconds=5) | indent(2) }}
-{{- sub_schema_values.probe("startup") | indent(2) }}
+{{- sub_schema_values.probe("liveness") | indent(2) }}
+{{- sub_schema_values.probe("readiness") | indent(2) }}
+{{- sub_schema_values.probe("startup", failureThreshold=5) | indent(2) }}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -1919,7 +1919,7 @@ postgres:
     failureThreshold: 3
 
     ## Number of seconds after the container has started before the probe starts
-    initialDelaySeconds: 45
+    initialDelaySeconds: 0
 
     ## How often (in seconds) to perform the probe
     periodSeconds: 10
@@ -1935,7 +1935,7 @@ postgres:
     failureThreshold: 3
 
     ## Number of seconds after the container has started before the probe starts
-    initialDelaySeconds: 15
+    initialDelaySeconds: 0
 
     ## How often (in seconds) to perform the probe
     periodSeconds: 10
@@ -1948,7 +1948,7 @@ postgres:
   ## Configuration of the thresholds and frequencies of the startupProbe
   startupProbe:
     ## How many consecutive failures for the probe to be considered failed
-    failureThreshold: 3
+    failureThreshold: 8
 
     ## Number of seconds after the container has started before the probe starts
     initialDelaySeconds: 0

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -964,10 +964,10 @@ elementWeb:
   ## Configuration of the thresholds and frequencies of the startupProbe
   startupProbe:
     ## How many consecutive failures for the probe to be considered failed
-    failureThreshold: 3
+    failureThreshold: 4
 
     ## Number of seconds after the container has started before the probe starts
-    initialDelaySeconds: 2
+    initialDelaySeconds: 0
 
     ## How often (in seconds) to perform the probe
     periodSeconds: 3

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -3644,7 +3644,7 @@ synapse:
       failureThreshold: 3
 
       ## Number of seconds after the container has started before the probe starts
-      initialDelaySeconds: 15
+      initialDelaySeconds: 0
 
       ## How often (in seconds) to perform the probe
       periodSeconds: 10
@@ -3660,7 +3660,7 @@ synapse:
       failureThreshold: 3
 
       ## Number of seconds after the container has started before the probe starts
-      initialDelaySeconds: 5
+      initialDelaySeconds: 0
 
       ## How often (in seconds) to perform the probe
       periodSeconds: 10
@@ -3673,7 +3673,7 @@ synapse:
     ## Configuration of the thresholds and frequencies of the startupProbe
     startupProbe:
       ## How many consecutive failures for the probe to be considered failed
-      failureThreshold: 3
+      failureThreshold: 5
 
       ## Number of seconds after the container has started before the probe starts
       initialDelaySeconds: 0

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -1569,10 +1569,10 @@ matrixAuthenticationService:
   ## Configuration of the thresholds and frequencies of the startupProbe
   startupProbe:
     ## How many consecutive failures for the probe to be considered failed
-    failureThreshold: 3
+    failureThreshold: 4
 
     ## Number of seconds after the container has started before the probe starts
-    initialDelaySeconds: 5
+    initialDelaySeconds: 0
 
     ## How often (in seconds) to perform the probe
     periodSeconds: 10

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -1144,7 +1144,7 @@ haproxy:
     failureThreshold: 3
 
     ## Number of seconds after the container has started before the probe starts
-    initialDelaySeconds: 10
+    initialDelaySeconds: 0
 
     ## How often (in seconds) to perform the probe
     periodSeconds: 10
@@ -1160,7 +1160,7 @@ haproxy:
     failureThreshold: 3
 
     ## Number of seconds after the container has started before the probe starts
-    initialDelaySeconds: 20
+    initialDelaySeconds: 0
 
     ## How often (in seconds) to perform the probe
     periodSeconds: 10

--- a/newsfragments/434.changed.md
+++ b/newsfragments/434.changed.md
@@ -1,0 +1,1 @@
+Replace the use of initialDelaySeconds in default probes with adjustments to the startupProbes.

--- a/tests/manifests/test_pod_probes.py
+++ b/tests/manifests/test_pod_probes.py
@@ -63,6 +63,12 @@ def assert_sensible_default_probe(template, probe_type):
             f"{template_id(template)} has container {container['name']} with a {probe_type} missing a timeoutSeconds"
         )
 
+        # We use startupProbes for this
+        assert "initialDelaySeconds" not in probe, (
+            f"{template_id(template)} has container {container['name']} with {probe_type}.initialDelaySeconds set "
+            "when we should be using a startupProbe"
+        )
+
         assert "httpGet" in probe or "exec" in probe or "tcpSocket" in probe
         if "httpGet" in probe:
             assert "port" in probe["httpGet"], (


### PR DESCRIPTION
The `startupProbe` proves more flexibility than `{liveness,readiness}Probe.initialDelaySeconds` does. We're not stopping people setting it but let's not set it by default