### PR TITLE
Pin Helm to 3.17.3

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 New Vector Ltd
+# Copyright 2024-2025 New Vector Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -81,6 +81,9 @@ jobs:
 
 
     - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112  # v4.3.0
+      # Until https://github.com/helm/helm/issues/30878 / https://github.com/helm/helm/issues/30880 are fixed
+      with:
+        version: 3.17.3
 
     - name: Test with pytest
       run: |

--- a/newsfragments/468.internal.md
+++ b/newsfragments/468.internal.md
@@ -1,0 +1,1 @@
+Pin to Helm 3.17.3 in the integration tests.


### PR DESCRIPTION
We're seeing things like `Deployment.apps "ingress-nginx-controller" is invalid: spec.progressDeadlineSeconds: Invalid value: 0: must be greater than minReadySeconds` on some pytest runs same as https://github.com/helm/helm/issues/30878