### PR TITLE
Support Synapse workers in the manifest tests

### DIFF
--- a/newsfragments/453.internal.1.md
+++ b/newsfragments/453.internal.1.md
@@ -1,0 +1,1 @@
+Add manifest test to confirm that all Pods have configurable resources.

--- a/newsfragments/453.internal.md
+++ b/newsfragments/453.internal.md
@@ -1,0 +1,1 @@
+Make it easier to test manifests for Synapse workers.

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -122,7 +122,7 @@ class DeployableDetails(abc.ABC):
             values_fragment = values_fragment.setdefault(helm_key, {})
         return values_fragment
 
-    def set_helm_values(self, all_values: dict[str, Any], propertyType: PropertyType, values_to_set: Any):
+    def set_helm_values(self, values: dict[str, Any], propertyType: PropertyType, values_to_set: Any):
         """
         Sets a fragment of values for this deployable for a given PropertyType.
         This fragment can be:
@@ -139,7 +139,7 @@ class DeployableDetails(abc.ABC):
         if helm_keys is None:
             return
 
-        values_fragment = all_values
+        values_fragment = values
         for index, helm_key in enumerate(helm_keys):
             # The last iteration through is the specific property we want to set. We know everything
             # higher this will be a dict, but at the end, for a specific property, we could be

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -17,6 +17,7 @@ class PropertyType(Enum):
     PodSecurityContext = "podSecurityContext"
     Postgres = "postgres"
     ReadinessProbe = "readinessProbe"
+    Resources = "resources"
     StartupProbe = "startupProbe"
     ServiceAccount = "serviceAccount"
     ServiceMonitor = "serviceMonitors"
@@ -457,6 +458,8 @@ all_components_details = [
                     PropertyType.LivenessProbe: None,
                     # has_workloads and so podSecurityContext but comes from synapse.podSecurityContext
                     PropertyType.PodSecurityContext: None,
+                    # has_workloads but comes from synapse.resources
+                    PropertyType.Resources: None,
                     # Job so no readinessProbe
                     PropertyType.ReadinessProbe: None,
                     # Job so no startupProbe

--- a/tests/manifests/test_pod_pull_secrets.py
+++ b/tests/manifests/test_pod_pull_secrets.py
@@ -1,11 +1,11 @@
-# Copyright 2024 New Vector Ltd
+# Copyright 2024-2025 New Vector Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import pytest
 
 from . import PropertyType, values_files_to_test
-from .utils import iterate_deployables_image_parts
+from .utils import iterate_deployables_parts
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -33,11 +33,12 @@ async def test_local_pull_secrets(deployables_details, values, base_values, make
         {"name": "global-secret"},
     ]
     values.setdefault("matrixTools", {}).setdefault("image", {})["pullSecrets"] = [{"name": "matrix-tools-secret"}]
-    iterate_deployables_image_parts(
+    iterate_deployables_parts(
         deployables_details,
         lambda deployable_details: deployable_details.set_helm_values(
             values, PropertyType.Image, {"pullSecrets": [{"name": "local-secret"}]}
         ),
+        lambda deployable_details: deployable_details.has_image,
     )
 
     for template in await make_templates(values):

--- a/tests/manifests/test_pod_resources.py
+++ b/tests/manifests/test_pod_resources.py
@@ -1,0 +1,55 @@
+# Copyright 2025 New Vector Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import pytest
+
+from . import DeployableDetails, PropertyType, values_files_to_test
+from .utils import iterate_deployables_workload_parts, template_id
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_pod_resources_are_configurable(
+    deployables_details, values, make_templates, template_to_deployable_details
+):
+    deployable_details_to_resources = {}
+    counter = 1
+
+    def set_resources(deployable_details: DeployableDetails):
+        nonlocal counter
+        resources = {
+            "requests": {
+                "cpu": f"{1000 + counter}",
+                "memory": f"{2000 + counter}Mi",
+            },
+            "limits": {
+                "cpu": f"{3000 + counter}",
+                "memory": f"{4000 + counter}Mi",
+            },
+        }
+        counter += 1
+        deployable_details_to_resources[deployable_details] = resources
+        deployable_details.set_helm_values(values, PropertyType.Resources, resources)
+
+    iterate_deployables_workload_parts(deployables_details, set_resources)
+    for template in await make_templates(values):
+        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+            for container in template["spec"]["template"]["spec"]["containers"]:
+                assert "resources" in container, (
+                    f"{template_id(template)} has container {container['name']} without resources"
+                )
+
+                deployable_details = template_to_deployable_details(template, container["name"])
+
+                # The check config job gets its resources from Synapse and doesn't have its own values
+                # We don't have a good way of "redirecting" to Synapse's expected resources so just skip
+                # test_synapse_resources_shared_by_default tests that the check config job uses synapse.resources
+                if deployable_details.name == "synapse-check-config-hook":
+                    continue
+
+                expected_resources = deployable_details_to_resources[deployable_details]
+                assert expected_resources == container["resources"], (
+                    f"{template_id(template)} has container {container['name']} "
+                    "which doesn't have the expected resources"
+                )

--- a/tests/manifests/test_synapse.py
+++ b/tests/manifests/test_synapse.py
@@ -3,15 +3,13 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 
-from typing import Any, Callable
-
 import pytest
 import yaml
 
 from . import DeployableDetails, PropertyType
 from .utils import (
     iterate_deployables_ingress_parts,
-    iterate_synapse_workers_parts,
+    iterate_deployables_parts,
     template_id,
 )
 
@@ -146,27 +144,11 @@ async def test_log_level_overrides(values, make_templates):
         raise RuntimeError("Could not find log_config.yaml")
 
 
-def assert_synapse_container(
-    templates, template_to_deployable_details, assertion_visitor: Callable[[dict[str, Any], dict[str, Any]], None]
-):
-    for template in templates:
-        if template_to_deployable_details(template).name != "synapse":
-            continue
-
-        if template["kind"] != "StatefulSet":
-            continue
-
-        for container in template["spec"]["template"]["spec"]["containers"]:
-            if container["name"] == "synapse":
-                assertion_visitor(template, container)
-                break
-        else:
-            raise AssertionError(f"{template_id(template)} has no container named 'synapse'")
-
-
 @pytest.mark.parametrize("values_file", ["synapse-worker-example-values.yaml"])
 @pytest.mark.asyncio_cooperative
-async def test_synapse_resources_shared_by_default(values, make_templates, template_to_deployable_details):
+async def test_synapse_resources_shared_by_default(
+    deployables_details, values, make_templates, template_to_deployable_details
+):
     resources = {
         "requests": {
             "cpu": "1000",
@@ -177,53 +159,25 @@ async def test_synapse_resources_shared_by_default(values, make_templates, templ
             "memory": "4000Mi",
         },
     }
-    values["synapse"]["resources"] = resources
 
-    def assert_expected_resources(template, container):
-        assert container["resources"] == resources, (
-            f"{template_id(template)} has incorrect resources {container['resources']} vs {resources}"
-        )
+    def set_resources(deployable_details: DeployableDetails):
+        if deployable_details.name == "synapse":
+            deployable_details.set_helm_values(values, PropertyType.Resources, resources)
 
-    assert_synapse_container(await make_templates(values), template_to_deployable_details, assert_expected_resources)
-
-
-@pytest.mark.parametrize("values_file", ["synapse-worker-example-values.yaml"])
-@pytest.mark.asyncio_cooperative
-async def test_per_worker_synapse_resources(all_values, release_name, make_templates, template_to_deployable_details):
-    workers_to_resources = {}
-    counter = 1
-
-    def set_resources(worker_name, values_fragment):
-        nonlocal counter
-        workers_to_resources[worker_name] = {
-            "requests": {
-                "cpu": f"{1000 + counter}",
-                "memory": f"{2000 + counter}Mi",
-            },
-            "limits": {
-                "cpu": f"{3000 + counter}",
-                "memory": f"{4000 + counter}Mi",
-            },
-        }
-        counter += 1
-        values_fragment["resources"] = workers_to_resources[worker_name]
-
-    iterate_synapse_workers_parts(all_values, set_resources)
-
-    seen_workers = []
-
-    def assert_expected_resources(template, container):
-        worker_name = template["metadata"]["name"].replace(f"{release_name}-synapse-", "")
-        if worker_name == "":
-            worker_name = "main"
-        seen_workers.append(worker_name)
-
-        expected_resources = workers_to_resources[worker_name]
-        assert container["resources"] == expected_resources, (
-            f"{template_id(template)} has incorrect resources {container['resources']} vs {expected_resources}"
-        )
-
-    assert_synapse_container(
-        await make_templates(all_values), template_to_deployable_details, assert_expected_resources
+    iterate_deployables_parts(
+        deployables_details, set_resources, lambda deployable_details: deployable_details.is_synapse_process
     )
-    assert len(workers_to_resources) == len(seen_workers), f"{seen_workers} has not seen all the expected workers"
+    for template in await make_templates(values):
+        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+            deployable_details = template_to_deployable_details(template)
+            if not deployable_details.is_synapse_process:
+                continue
+
+            for container in template["spec"]["template"]["spec"]["containers"]:
+                assert "resources" in container, (
+                    f"{template_id(template)} has container {container['name']} without resources"
+                )
+                assert resources == container["resources"], (
+                    f"{template_id(template)} has container {container['name']} "
+                    "which doesn't have the expected resources"
+                )

--- a/tests/manifests/test_synapse.py
+++ b/tests/manifests/test_synapse.py
@@ -1,4 +1,4 @@
-# Copyright 2024 New Vector Ltd
+# Copyright 2024-2025 New Vector Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -9,7 +9,11 @@ import pytest
 import yaml
 
 from . import DeployableDetails, PropertyType
-from .utils import iterate_deployables_ingress_parts, iterate_synapse_workers_parts, template_id
+from .utils import (
+    iterate_deployables_ingress_parts,
+    iterate_synapse_workers_parts,
+    template_id,
+)
 
 
 @pytest.mark.parametrize("values_file", ["synapse-minimal-values.yaml"])

--- a/tests/manifests/utils.py
+++ b/tests/manifests/utils.py
@@ -252,13 +252,6 @@ def iterate_deployables_workload_parts(
     iterate_deployables_parts(deployables_details, visitor, lambda deployable_details: deployable_details.has_workloads)
 
 
-def iterate_deployables_image_parts(
-    deployables_details: tuple[DeployableDetails],
-    visitor: Callable[[DeployableDetails], None],
-):
-    iterate_deployables_parts(deployables_details, visitor, lambda deployable_details: deployable_details.has_image)
-
-
 def iterate_deployables_ingress_parts(
     deployables_details: tuple[DeployableDetails],
     visitor: Callable[[DeployableDetails], None],

--- a/tests/manifests/utils.py
+++ b/tests/manifests/utils.py
@@ -70,26 +70,6 @@ def values(values_file) -> dict[str, Any]:
 
 
 @pytest.fixture
-def all_values(values, base_values) -> dict[str, Any]:
-    def merge(a: dict, b: dict, path=None):
-        if not path:
-            path = []
-        for key in b:
-            if key in a:
-                if isinstance(a[key], dict) and isinstance(b[key], dict):
-                    merge(a[key], b[key], path + [str(key)])
-                elif type(a[key]) is not type(b[key]):
-                    raise Exception("Conflict at " + ".".join(path + [str(key)]))
-                else:
-                    a[key] = b[key]
-            else:
-                a[key] = b[key]
-        return a
-
-    return merge(copy.deepcopy(base_values), copy.deepcopy(values))
-
-
-@pytest.fixture
 async def templates(chart: pyhelm3.Chart, release_name: str, values: dict[str, Any]):
     return await helm_template(chart, release_name, values)
 
@@ -257,24 +237,6 @@ def iterate_deployables_ingress_parts(
     visitor: Callable[[DeployableDetails], None],
 ):
     iterate_deployables_parts(deployables_details, visitor, lambda deployable_details: deployable_details.has_ingress)
-
-
-def iterate_synapse_workers_parts(
-    all_values: dict[str, Any],
-    visitor: Callable[[str, dict[str, Any]], None],
-    key_to_check: str | None = None,
-) -> None:
-    if not all_values["synapse"]["enabled"]:
-        return
-
-    if key_to_check is None or key_to_check in all_values["synapse"]:
-        visitor("main", all_values["synapse"])
-
-    for worker_name, worker_values in all_values["synapse"]["workers"].items():
-        if not worker_values["enabled"]:
-            continue
-        if key_to_check is None or key_to_check in worker_values:
-            visitor(worker_name, worker_values)
 
 
 @pytest.fixture


### PR DESCRIPTION
Treat Synapse workers as sub-components like everything else to remove special casing of them