### PR TITLE
matrix-rtc: rename authorizer to matrix-rtc-authorisation-service

### DIFF
--- a/charts/matrix-stack/configs/matrix-rtc/sfu/config.yaml.tpl
+++ b/charts/matrix-stack/configs/matrix-rtc/sfu/config.yaml.tpl
@@ -37,7 +37,7 @@ key_file: /secrets/{{ (printf "/secrets/%s"
       (include "element-io.ess-library.provided-secret-path" (
         dict "root" $root "context" (
           dict "secretPath" "matrixRTC.livekitAuth.keysYaml"
-              "defaultSecretName" (printf "%s-matrix-rtc-authorizer" $root.Release.Name)
+              "defaultSecretName" (printf "%s-matrix-rtc-authorisation-service" $root.Release.Name)
               "defaultSecretKey" "LIVEKIT_KEYS_YAML"
               )
         ))) }}

--- a/charts/matrix-stack/templates/matrix-rtc/_helpers.tpl
+++ b/charts/matrix-stack/templates/matrix-rtc/_helpers.tpl
@@ -15,13 +15,13 @@ app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .
 {{- end }}
 {{- end }}
 
-{{- define "element-io.matrix-rtc-authorizer.labels" -}}
+{{- define "element-io.matrix-rtc-authorisation-service.labels" -}}
 {{- $root := .root -}}
 {{- with required "element-io.matrix-rtc.labels missing context" .context -}}
 {{ include "element-io.ess-library.labels.common" (dict "root" $root "context" (dict "labels" .labels "withChartVersion" .withChartVersion)) }}
-app.kubernetes.io/component: matrix-rtc-authorizer
-app.kubernetes.io/name: matrix-rtc-authorizer
-app.kubernetes.io/instance: {{ $root.Release.Name }}-matrix-rtc-authorizer
+app.kubernetes.io/component: matrix-rtc-authorisation-service
+app.kubernetes.io/name: matrix-rtc-authorisation-service
+app.kubernetes.io/instance: {{ $root.Release.Name }}-matrix-rtc-authorisation-service
 app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .image.tag }}
 {{- end }}
 {{- end }}
@@ -48,9 +48,9 @@ app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .
 {{- end }}
 {{- end }}
 
-{{- define "element-io.matrix-rtc-authorizer.env" }}
+{{- define "element-io.matrix-rtc-authorisation-service.env" }}
 {{- $root := .root -}}
-{{- with required "element-io.authorizer.env missing context" .context -}}
+{{- with required "element-io.matrix-rtc-authorisation-service.env missing context" .context -}}
 {{- $resultEnv := dict -}}
 {{- range $envEntry := .extraEnv -}}
 {{- $_ := set $resultEnv $envEntry.name $envEntry.value -}}
@@ -60,7 +60,7 @@ app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .
       (include "element-io.ess-library.provided-secret-path" (
         dict "root" $root "context" (
           dict "secretPath" "matrixRTC.livekitAuth.keysYaml"
-              "defaultSecretName" (printf "%s-matrix-rtc-authorizer" $root.Release.Name)
+              "defaultSecretName" (printf "%s-matrix-rtc-authorisation-service" $root.Release.Name)
               "defaultSecretKey" "LIVEKIT_KEYS_YAML"
               )
         ))) }}
@@ -71,7 +71,7 @@ app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .
         dict "root" $root "context" (
           dict "secretPath" "matrixRTC.livekitAuth.secret"
               "initSecretKey" "ELEMENT_CALL_LIVEKIT_SECRET"
-              "defaultSecretName" (printf "%s-matrix-rtc-authorizer" $root.Release.Name)
+              "defaultSecretName" (printf "%s-matrix-rtc-authorisation-service" $root.Release.Name)
               "defaultSecretKey" "LIVEKIT_SECRET"
               )
         ))) }}
@@ -88,7 +88,7 @@ app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .
 
 {{- define "element-io.matrix-rtc-sfu.env" }}
 {{- $root := .root -}}
