### PR TITLE
Use the correct namespace on the base branch for `template-dyff` too

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -131,6 +131,7 @@ jobs:
         for values in charts/matrix-stack/ci/*values.yaml; do
           echo "Generating old templates with $values";
           helm template \
+              -n ess-ci \
               -a monitoring.coreos.com/v1/ServiceMonitor \
               -f "$values" charts/matrix-stack | \
           yq ea '[.] | sort_by(.kind, .metadata.name) | .[] | splitDoc' > "$RUNNER_TEMP/old/$(basename "$values")"

--- a/newsfragments/431.internal.md
+++ b/newsfragments/431.internal.md
@@ -1,0 +1,1 @@
+Add a job to compare the generated templates between source and target branches in PRs.

--- a/newsfragments/436.internal.md
+++ b/newsfragments/436.internal.md
@@ -1,0 +1,1 @@
+Add a job to compare the generated templates between source and target branches in PRs.

--- a/newsfragments/443.internal.md
+++ b/newsfragments/443.internal.md
@@ -1,0 +1,1 @@
+Add a job to compare the generated templates between source and target branches in PRs.

--- a/newsfragments/447.internal.md
+++ b/newsfragments/447.internal.md
@@ -1,0 +1,1 @@
+Add a job to compare the generated templates between source and target branches in PRs.


### PR DESCRIPTION
#444 set the namespace on `kubeconform` and the new manifests in `template-dyff` but not the base manifests in `template-dyff`. Fix this.

Also rather than renaming release notes, c/p them so that multiple PRs are attached to it