### PR TITLE
Synapse Redis has extraEnv like everything else

### DIFF
--- a/charts/matrix-stack/source/synapse.yaml.j2
+++ b/charts/matrix-stack/source/synapse.yaml.j2
@@ -108,6 +108,7 @@ redis:
 {{- sub_schema_values.labels() | indent(2) }}
 {{- sub_schema_values.workloadAnnotations() | indent(2) }}
 {{- sub_schema_values.containersSecurityContext() | indent(2) }}
+{{- sub_schema_values.extraEnv() | indent(2) }}
 {{- sub_schema_values.nodeSelector() | indent(2) }}
 {{- sub_schema_values.podSecurityContext(user_id='10002', group_id='10002') | indent(2) }}
 {{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='50Mi') | indent(2) }}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -3550,6 +3550,12 @@ synapse:
       ## localhostProfile must only be set set if type Localhost. It indicates the path of the pre-configured profile on the node, relative to the kubelet's configured Seccomp profile location (configured with the --root-dir flag).
       # seccompProfile:
       #  type: RuntimeDefault
+    ## Defines additional environment variables to be injected onto this workload
+    ## e.g.
+    ## extraEnv:
+    ## - name: FOO
+    ##   value: "bar"
+    extraEnv: []
     ## NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
     # nodeSelector: {}
     ## A subset of PodSecurityContext. PodSecurityContext holds pod-level security attributes and common container settings

--- a/newsfragments/458.changed.md
+++ b/newsfragments/458.changed.md
@@ -1,0 +1,1 @@
+Document Synapse's Redis extraEnv property in values.yaml.


### PR DESCRIPTION
In the schema, templates and tests but not in `values.yaml`