### PR TITLE
Add manifest test to ensure YAML/JSON written to ConfigMaps and Secrets is valid

### DIFF
--- a/newsfragments/480.internal.md
+++ b/newsfragments/480.internal.md
@@ -1,0 +1,1 @@
+Add manifest test to ensure YAML/JSON written to `ConfigMaps` and `Secrets` is valid.

--- a/tests/manifests/test_configs.py
+++ b/tests/manifests/test_configs.py
@@ -1,0 +1,30 @@
+# Copyright 2025 New Vector Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import base64
+import json
+
+import pytest
+import yaml
+
+from . import secret_values_files_to_test
+
+
+@pytest.mark.parametrize("values_file", secret_values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_configs_are_valid(templates):
+    for template in templates:
+        if template["kind"] not in ["ConfigMap", "Secret"]:
+            continue
+
+        if "data" not in template or not template["data"]:
+            continue
+        for key, value in template["data"].items():
+            if template["kind"] == "Secret":
+                value = base64.b64decode(value)
+
+            if key.endswith(".yaml") or key.endswith(".yml"):
+                assert yaml.safe_load(value) is not None
+            elif key.endswith(".json"):
+                assert json.loads(value) is not None


### PR DESCRIPTION
The only catches the chart controlled YAML/JSON (which includes user additional that's supplied in the Helm values file). It doesn't check the merged output but given `render-config` needs valid input this is fine