### PR TITLE
tests: Verify that volume names in workloads specs are not too long

### DIFF
--- a/newsfragments/471.internal.md
+++ b/newsfragments/471.internal.md
@@ -1,0 +1,1 @@
+Add an internal test to check that the kubernetes volume name is not too long.

--- a/tests/manifests/test_volumes_mounts.py
+++ b/tests/manifests/test_volumes_mounts.py
@@ -18,6 +18,7 @@ async def test_volumes_mounts_exists(templates, other_secrets):
         if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
             volumes_names = []
             for volume in template["spec"]["template"]["spec"].get("volumes", []):
+                assert len(volume["name"]) <= 63, f"Volume name {volume['name']} is too long: {volume['name']}"
                 volumes_names.append(volume["name"])
                 if "secret" in volume:
                     assert volume["secret"]["secretName"] in secrets_names


### PR DESCRIPTION
This is a kubernetes requirement.