### PR TITLE
Fix Element Web built-in config not being override-able

### DIFF
--- a/charts/matrix-stack/configs/element-web/config.json.tpl
+++ b/charts/matrix-stack/configs/element-web/config.json.tpl
@@ -38,7 +38,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- with .additional }}
 {{- range $key := (. | keys | uniq | sortAlpha) }}
 {{- $prop := index $root.Values.elementWeb.additional $key }}
-{{- $config = (mustMergeOverwrite ((tpl $prop $root) | fromJson) $config) -}}
+{{- $config = (mustMergeOverwrite $config ((tpl $prop $root) | fromJson)) -}}
 {{- end }}
 {{- end }}
 {{- toPrettyJson $config -}}

--- a/newsfragments/456.fixed.md
+++ b/newsfragments/456.fixed.md
@@ -1,0 +1,1 @@
+Fix built-in Element Web not being allowed to be overridden.

--- a/tests/manifests/test_element_web.py
+++ b/tests/manifests/test_element_web.py
@@ -37,14 +37,10 @@ async def test_config_json_override(values, make_templates):
     }
 
     for template in await make_templates(values):
-        if (
-            template["kind"] == "ConfigMap"
-            and "synapse" in template["metadata"]["name"]
-            and "log_config.yaml" in template["data"]
-        ):
-            config_json = json.safe_load(template["data"]["config.json"])
+        if template["kind"] == "ConfigMap" and "element-web" in template["metadata"]["name"]:
+            config_json = json.loads(template["data"]["config.json"])
             assert config_json == {
-                "bug_report_endpoint_url": "other-url",
+                "bug_report_endpoint_url": "https://other-url",
                 "default_server_config": {"m.homeserver": {}},
                 "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx",
                 "setting_defaults": {},
@@ -53,3 +49,5 @@ async def test_config_json_override(values, make_templates):
                 "again_other_key": {"other_value": "value_third"},
             }
             break
+    else:
+        raise RuntimeError("Could not find config.json")


### PR DESCRIPTION
Based on what was written in the test, this was the intention. Unlike with Synapse or Well-Known Delegation, it probably isn't a huge problem if these properties are overridden. If it does become so we can add an override/underride scheme