-{{- with required "element-io.authorizer missing context" .context -}}
+{{- with required "element-io.matrix-rtc-authorisation-service missing context" .context -}}
 {{- $resultEnv := dict -}}
 {{- range $envEntry := .extraEnv -}}
 {{- $_ := set $resultEnv $envEntry.name $envEntry.value -}}
@@ -100,15 +100,15 @@ app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .
 {{- end -}}
 {{- end -}}
 
-{{- define "element-io.matrix-rtc-authorizer.configSecrets" -}}
+{{- define "element-io.matrix-rtc-authorisation-service.configSecrets" -}}
 {{- $root := .root -}}
-{{- with required "element-io.matrix-rtc-authorizer.configSecrets missing context" .context -}}
+{{- with required "element-io.matrix-rtc-authorisation-service.configSecrets missing context" .context -}}
 {{- $configSecrets := list -}}
 {{- if and $root.Values.initSecrets.enabled (include "element-io.init-secrets.generated-secrets" (dict "root" $root)) }}
 {{ $configSecrets = append $configSecrets (printf "%s-generated" $root.Release.Name) }}
 {{- end }}
 {{- if or ((.livekitAuth).keysYaml).value ((.livekitAuth).secret).value -}}
-{{ $configSecrets = append $configSecrets (printf "%s-matrix-rtc-authorizer" $root.Release.Name) }}
+{{ $configSecrets = append $configSecrets (printf "%s-matrix-rtc-authorisation-service" $root.Release.Name) }}
 {{- end -}}
 {{- with ((.livekitAuth).keysYaml).secret -}}
 {{ $configSecrets = append $configSecrets (tpl . $root) }}
@@ -134,9 +134,9 @@ keys-template.yaml: |
 {{- end -}}
 {{- end -}}
 
-{{- define "element-io.matrix-rtc-authorizer.secret-data" -}}
+{{- define "element-io.matrix-rtc-authorisation-service.secret-data" -}}
 {{- $root := .root -}}
-{{- with required "element-io.matrix-rtc-authorizer secret missing context" .context -}}
+{{- with required "element-io.matrix-rtc-authorisation-service secret missing context" .context -}}
 {{- if not .keysYaml }}
   {{- if $root.Values.matrixRTC.sfu.enabled -}}
     {{- include "element-io.ess-library.check-credential" (dict "root" $root "context" (dict "secretPath" "matrixRTC.livekitAuth.secret" "initIfAbsent" true)) }}

--- a/charts/matrix-stack/templates/matrix-rtc/ingress.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/ingress.yaml
@@ -24,7 +24,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: "{{ $.Release.Name }}-matrix-rtc-authorizer"
+            name: "{{ $.Release.Name }}-matrix-rtc-authorisation-service"
             port:
               name: http
 {{ if .sfu.enabled }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
@@ -73,7 +73,7 @@ spec:
                     "context" (dict
                       "secretPath" "matrixRTC.livekitAuth.secret"
                       "initSecretKey" "ELEMENT_CALL_LIVEKIT_SECRET"
-                      "defaultSecretName" (printf "%s-matrix-rtc-authorizer" $.Release.Name)
+                      "defaultSecretName" (printf "%s-matrix-rtc-authorisation-service" $.Release.Name)
                       "defaultSecretKey" "LIVEKIT_SECRET"
                       )
                     )
@@ -98,7 +98,7 @@ spec:
         - mountPath: /conf
           name: rendered-config
           readOnly: false
-{{- range $secret := include "element-io.matrix-rtc-authorizer.configSecrets" (dict "root" $ "context" $.Values.matrixRTC) | fromJsonArray }}
+{{- range $secret := include "element-io.matrix-rtc-authorisation-service.configSecrets" (dict "root" $ "context" $.Values.matrixRTC) | fromJsonArray }}
         - mountPath: /secrets/{{ tpl $secret $ }}
           name: "secret-{{ tpl $secret $ }}"
           readOnly: true
@@ -194,7 +194,7 @@ spec:
           name: plain-config
           subPath: config.yaml
       volumes:
