### PR TITLE
Have a distinct copyright dates job

### DIFF
--- a/.github/workflows/licensing.yml
+++ b/.github/workflows/licensing.yml
@@ -19,7 +19,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
-        fetch-depth: 0
 
     - uses: matrix-org/setup-python-poetry@5bbf6603c5c930615ec8a29f1b5d7d258d905aa4  # v2
       with:
@@ -41,6 +40,15 @@ jobs:
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
         reuse --version
         reuse spdx | ./scripts/spdx_checks.py
+
+  copyright-dates:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
 
 # REUSE-IgnoreStart
     - name: Copyright dates

--- a/.github/workflows/licensing.yml
+++ b/.github/workflows/licensing.yml
@@ -88,7 +88,7 @@ jobs:
             fi
         done
 
-        if [[ "$error_flag" == "true" ]]; then
+        if [ "$error_flag" = "true" ]; then
           echo "errors happened"
           exit 1
         else

--- a/newsfragments/466.internal.md
+++ b/newsfragments/466.internal.md
@@ -1,0 +1,1 @@
+Move job validating copyright date header into distinct workflow job.


### PR DESCRIPTION
So that failures are clearly identified in emails.

Also harmonise on `sh` for string comparisons rather than mixing `bash` and `sh`