### PR TITLE
Fix manifest tests being skipped

### DIFF
--- a/newsfragments/465.internal.1.md
+++ b/newsfragments/465.internal.1.md
@@ -1,0 +1,1 @@
+Fix some values files being accidentally skip in the manifest tests.

--- a/newsfragments/465.internal.md
+++ b/newsfragments/465.internal.md
@@ -1,0 +1,1 @@
+Update manifest tests so that the components under test don't need to be enumerated.

--- a/tests/manifests/test_basic.py
+++ b/tests/manifests/test_basic.py
@@ -1,10 +1,10 @@
-# Copyright 2024 New Vector Ltd
+# Copyright 2024-2025 New Vector Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import pytest
 
-from . import values_files_to_test
+from . import all_deployables_details, values_files_to_test
 from .utils import template_id
 
 
@@ -32,11 +32,11 @@ async def test_postgres_on_its_own_renders_nothing(values, make_templates):
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_values_file_renders_only_itself(release_name, deployables_details, templates):
+async def test_values_file_renders_only_itself(release_name, templates):
     assert len(templates) > 0
 
     allowed_starts_with = []
-    for deployable_details in deployables_details:
+    for deployable_details in all_deployables_details:
         allowed_starts_with.append(f"{release_name}-{deployable_details.name}")
 
     for template in templates:
@@ -47,7 +47,7 @@ async def test_values_file_renders_only_itself(release_name, deployables_details
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_values_file_renders_idempotent(release_name, values, make_templates):
+async def test_values_file_renders_idempotent(values, make_templates):
     first_render = {}
     for template in await make_templates(values, skip_cache=True):
         first_render[template_id(template)] = template

--- a/tests/manifests/test_configs_and_mounts_consistency.py
+++ b/tests/manifests/test_configs_and_mounts_consistency.py
@@ -226,7 +226,7 @@ def assert_exists_according_to_hook_weight(template, hook_weight, used_by):
         )
 
 