-{{- range $secret := include "element-io.matrix-rtc-authorizer.configSecrets" (dict "root" $ "context" $.Values.matrixRTC) | fromJsonArray }}
+{{- range $secret := include "element-io.matrix-rtc-authorisation-service.configSecrets" (dict "root" $ "context" $.Values.matrixRTC) | fromJsonArray }}
       - secret:
           secretName: {{ tpl $secret $ }}
         name: secret-{{ tpl $secret $ }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_deployment.yaml
@@ -14,15 +14,15 @@ metadata:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   labels:
-    {{- include "element-io.matrix-rtc-authorizer.labels" (dict "root" $ "context" .) | nindent 4 }}
-    k8s.element.io/matrix-rtc-authorizer-secret-hash: {{ include "element-io.matrix-rtc-authorizer.secret-data" (dict "root" $ "context" .) | sha1sum }}
-  name: {{ $.Release.Name }}-matrix-rtc-authorizer
+    {{- include "element-io.matrix-rtc-authorisation-service.labels" (dict "root" $ "context" .) | nindent 4 }}
+    k8s.element.io/matrix-rtc-authorisation-service-secret-hash: {{ include "element-io.matrix-rtc-authorisation-service.secret-data" (dict "root" $ "context" .) | sha1sum }}
+  name: {{ $.Release.Name }}-matrix-rtc-authorisation-service
   namespace: {{ $.Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/instance: {{ $.Release.Name }}-matrix-rtc-authorizer
+      app.kubernetes.io/instance: {{ $.Release.Name }}-matrix-rtc-authorisation-service
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -31,8 +31,8 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "element-io.matrix-rtc-authorizer.labels" (dict "root" $ "context" (dict "image" .image "labels" .labels "withChartVersion" false)) | nindent 8 }}
-        k8s.element.io/matrix-rtc-authorizer-secret-hash: {{ include "element-io.matrix-rtc-authorizer.secret-data" (dict "root" $ "context" .) | sha1sum }}
+        {{- include "element-io.matrix-rtc-authorisation-service.labels" (dict "root" $ "context" (dict "image" .image "labels" .labels "withChartVersion" false)) | nindent 8 }}
+        k8s.element.io/matrix-rtc-authorisation-service-secret-hash: {{ include "element-io.matrix-rtc-authorisation-service.secret-data" (dict "root" $ "context" .) | sha1sum }}
 {{- with .annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
@@ -42,9 +42,9 @@ spec:
       hostAliases:
         {{- tpl (toYaml . | nindent 8) $ }}
 {{- end }}
-{{- include "element-io.ess-library.pods.commonSpec" (dict "root" $ "context" (dict "componentValues" . "instanceSuffix" "matrix-rtc-authorizer" "deployment" true)) | nindent 6 }}
+{{- include "element-io.ess-library.pods.commonSpec" (dict "root" $ "context" (dict "componentValues" . "instanceSuffix" "matrix-rtc-authorisation-service" "deployment" true)) | nindent 6 }}
       containers:
-      - name: authorizer
+      - name: matrix-rtc-authorisation-service
 {{- with .image -}}
 {{- if .digest }}
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
@@ -59,7 +59,7 @@ spec:
           {{- toYaml . | nindent 10 }}
 {{- end }}
         env:
-          {{- include "element-io.matrix-rtc-authorizer.env" (dict "root" $ "context" .) | nindent 8 }}
+          {{- include "element-io.matrix-rtc-authorisation-service.env" (dict "root" $ "context" .) | nindent 8 }}
         ports:
         - containerPort: 8080
           name: http
@@ -81,13 +81,13 @@ spec:
           {{- toYaml . | nindent 10 }}
 {{- end }}
         volumeMounts:
-{{- range $secret := include "element-io.matrix-rtc-authorizer.configSecrets" (dict "root" $ "context" $.Values.matrixRTC) | fromJsonArray }}
+{{- range $secret := include "element-io.matrix-rtc-authorisation-service.configSecrets" (dict "root" $ "context" $.Values.matrixRTC) | fromJsonArray }}
         - mountPath: /secrets/{{ tpl $secret $ }}
           name: "secret-{{ tpl $secret $ }}"
           readOnly: true
 {{- end }}
       volumes:
-{{- range $secret := include "element-io.matrix-rtc-authorizer.configSecrets" (dict "root" $ "context" $.Values.matrixRTC) | fromJsonArray }}
+{{- range $secret := include "element-io.matrix-rtc-authorisation-service.configSecrets" (dict "root" $ "context" $.Values.matrixRTC) | fromJsonArray }}
       - secret:
           secretName: {{ tpl $secret $ }}
         name: secret-{{ tpl $secret $ }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_secret.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_secret.yaml
@@ -9,12 +9,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $.Release.Name }}-matrix-rtc-authorizer
+  name: {{ $.Release.Name }}-matrix-rtc-authorisation-service
   namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "element-io.matrix-rtc-authorizer.labels" (dict "root" $ "context" .) | nindent 4 }}
