### PR TITLE
HAProxy startupProbe and named ports

### DIFF
--- a/charts/matrix-stack/templates/haproxy/deployment.yaml
+++ b/charts/matrix-stack/templates/haproxy/deployment.yaml
@@ -111,14 +111,17 @@ spec:
           name: synapse-ready
           protocol: TCP
 {{- end }}
-{{- if $.Values.synapse.enabled }}
         startupProbe:
           httpGet:
+{{- if $.Values.synapse.enabled }}
             path: /synapse_ready
             port: synapse-ready
+{{- else }}
+            path: /haproxy_test
+            port: haproxy-metrics
+{{- end }}
           periodSeconds: 2
           failureThreshold: 150
-{{- end }}
         livenessProbe:
           httpGet:
             path: /haproxy_test

--- a/charts/matrix-stack/templates/haproxy/deployment.yaml
+++ b/charts/matrix-stack/templates/haproxy/deployment.yaml
@@ -115,20 +115,20 @@ spec:
         startupProbe:
           httpGet:
             path: /synapse_ready
-            port: 8406
+            port: synapse-ready
           periodSeconds: 2
           failureThreshold: 150
 {{- end }}
         livenessProbe:
           httpGet:
             path: /haproxy_test
-            port: 8405
+            port: haproxy-metrics
           initialDelaySeconds: 10
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
             path: /haproxy_test
-            port: 8405
+            port: haproxy-metrics
           initialDelaySeconds: 20
           timeoutSeconds: 5
 {{- with .resources }}

--- a/newsfragments/437.changed.md
+++ b/newsfragments/437.changed.md
@@ -1,0 +1,1 @@
+Ensure HAProxy has a startupProbe when Synapse isn't enabled.


### PR DESCRIPTION
We always want a `startupProbe` for HAProxy. We also always want to use named ports (so that changing the port number doesn't cause breakages in the probes.

The `periodSeconds` and `failureThreshold` are going to be extreme with no Synapse but this is a problem after #430 that we push onto users.

Doing as a separate PR to minimise `dyff` & increase reviewability