### PR TITLE
Correctly merge Synapse per-process values that override shared values

### DIFF
--- a/charts/matrix-stack/templates/synapse/synapse_statefulset.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_statefulset.yaml
@@ -8,8 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- if .enabled -}}
 {{- $enabledWorkers := (include "element-io.synapse.enabledWorkers" (dict "root" $)) | fromJson }}
 {{- range $processType, $unmergedProcessDetails := mustMergeOverwrite (dict "main" dict) $enabledWorkers }}
-{{- $perProcessRoot := mustMergeOverwrite ($.Values.synapse | deepCopy) (dict "processType" $processType "isHook" false) }}
-{{- with (mustMergeOverwrite ($.Values.synapse | deepCopy) ($unmergedProcessDetails | deepCopy) dict) }}
+{{- with (mustMergeOverwrite ($.Values.synapse | deepCopy) ($unmergedProcessDetails | deepCopy) (dict "processType" $processType "isHook" false)) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -18,9 +17,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   labels:
-    {{- include "element-io.synapse.process.labels" (dict "root" $ "context" $perProcessRoot) | nindent 4 }}
-    k8s.element.io/synapse-config-hash: "{{ include "element-io.synapse.configmap-data"  (dict "root" $ "context" $perProcessRoot) | sha1sum }}"
-    k8s.element.io/synapse-secret-hash: "{{ include "element-io.synapse.secret-data"  (dict "root" $ "context" $perProcessRoot) | sha1sum }}"
+    {{- include "element-io.synapse.process.labels" (dict "root" $ "context" .) | nindent 4 }}
+    k8s.element.io/synapse-config-hash: "{{ include "element-io.synapse.configmap-data"  (dict "root" $ "context" .) | sha1sum }}"
+    k8s.element.io/synapse-secret-hash: "{{ include "element-io.synapse.secret-data"  (dict "root" $ "context" .) | sha1sum }}"
 {{- range $index, $appservice := .appservices }}
 {{- if .configMap }}
     k8s.element.io/as-registration-{{ $index }}-hash: "{{ (lookup "v1" "ConfigMap" $.Release.Namespace (tpl $appservice.configMap $)) | toJson | sha1sum }}"
@@ -45,7 +44,7 @@ spec:
     type: RollingUpdate
   # Without this CrashLoopBackoffs due to config failures block pod recreation
   podManagementPolicy: Parallel
-  {{- include "element-io.synapse.pod-template" (dict "root" $ "context" $perProcessRoot) | nindent 2 }}
+  {{- include "element-io.synapse.pod-template" (dict "root" $ "context" .) | nindent 2 }}
 ---
 {{- end }}
 {{- end }}

--- a/newsfragments/438.fixed.md
+++ b/newsfragments/438.fixed.md
@@ -1,0 +1,1 @@
+Fix Synapse per-worker resource overrides not being respected.

--- a/tests/manifests/utils.py
+++ b/tests/manifests/utils.py
@@ -70,6 +70,26 @@ def values(values_file) -> dict[str, Any]:
 
 
 @pytest.fixture
+def all_values(values, base_values) -> dict[str, Any]:
+    def merge(a: dict, b: dict, path=None):
+        if not path:
+            path = []
+        for key in b:
+            if key in a:
+                if isinstance(a[key], dict) and isinstance(b[key], dict):
+                    merge(a[key], b[key], path + [str(key)])
+                elif type(a[key]) is not type(b[key]):
+                    raise Exception("Conflict at " + ".".join(path + [str(key)]))
+                else:
+                    a[key] = b[key]
+            else:
+                a[key] = b[key]
+        return a
+
+    return merge(copy.deepcopy(base_values), copy.deepcopy(values))
+
+
+@pytest.fixture
 async def templates(chart: pyhelm3.Chart, release_name: str, values: dict[str, Any]):
     return await helm_template(chart, release_name, values)
 
@@ -253,6 +273,24 @@ def iterate_deployables_service_monitor_parts(
     iterate_deployables_parts(
         deployables_details, visitor, lambda deployable_details: deployable_details.has_service_monitor
     )
+
+
+def iterate_synapse_workers_parts(
+    all_values: dict[str, Any],
+    visitor: Callable[[str, dict[str, Any]], None],
+    key_to_check: str | None = None,
+) -> None:
+    if not all_values["synapse"]["enabled"]:
+        return
+
+    if key_to_check is None or key_to_check in all_values["synapse"]:
+        visitor("main", all_values["synapse"])
+
+    for worker_name, worker_values in all_values["synapse"]["workers"].items():
+        if not worker_values["enabled"]:
+            continue
+        if key_to_check is None or key_to_check in worker_values:
+            visitor(worker_name, worker_values)
 
 
 @pytest.fixture


### PR DESCRIPTION
Discovered when looking at #430 that worker probe values weren't overriding "shared" (main process) values. This was because `$perProcessRoot` was being passed into `element-io.synapse.pod-template` which didn't include `synapse.workers.<worker name>` values.

Remove the split variable and simply make the context the full merge between `synapse`, `synapse.workers.<worker name>` and the static `processType` & `isHook` variables.

Add tests to assert this