+    {{- include "element-io.matrix-rtc-authorisation-service.labels" (dict "root" $ "context" .) | nindent 4 }}
 type: Opaque
 data:
-  {{- include "element-io.matrix-rtc-authorizer.secret-data" (dict "root" $ "context" .) | nindent 2 -}}
+  {{- include "element-io.matrix-rtc-authorisation-service.secret-data" (dict "root" $ "context" .) | nindent 2 -}}
 {{- end -}}
 {{- end -}}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_service.yaml
@@ -10,8 +10,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{- include "element-io.matrix-rtc-authorizer.labels" (dict "root" $ "context" .) | nindent 4 }}
-  name: {{ $.Release.Name }}-matrix-rtc-authorizer
+    {{- include "element-io.matrix-rtc-authorisation-service.labels" (dict "root" $ "context" .) | nindent 4 }}
+  name: {{ $.Release.Name }}-matrix-rtc-authorisation-service
   namespace: {{ $.Release.Namespace }}
 spec:
   type: ClusterIP
@@ -20,6 +20,6 @@ spec:
     port: 8080
     targetPort: http
   selector:
-    app.kubernetes.io/instance: "{{ $.Release.Name }}-matrix-rtc-authorizer"
+    app.kubernetes.io/instance: "{{ $.Release.Name }}-matrix-rtc-authorisation-service"
 {{- end -}}
 {{- end -}}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_service_monitor.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_service_monitor.yaml
@@ -12,8 +12,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    {{- include "element-io.matrix-rtc-authorizer.labels" (dict "root" $ "context" .) | nindent 4 }}
-  name: {{ $.Release.Name }}-matrix-rtc-authorizer
+    {{- include "element-io.matrix-rtc-authorisation-service.labels" (dict "root" $ "context" .) | nindent 4 }}
+  name: {{ $.Release.Name }}-matrix-rtc-authorisation-service
   namespace: {{ $.Release.Namespace }}
 spec:
   endpoints:
@@ -22,8 +22,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/part-of: matrix-stack
-      app.kubernetes.io/component: matrix-rtc-authorizer
-      app.kubernetes.io/instance: {{ $.Release.Name }}-matrix-rtc-authorizer
+      app.kubernetes.io/component: matrix-rtc-authorisation-service
+      app.kubernetes.io/instance: {{ $.Release.Name }}-matrix-rtc-authorisation-service
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_serviceaccount.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_serviceaccount.yaml
@@ -6,6 +6,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 {{- with $.Values.matrixRTC -}}
 {{- if .enabled -}}
-{{- include "element-io.ess-library.serviceAccount" (dict "root" $ "context" (dict "componentValues" . "nameSuffix" "matrix-rtc-authorizer")) }}
+{{- include "element-io.ess-library.serviceAccount" (dict "root" $ "context" (dict "componentValues" . "nameSuffix" "matrix-rtc-authorisation-service")) }}
 {{- end -}}
 {{- end -}}

--- a/newsfragments/446.changed.md
+++ b/newsfragments/446.changed.md
@@ -1,0 +1,1 @@
+Matrix RTC Authorizer is now named Matrix RTC Authorisation Service.


### PR DESCRIPTION
It was decided to converge to Matrix RTC Authorisation Service to name the service issuing JWTs.