-@pytest.mark.parametrize("values_file", values_files_to_test + secret_values_files_to_test)
+@pytest.mark.parametrize("values_file", values_files_to_test | secret_values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_secrets_consistency(templates, other_secrets, template_to_deployable_details):
     """

--- a/tests/manifests/test_manifest_test_infrastructure.py
+++ b/tests/manifests/test_manifest_test_infrastructure.py
@@ -1,4 +1,4 @@
-# Copyright 2024 New Vector Ltd
+# Copyright 2024-2025 New Vector Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -22,7 +22,7 @@ def test_all_components_covered():
         assert contents.name in expected_folders
 
 
-@pytest.mark.parametrize("values_file", values_files_to_test + secret_values_files_to_test)
+@pytest.mark.parametrize("values_file", values_files_to_test | secret_values_files_to_test)
 @pytest.mark.asyncio_cooperative
 def test_component_has_values_file(values_file):
     ci_folder = Path(__file__).parent.parent.parent / Path("charts/matrix-stack/ci")

--- a/tests/manifests/test_pod_env.py
+++ b/tests/manifests/test_pod_env.py
@@ -12,13 +12,13 @@ extra_env = {"a_string": "a", "b_boolean": True, "c_integer": 1, "d_float": 1.1}
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_unique_env_name_in_containers(deployables_details, values, make_templates):
+async def test_unique_env_name_in_containers(values, make_templates):
     def set_extra_env(deployable_details: DeployableDetails):
         deployable_details.set_helm_values(
             values, PropertyType.Env, [{"name": k, "value": str(v)} for k, v in extra_env.items()]
         )
 
-    iterate_deployables_workload_parts(deployables_details, set_extra_env)
+    iterate_deployables_workload_parts(set_extra_env)
 
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "Job", "StatefulSet"]:
@@ -37,13 +37,13 @@ async def test_unique_env_name_in_containers(deployables_details, values, make_t
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_env_values_are_strings_in_containers(deployables_details, values, make_templates):
+async def test_env_values_are_strings_in_containers(values, make_templates):
     def set_extra_env(deployable_details: DeployableDetails):
         deployable_details.set_helm_values(
             values, PropertyType.Env, [{"name": k, "value": str(v)} for k, v in extra_env.items()]
         )
 
-    iterate_deployables_workload_parts(deployables_details, set_extra_env)
+    iterate_deployables_workload_parts(set_extra_env)
 
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "Job", "StatefulSet"]:

--- a/tests/manifests/test_pod_probes.py
+++ b/tests/manifests/test_pod_probes.py
@@ -85,7 +85,7 @@ def assert_sensible_default_probe(template, probe_type):
             assert any([port["name"] == probePort for port in container["ports"]])
 
 
-def set_probe_details(deployables_details, values, probe_type):
+def set_probe_details(values, probe_type):
     deployable_details_to_probe_details = {}
 
     # We have a counter that increments for each probe field for each deployable details
@@ -109,7 +109,7 @@ def set_probe_details(deployables_details, values, probe_type):
         deployable_details_to_probe_details[deployable_details] = probe_details
         deployable_details.set_helm_values(values, probe_type, probe_details)
 
-    iterate_deployables_workload_parts(deployables_details, set_probe_details)
+    iterate_deployables_workload_parts(set_probe_details)
     return deployable_details_to_probe_details
 
 
@@ -149,10 +149,8 @@ async def test_sensible_livenessProbes_by_default(templates):
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_livenessProbes_are_configurable(
-    deployables_details, values, make_templates, template_to_deployable_details
-):
-    deployable_details_to_probe_details = set_probe_details(deployables_details, values, PropertyType.LivenessProbe)
+async def test_livenessProbes_are_configurable(values, make_templates, template_to_deployable_details):
+    deployable_details_to_probe_details = set_probe_details(values, PropertyType.LivenessProbe)
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "StatefulSet"]:
             assert_matching_probe(
@@ -173,10 +171,8 @@ async def test_sensible_readinessProbes_by_default(templates):
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_readinessProbes_are_configurable(
-    deployables_details, values, make_templates, template_to_deployable_details
-):
-    deployable_details_to_probe_details = set_probe_details(deployables_details, values, PropertyType.ReadinessProbe)
+async def test_readinessProbes_are_configurable(values, make_templates, template_to_deployable_details):
+    deployable_details_to_probe_details = set_probe_details(values, PropertyType.ReadinessProbe)
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "StatefulSet"]:
             assert_matching_probe(
@@ -197,10 +193,8 @@ async def test_sensible_startupProbes_by_default(templates):
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_startupProbes_are_configurable(
-    deployables_details, values, make_templates, template_to_deployable_details
-):
-    deployable_details_to_probe_details = set_probe_details(deployables_details, values, PropertyType.StartupProbe)
+async def test_startupProbes_are_configurable(values, make_templates, template_to_deployable_details):
+    deployable_details_to_probe_details = set_probe_details(values, PropertyType.StartupProbe)
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "StatefulSet"]:
             assert_matching_probe(

--- a/tests/manifests/test_pod_pull_secrets.py
+++ b/tests/manifests/test_pod_pull_secrets.py
@@ -28,13 +28,12 @@ async def test_sets_global_pull_secrets(values, make_templates):
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_local_pull_secrets(deployables_details, values, base_values, make_templates):
+async def test_local_pull_secrets(values, base_values, make_templates):
     values["imagePullSecrets"] = [
         {"name": "global-secret"},
     ]
     values.setdefault("matrixTools", {}).setdefault("image", {})["pullSecrets"] = [{"name": "matrix-tools-secret"}]
     iterate_deployables_parts(
-        deployables_details,
         lambda deployable_details: deployable_details.set_helm_values(
             values, PropertyType.Image, {"pullSecrets": [{"name": "local-secret"}]}
         ),

--- a/tests/manifests/test_pod_resources.py
+++ b/tests/manifests/test_pod_resources.py
@@ -10,9 +10,7 @@ from .utils import iterate_deployables_workload_parts, template_id
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_pod_resources_are_configurable(
-    deployables_details, values, make_templates, template_to_deployable_details
-):
+async def test_pod_resources_are_configurable(values, make_templates, template_to_deployable_details):
     deployable_details_to_resources = {}
     counter = 1
 
@@ -32,7 +30,7 @@ async def test_pod_resources_are_configurable(
         deployable_details_to_resources[deployable_details] = resources
         deployable_details.set_helm_values(values, PropertyType.Resources, resources)
 
-    iterate_deployables_workload_parts(deployables_details, set_resources)
+    iterate_deployables_workload_parts(set_resources)
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
             for container in template["spec"]["template"]["spec"]["containers"]:

--- a/tests/manifests/test_pod_securityContext.py
+++ b/tests/manifests/test_pod_securityContext.py
@@ -1,4 +1,4 @@
-# Copyright 2024 New Vector Ltd
+# Copyright 2024-2025 New Vector Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -38,9 +38,8 @@ async def test_sets_nonRoot_uids_gids_in_pod_securityContext_by_default(template
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_can_nuke_pod_securityContext_ids(deployables_details, values, make_templates):
+async def test_can_nuke_pod_securityContext_ids(values, make_templates):
     iterate_deployables_workload_parts(
-        deployables_details,
         lambda deployable_details: deployable_details.set_helm_values(
             values, PropertyType.PodSecurityContext, {"runAsUser": None, "runAsGroup": None, "fsGroup": None}
         ),
@@ -84,9 +83,8 @@ async def test_sets_seccompProfile_in_pod_securityContext_by_default(templates):
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_can_nuke_pod_securityContext_seccompProfile(deployables_details, values, make_templates):
+async def test_can_nuke_pod_securityContext_seccompProfile(values, make_templates):
     iterate_deployables_workload_parts(
-        deployables_details,
         lambda deployable_details: deployable_details.set_helm_values(
             values, PropertyType.PodSecurityContext, {"seccompProfile": None}
         ),

--- a/tests/manifests/test_service_monitors.py
+++ b/tests/manifests/test_service_monitors.py
@@ -17,9 +17,7 @@ from .utils import (
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_service_monitored_as_appropriate(
-    deployables_details, values: dict, make_templates, template_to_deployable_details
-):
+async def test_service_monitored_as_appropriate(values: dict, make_templates, template_to_deployable_details):
     def workload_ids_covered_by_service_monitor(
         service_monitor_template: dict[str, Any], templates_by_kind: dict[str, list[dict[str, Any]]]
     ):
@@ -41,7 +39,6 @@ async def test_service_monitored_as_appropriate(
         return covered_workload_ids
 
     await assert_covers_expected_workloads(
-        deployables_details,
         values,
         make_templates,
         template_to_deployable_details,

--- a/tests/manifests/test_serviceaccounts.py
+++ b/tests/manifests/test_serviceaccounts.py
@@ -1,4 +1,4 @@
-# Copyright 2024 New Vector Ltd
+# Copyright 2024-2025 New Vector Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -6,7 +6,7 @@ import copy
 
 import pytest
 
-from . import DeployableDetails, PropertyType, values_files_to_test
+from . import DeployableDetails, PropertyType, all_deployables_details, values_files_to_test
 from .utils import iterate_deployables_workload_parts
 
 
@@ -57,7 +57,7 @@ async def test_uses_serviceaccount_named_as_per_pod_controller_by_default(templa
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_uses_serviceaccount_named_as_values_if_specified(deployables_details, values, make_templates):
+async def test_uses_serviceaccount_named_as_values_if_specified(values, make_templates):
     def service_account_name(deployable_details: DeployableDetails):
         deployable_details.set_helm_values(
             values, PropertyType.ServiceAccount, {"name": f"{deployable_details.name}-pytest"}
@@ -66,7 +66,7 @@ async def test_uses_serviceaccount_named_as_values_if_specified(deployables_deta
             values, PropertyType.Labels, {"expected.name": f"{deployable_details.name}-pytest"}
         )
 
-    iterate_deployables_workload_parts(deployables_details, service_account_name)
+    iterate_deployables_workload_parts(service_account_name)
 
     workloads_by_id = {}
     serviceaccount_names = []
@@ -91,8 +91,8 @@ async def test_uses_serviceaccount_named_as_values_if_specified(deployables_deta
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_does_not_create_serviceaccounts_if_configured_not_to(deployables_details, values, make_templates):
-    for deployable_details in deployables_details:
+async def test_does_not_create_serviceaccounts_if_configured_not_to(values, make_templates):
+    for deployable_details in all_deployables_details:
         if not deployable_details.has_workloads:
             continue
 

--- a/tests/manifests/test_synapse.py
+++ b/tests/manifests/test_synapse.py
@@ -88,7 +88,7 @@ async def test_max_upload_size_annotation_global_ingressType(values, make_templa
 
 @pytest.mark.parametrize("values_file", ["synapse-minimal-values.yaml"])
 @pytest.mark.asyncio_cooperative
-async def test_max_upload_size_annotation_component_ingressType(values, deployables_details, make_templates):
+async def test_max_upload_size_annotation_component_ingressType(values, make_templates):
     def set_ingress_type(deployable_details: DeployableDetails):
         deployable_details.set_helm_values(values, PropertyType.Ingress, {"controllerType": "ingress-nginx"})
 
@@ -96,7 +96,7 @@ async def test_max_upload_size_annotation_component_ingressType(values, deployab
         if template["kind"] == "Ingress":
             assert "nginx.ingress.kubernetes.io/proxy-body-size" not in template["metadata"].get("annotations", {})
 
-    iterate_deployables_ingress_parts(deployables_details, set_ingress_type)
+    iterate_deployables_ingress_parts(set_ingress_type)
 
     for template in await make_templates(values):
         if template["kind"] == "Ingress":
@@ -146,9 +146,7 @@ async def test_log_level_overrides(values, make_templates):
 
 @pytest.mark.parametrize("values_file", ["synapse-worker-example-values.yaml"])
 @pytest.mark.asyncio_cooperative
-async def test_synapse_resources_shared_by_default(
-    deployables_details, values, make_templates, template_to_deployable_details
-):
+async def test_synapse_resources_shared_by_default(values, make_templates, template_to_deployable_details):
     resources = {
         "requests": {
             "cpu": "1000",
@@ -164,9 +162,7 @@ async def test_synapse_resources_shared_by_default(
         if deployable_details.name == "synapse":
             deployable_details.set_helm_values(values, PropertyType.Resources, resources)
 
-    iterate_deployables_parts(
-        deployables_details, set_resources, lambda deployable_details: deployable_details.is_synapse_process
-    )
+    iterate_deployables_parts(set_resources, lambda deployable_details: deployable_details.is_synapse_process)
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
             deployable_details = template_to_deployable_details(template)

--- a/tests/manifests/test_tolerations.py
+++ b/tests/manifests/test_tolerations.py
@@ -1,4 +1,4 @@
-# Copyright 2024 New Vector Ltd
+# Copyright 2024-2025 New Vector Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -36,9 +36,8 @@ async def test_no_tolerations_by_default(templates):
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_all_components_and_sub_components_render_tolerations(deployables_details, values, make_templates):
+async def test_all_components_and_sub_components_render_tolerations(values, make_templates):
     iterate_deployables_workload_parts(
-        deployables_details,
         lambda deployable_details: deployable_details.set_helm_values(
             values, PropertyType.Tolerations, [specific_toleration]
         ),
@@ -71,9 +70,8 @@ async def test_global_tolerations_render(values, make_templates):
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_merges_global_and_specific_tolerations(deployables_details, values, make_templates):
+async def test_merges_global_and_specific_tolerations(values, make_templates):
     iterate_deployables_workload_parts(
-        deployables_details,
         lambda deployable_details: deployable_details.set_helm_values(
             values, PropertyType.Tolerations, [specific_toleration]
         ),

--- a/tests/manifests/test_topology_spread_constraints.py
+++ b/tests/manifests/test_topology_spread_constraints.py
@@ -1,4 +1,4 @@
-# Copyright 2024 New Vector Ltd
+# Copyright 2024-2025 New Vector Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -22,9 +22,7 @@ async def test_sets_no_topology_spread_constraint_default(templates):
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_topology_spread_constraint_has_default(
-    deployables_details, values, make_templates, template_to_deployable_details
-):
+async def test_topology_spread_constraint_has_default(values, make_templates, template_to_deployable_details):
     def set_topology_spread_constraints(deployable_details: DeployableDetails):
         deployable_details.set_helm_values(
             values,
@@ -39,7 +37,6 @@ async def test_topology_spread_constraint_has_default(
         )
 
     iterate_deployables_parts(
-        deployables_details,
         set_topology_spread_constraints,
         lambda deployable_details: deployable_details.has_topology_spread_constraints,
     )
@@ -71,9 +68,7 @@ async def test_topology_spread_constraint_has_default(
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_can_nuke_topology_spread_constraint_defaults(
-    deployables_details, values, make_templates, template_to_deployable_details
-):
+async def test_can_nuke_topology_spread_constraint_defaults(values, make_templates, template_to_deployable_details):
     def set_topology_spread_constraints(deployable_details: DeployableDetails):
         deployable_details.set_helm_values(
             values,
@@ -95,7 +90,6 @@ async def test_can_nuke_topology_spread_constraint_defaults(
         )
 
     iterate_deployables_parts(
-        deployables_details,
         set_topology_spread_constraints,
         lambda deployable_details: deployable_details.has_topology_spread_constraints,
     )

--- a/tests/manifests/test_volumes_mounts.py
+++ b/tests/manifests/test_volumes_mounts.py
@@ -7,7 +7,7 @@ import pytest
 from . import secret_values_files_to_test, values_files_to_test
 
 
-@pytest.mark.parametrize("values_file", values_files_to_test + secret_values_files_to_test)
+@pytest.mark.parametrize("values_file", values_files_to_test | secret_values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_volumes_mounts_exists(templates, other_secrets):
     configmaps_names = [t["metadata"]["name"] for t in templates if t["kind"] == "ConfigMap"]

--- a/tests/manifests/test_well_known_delegation.py
+++ b/tests/manifests/test_well_known_delegation.py
@@ -1,4 +1,4 @@
-# Copyright 2024 New Vector Ltd
+# Copyright 2024-2025 New Vector Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -164,7 +164,7 @@ async def test_dot_path_global_ingressType(values, make_templates):
 
 @pytest.mark.parametrize("values_file", ["well-known-minimal-values.yaml"])
 @pytest.mark.asyncio_cooperative
-async def test_dot_path_component_ingressType(deployables_details, values, make_templates):
+async def test_dot_path_component_ingressType(values, make_templates):
     def set_ingress_type(deployable_details: DeployableDetails):
         deployable_details.set_helm_values(values, PropertyType.Ingress, {"controllerType": "ingress-nginx"})
 
@@ -174,7 +174,7 @@ async def test_dot_path_component_ingressType(deployables_details, values, make_
                 if path["path"].startswith("/.well-known"):
                     assert path["pathType"] == "Prefix"
 
-    iterate_deployables_ingress_parts(deployables_details, set_ingress_type)
+    iterate_deployables_ingress_parts(set_ingress_type)
 
     for template in await make_templates(values):
         if template["kind"] == "Ingress":

--- a/tests/manifests/utils.py
+++ b/tests/manifests/utils.py
@@ -16,7 +16,7 @@ import pyhelm3
 import pytest
 import yaml
 
-from . import DeployableDetails, PropertyType, values_files_to_deployables_details
+from . import DeployableDetails, PropertyType, all_deployables_details
 
 template_cache = {}
 values_cache = {}
@@ -45,8 +45,8 @@ async def chart(helm_client: pyhelm3.Client):
 
 
 @pytest.fixture
-def deployables_details(values_file) -> tuple[DeployableDetails, ...]:
-    return values_files_to_deployables_details[values_file]
+def deployables_details() -> set[DeployableDetails]:
+    return all_deployables_details
 
 
 @pytest.fixture(scope="session")

--- a/tests/manifests/utils.py
+++ b/tests/manifests/utils.py
@@ -44,11 +44,6 @@ async def chart(helm_client: pyhelm3.Client):
     return await helm_client.get_chart("charts/matrix-stack")
 
 
-@pytest.fixture
-def deployables_details() -> set[DeployableDetails]:
-    return all_deployables_details
-
-
 @pytest.fixture(scope="session")
 def base_values() -> dict[str, Any]:
     return yaml.safe_load(Path("charts/matrix-stack/values.yaml").read_text("utf-8"))
@@ -223,31 +218,28 @@ def make_templates(chart: pyhelm3.Chart, release_name: str):
 
 
 def iterate_deployables_parts(
-    deployables_details: tuple[DeployableDetails],
     visitor: Callable[[DeployableDetails], None],
     if_condition: Callable[[DeployableDetails], bool],
 ):
-    for deployable_details in deployables_details:
+    for deployable_details in all_deployables_details:
         if if_condition(deployable_details):
             visitor(deployable_details)
 
 
 def iterate_deployables_workload_parts(
-    deployables_details: tuple[DeployableDetails],
     visitor: Callable[[DeployableDetails], None],
 ):
-    iterate_deployables_parts(deployables_details, visitor, lambda deployable_details: deployable_details.has_workloads)
+    iterate_deployables_parts(visitor, lambda deployable_details: deployable_details.has_workloads)
 
 
 def iterate_deployables_ingress_parts(
-    deployables_details: tuple[DeployableDetails],
     visitor: Callable[[DeployableDetails], None],
 ):
-    iterate_deployables_parts(deployables_details, visitor, lambda deployable_details: deployable_details.has_ingress)
+    iterate_deployables_parts(visitor, lambda deployable_details: deployable_details.has_ingress)
 
 
 @pytest.fixture
-def template_to_deployable_details(deployables_details: tuple[DeployableDetails]):
+def template_to_deployable_details():
     def _template_to_deployable_details(
         template: dict[str, Any], container_name: str | None = None
     ) -> DeployableDetails:
@@ -255,7 +247,7 @@ def template_to_deployable_details(deployables_details: tuple[DeployableDetails]
         manifest_name: str = template["metadata"]["labels"]["app.kubernetes.io/name"]
 
         match = None
-        for deployable_details in deployables_details:
+        for deployable_details in all_deployables_details:
             # We name the various DeployableDetails to match the name the chart should use for
             # the manifest name and thus the app.kubernetes.io/name label above. e.g. A manifest
             # belonging to Synapse should be named `<release-name>-synapse(-<optional extra>)`.
@@ -320,7 +312,6 @@ def selector_match(labels: dict[str, str], selector: dict[str, str]) -> bool:
 
 
 async def assert_covers_expected_workloads(
-    deployables_details,
     values,
     make_templates,
     template_to_deployable_details,
@@ -332,7 +323,7 @@ async def assert_covers_expected_workloads(
     def disable_covering_templates(deployable_details: DeployableDetails):
         deployable_details.set_helm_values(values, toggling_property_type, {"enabled": False})
 
-    iterate_deployables_parts(deployables_details, disable_covering_templates, if_condition)
+    iterate_deployables_parts(disable_covering_templates, if_condition)
 
     # We should now have no rendered templates of the covering_kind
     workload_ids_to_cover = set()
@@ -347,7 +338,7 @@ async def assert_covers_expected_workloads(
     def enable_covering_templates(deployable_details: DeployableDetails):
         deployable_details.set_helm_values(values, toggling_property_type, {"enabled": True})
 
-    iterate_deployables_parts(deployables_details, enable_covering_templates, if_condition)
+    iterate_deployables_parts(enable_covering_templates, if_condition)
 
     templates_by_kind = dict[str, list[dict[str, Any]]]()
     for template in await make_templates(values):

--- a/tests/manifests/utils.py
+++ b/tests/manifests/utils.py
@@ -58,12 +58,19 @@ def base_values() -> dict[str, Any]:
 def values(values_file) -> dict[str, Any]:
     if values_file not in values_cache:
         v = yaml.safe_load((Path("charts/matrix-stack/ci") / values_file).read_text("utf-8"))
-        if not v.get("initSecrets"):
-            v["initSecrets"] = {"enabled": True}
-        if not v.get("postgres"):
-            v["postgres"] = {"enabled": True}
-        if not v.get("wellKnownDelegation"):
-            v["wellKnownDelegation"] = {"enabled": True}
+        for default_enabled_component in [
+            "elementWeb",
+            "initSecrets",
+            "postgres",
+            "matrixRTC",
+            "matrixAuthenticationService",
+            "synapse",
+            "wellKnownDelegation",
+        ]:
+            if default_enabled_component not in v:
+                v[default_enabled_component] = {}
+            if "enabled" not in v[default_enabled_component]:
+                v[default_enabled_component]["enabled"] = True
 
         values_cache[values_file] = v
     return copy.deepcopy(values_cache[values_file])


### PR DESCRIPTION
If a values file is added to both `additional_values_files` and `additional_secret_values_files` it is only run for the secret only tests. This was due to https://github.com/element-hq/ess-helm/pull/273 and ends up with us accidentally skipping values files when testing.

Thinking about it further the whole need to know which components are involved in a test was mostly unneeded. The only test which actually cares is `test_ingress_is_expected_host` and by adding a `PropertyType.Enabled` we can fix this (1st commit).

Make `deployables_details` constant and renamed to `all_deployables_details` and simplify the values file set construction so that it is hard to get wrong (2nd commit).

The final commit simplifies all tests that were obtaining `deployables_details` just to `iterate_deployable_parts` (or similar) by statically importing `all_deployables_details` into the iterate functions instead.