### PR TITLE
Image validation via schema

### DIFF
--- a/charts/matrix-stack/source/common/image.json
+++ b/charts/matrix-stack/source/common/image.json
@@ -3,6 +3,34 @@
   "required": [
     "repository"
   ],
+  "oneOf": [
+    {
+      "required": [
+        "tag",
+        "digest"
+      ]
+    },
+    {
+      "required": [
+        "digest"
+      ],
+      "not": {
+        "required": [
+          "tag"
+        ]
+      }
+    },
+    {
+      "required": [
+        "tag"
+      ],
+      "not": {
+        "required": [
+          "digest"
+        ]
+      }
+    }
+  ],
   "properties": {
     "registry": {
       "type": "string"
@@ -11,10 +39,16 @@
       "type": "string"
     },
     "tag": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "digest": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "pullPolicy": {
       "type": "string",

--- a/charts/matrix-stack/templates/element-web/deployment.yaml
+++ b/charts/matrix-stack/templates/element-web/deployment.yaml
@@ -61,7 +61,7 @@ spec:
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
         imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
 {{- else }}
-        image: "{{ .registry }}/{{ .repository }}:{{ required "elementWeb.image.tag is required if no digest" .tag }}"
+        image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
         imagePullPolicy: {{ .pullPolicy | default "Always" }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/ess-library/_labels.tpl
+++ b/charts/matrix-stack/templates/ess-library/_labels.tpl
@@ -1,10 +1,12 @@
 {{- /*
-Copyright 2024 New Vector Ltd
+Copyright 2024-2025 New Vector Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- define "element-io.ess-library.labels.makeSafe" -}}
+{{- if . -}}
 {{ . | replace  "+" "_" | trunc 63 | trimSuffix "-" | quote }}
+{{- end -}}
 {{- end -}}
 
 {{- define "element-io.ess-library.labels.common" -}}

--- a/charts/matrix-stack/templates/haproxy/deployment.yaml
+++ b/charts/matrix-stack/templates/haproxy/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2024 New Vector Ltd
+Copyright 2024-2025 New Vector Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -77,7 +77,7 @@ spec:
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
         imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
 {{- else }}
-        image: "{{ .registry }}/{{ .repository }}:{{ required "synapse.haproxy.image.tag is required if no digest" .tag }}"
+        image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
         imagePullPolicy: {{ .pullPolicy | default "Always" }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/init-secrets/job.yaml
+++ b/charts/matrix-stack/templates/init-secrets/job.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2024 New Vector Ltd
+Copyright 2024-2025 New Vector Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -45,7 +45,7 @@ spec:
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
         imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
 {{- else }}
-        image: "{{ .registry }}/{{ .repository }}:{{ required "matrixTools.image.tag is required if no digest" .tag }}"
+        image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
         imagePullPolicy: {{ .pullPolicy | default "Always" }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
@@ -70,7 +70,7 @@ spec:
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
         imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
 {{- else }}
-        image: "{{ .registry }}/{{ .repository }}:{{ required "matrixTools.image.tag is required if no digest" .tag }}"
+        image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
         imagePullPolicy: {{ .pullPolicy | default "Always" }}
 {{- end }}
 {{- end }}
@@ -118,7 +118,7 @@ spec:
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
         imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
 {{- else }}
-        image: "{{ .registry }}/{{ .repository }}:{{ required "matrixTools.image.tag is required if no digest" .tag }}"
+        image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
         imagePullPolicy: {{ .pullPolicy | default "Always" }}
 {{- end }}
 {{- end }}
@@ -142,7 +142,7 @@ spec:
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
         imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
 {{- else }}
-        image: "{{ .registry }}/{{ .repository }}:{{ required "matrixAuthenticationService.image.tag is required if no digest" .tag }}"
+        image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
         imagePullPolicy: {{ .pullPolicy | default "Always" }}
 {{- end }}
 {{- end }}
@@ -174,7 +174,7 @@ spec:
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
         imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
 {{- else }}
-        image: "{{ .registry }}/{{ .repository }}:{{ required "matrixAuthenticationService.image.tag is required if no digest" .tag }}"
+        image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
         imagePullPolicy: {{ .pullPolicy | default "Always" }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2024 New Vector Ltd
+Copyright 2024-2025 New Vector Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -53,7 +53,7 @@ spec:
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
         imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
 {{- else }}
-        image: "{{ .registry }}/{{ .repository }}:{{ required "matrixTools.image.tag is required if no digest" .tag }}"
+        image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
         imagePullPolicy: {{ .pullPolicy | default "Always" }}
 {{- end }}
 {{- end }}
@@ -115,7 +115,7 @@ spec:
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
         imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
 {{- else }}
-        image: "{{ .registry }}/{{ .repository }}:{{ required ".matrixRTC.sfu.image.tag is required if no digest" .tag }}"
+        image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
         imagePullPolicy: {{ .pullPolicy | default "Always" }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_jwt_deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2024 New Vector Ltd
+Copyright 2024-2025 New Vector Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -50,7 +50,7 @@ spec:
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
         imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
 {{- else }}
-        image: "{{ .registry }}/{{ .repository }}:{{ required ".matrixRTC.image.tag is required if no digest" .tag }}"
+        image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
         imagePullPolicy: {{ .pullPolicy | default "Always" }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/_synapse_pod.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_pod.tpl
@@ -66,7 +66,7 @@ We have an init container to render & merge the config for several reasons:
       image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
       imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
 {{- else }}
-      image: "{{ .registry }}/{{ .repository }}:{{ required "matrixTools.image.tag is required if no digest" .tag }}"
+      image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
       imagePullPolicy: {{ .pullPolicy | default "Always" }}
 {{- end }}
 {{- end }}
@@ -121,7 +121,7 @@ We have an init container to render & merge the config for several reasons:
       image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
       imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
 {{- else }}
-      image: "{{ .registry }}/{{ .repository }}:{{ required "matrixTools.image.tag is required if no digest" .tag }}"
+      image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
       imagePullPolicy: {{ .pullPolicy | default "Always" }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/redis_deployment.yaml
+++ b/charts/matrix-stack/templates/synapse/redis_deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2024 New Vector Ltd
+Copyright 2024-2025 New Vector Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -50,7 +50,7 @@ spec:
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
         imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
 {{- else }}
-        image: "{{ .registry }}/{{ .repository }}:{{ required "synapse.redis.image.tag is required if no digest" .tag }}"
+        image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
         imagePullPolicy: {{ .pullPolicy | default "Always" }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -39,6 +39,34 @@
           "required": [
             "repository"
           ],
+          "oneOf": [
+            {
+              "required": [
+                "tag",
+                "digest"
+              ]
+            },
+            {
+              "required": [
+                "digest"
+              ],
+              "not": {
+                "required": [
+                  "tag"
+                ]
+              }
+            },
+            {
+              "required": [
+                "tag"
+              ],
+              "not": {
+                "required": [
+                  "digest"
+                ]
+              }
+            }
+          ],
           "properties": {
             "registry": {
               "type": "string"
@@ -47,10 +75,16 @@
               "type": "string"
             },
             "tag": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "digest": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pullPolicy": {
               "type": "string",
@@ -615,6 +649,34 @@
           "required": [
             "repository"
           ],
+          "oneOf": [
+            {
+              "required": [
+                "tag",
+                "digest"
+              ]
+            },
+            {
+              "required": [
+                "digest"
+              ],
+              "not": {
+                "required": [
+                  "tag"
+                ]
+              }
+            },
+            {
+              "required": [
+                "tag"
+              ],
+              "not": {
+                "required": [
+                  "digest"
+                ]
+              }
+            }
+          ],
           "properties": {
             "registry": {
               "type": "string"
@@ -623,10 +685,16 @@
               "type": "string"
             },
             "tag": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "digest": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pullPolicy": {
               "type": "string",
@@ -1177,6 +1245,34 @@
               "required": [
                 "repository"
               ],
+              "oneOf": [
+                {
+                  "required": [
+                    "tag",
+                    "digest"
+                  ]
+                },
+                {
+                  "required": [
+                    "digest"
+                  ],
+                  "not": {
+                    "required": [
+                      "tag"
+                    ]
+                  }
+                },
+                {
+                  "required": [
+                    "tag"
+                  ],
+                  "not": {
+                    "required": [
+                      "digest"
+                    ]
+                  }
+                }
+              ],
               "properties": {
                 "registry": {
                   "type": "string"
@@ -1185,10 +1281,16 @@
                   "type": "string"
                 },
                 "tag": {
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "digest": {
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "pullPolicy": {
                   "type": "string",
@@ -1738,6 +1840,34 @@
           "required": [
             "repository"
           ],
+          "oneOf": [
+            {
+              "required": [
+                "tag",
+                "digest"
+              ]
+            },
+            {
+              "required": [
+                "digest"
+              ],
+              "not": {
+                "required": [
+                  "tag"
+                ]
+              }
+            },
+            {
+              "required": [
+                "tag"
+              ],
+              "not": {
+                "required": [
+                  "digest"
+                ]
+              }
+            }
+          ],
           "properties": {
             "registry": {
               "type": "string"
@@ -1746,10 +1876,16 @@
               "type": "string"
             },
             "tag": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "digest": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pullPolicy": {
               "type": "string",
@@ -2298,6 +2434,34 @@
           "required": [
             "repository"
           ],
+          "oneOf": [
+            {
+              "required": [
+                "tag",
+                "digest"
+              ]
+            },
+            {
+              "required": [
+                "digest"
+              ],
+              "not": {
+                "required": [
+                  "tag"
+                ]
+              }
+            },
+            {
+              "required": [
+                "tag"
+              ],
+              "not": {
+                "required": [
+                  "digest"
+                ]
+              }
+            }
+          ],
           "properties": {
             "registry": {
               "type": "string"
@@ -2306,10 +2470,16 @@
               "type": "string"
             },
             "tag": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "digest": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pullPolicy": {
               "type": "string",
@@ -3064,6 +3234,34 @@
           "required": [
             "repository"
           ],
+          "oneOf": [
+            {
+              "required": [
+                "tag",
+                "digest"
+              ]
+            },
+            {
+              "required": [
+                "digest"
+              ],
+              "not": {
+                "required": [
+                  "tag"
+                ]
+              }
+            },
+            {
+              "required": [
+                "tag"
+              ],
+              "not": {
+                "required": [
+                  "digest"
+                ]
+              }
+            }
+          ],
           "properties": {
             "registry": {
               "type": "string"
@@ -3072,10 +3270,16 @@
               "type": "string"
             },
             "tag": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "digest": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pullPolicy": {
               "type": "string",
@@ -3603,6 +3807,34 @@
           "required": [
             "repository"
           ],
+          "oneOf": [
+            {
+              "required": [
+                "tag",
+                "digest"
+              ]
+            },
+            {
+              "required": [
+                "digest"
+              ],
+              "not": {
+                "required": [
+                  "tag"
+                ]
+              }
+            },
+            {
+              "required": [
+                "tag"
+              ],
+              "not": {
+                "required": [
+                  "digest"
+                ]
+              }
+            }
+          ],
           "properties": {
             "registry": {
               "type": "string"
@@ -3611,10 +3843,16 @@
               "type": "string"
             },
             "tag": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "digest": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pullPolicy": {
               "type": "string",
@@ -3647,6 +3885,34 @@
               "required": [
                 "repository"
               ],
+              "oneOf": [
+                {
+                  "required": [
+                    "tag",
+                    "digest"
+                  ]
+                },
+                {
+                  "required": [
+                    "digest"
+                  ],
+                  "not": {
+                    "required": [
+                      "tag"
+                    ]
+                  }
+                },
+                {
+                  "required": [
+                    "tag"
+                  ],
+                  "not": {
+                    "required": [
+                      "digest"
+                    ]
+                  }
+                }
+              ],
               "properties": {
                 "registry": {
                   "type": "string"
@@ -3655,10 +3921,16 @@
                   "type": "string"
                 },
                 "tag": {
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "digest": {
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "pullPolicy": {
                   "type": "string",
@@ -4867,6 +5139,34 @@
           "required": [
             "repository"
           ],
+          "oneOf": [
+            {
+              "required": [
+                "tag",
+                "digest"
+              ]
+            },
+            {
+              "required": [
+                "digest"
+              ],
+              "not": {
+                "required": [
+                  "tag"
+                ]
+              }
+            },
+            {
+              "required": [
+                "tag"
+              ],
+              "not": {
+                "required": [
+                  "digest"
+                ]
+              }
+            }
+          ],
           "properties": {
             "registry": {
               "type": "string"
@@ -4875,10 +5175,16 @@
               "type": "string"
             },
             "tag": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "digest": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pullPolicy": {
               "type": "string",
@@ -9824,6 +10130,34 @@
               "required": [
                 "repository"
               ],
+              "oneOf": [
+                {
+                  "required": [
+                    "tag",
+                    "digest"
+                  ]
+                },
+                {
+                  "required": [
+                    "digest"
+                  ],
+                  "not": {
+                    "required": [
+                      "tag"
+                    ]
+                  }
+                },
+                {
+                  "required": [
+                    "tag"
+                  ],
+                  "not": {
+                    "required": [
+                      "digest"
+                    ]
+                  }
+                }
+              ],
               "properties": {
                 "registry": {
                   "type": "string"
@@ -9832,10 +10166,16 @@
                   "type": "string"
                 },
                 "tag": {
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "digest": {
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "pullPolicy": {
                   "type": "string",

--- a/newsfragments/484.changed.md
+++ b/newsfragments/484.changed.md
@@ -1,0 +1,1 @@
+Improve the validation that for every image the tag and/or the digest is set.

--- a/newsfragments/484.internal.md
+++ b/newsfragments/484.internal.md
@@ -1,0 +1,1 @@
+Make it easier to write manifest tests where sub-components and sidecars read values from their parent component.

--- a/tests/manifests/test_labels.py
+++ b/tests/manifests/test_labels.py
@@ -66,10 +66,10 @@ async def test_templates_have_postgres_hash_label(release_name, templates, value
                 continue
 
             assert "k8s.element.io/postgres-password-hash" in labels, f"{id} does not have postgres password hash label"
-            assert (
-                len(deployable_details.helm_keys) == 1
-            )  # We currently assume that Postgres is for top-level components only
-            helm_key = deployable_details.helm_keys[0]
+            # We currently assume that Postgres is for top-level components only and so there is a single segment
+            # write (or read) path
+            assert len(deployable_details.values_file_path.write_path) == 1
+            helm_key = deployable_details.values_file_path.read_path[0]
             values_fragment = deployable_details.get_helm_values(values, PropertyType.Postgres)
             if values_fragment.get("password", {}).get("value", None):
                 expected = values_fragment["password"]["value"]

--- a/tests/manifests/test_pod_images.py
+++ b/tests/manifests/test_pod_images.py
@@ -1,0 +1,147 @@
+# Copyright 2025 New Vector Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import pytest
+
+from . import DeployableDetails, PropertyType, values_files_to_test
+from .utils import iterate_deployables_parts, template_id
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_pods_with_tags_and_no_digests(release_name, values, make_templates, template_to_deployable_details):
+    counter = 1
+    matrix_tools_marker = f"matrix-tools-marker={release_name}"
+    values.setdefault("matrixTools", {}).setdefault("image", {}).update(
+        {"repository": matrix_tools_marker, "tag": f"image-tag-{counter}", "digest": None}
+    )
+
+    def set_tag(deployable_details: DeployableDetails):
+        nonlocal counter
+        counter += 1
+        deployable_details.set_helm_values(values, PropertyType.Image, {"tag": f"image-tag-{counter}", "digest": None})
+
+    iterate_deployables_parts(set_tag, lambda deployable_details: deployable_details.has_image)
+    for template in await make_templates(values):
+        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+            deployable_details = template_to_deployable_details(template)
+            if deployable_details.has_image:
+                expected_image_values = deployable_details.get_helm_values(values, PropertyType.Image)
+            else:
+                expected_image_values = values["matrixTools"]["image"]
+            assert template["metadata"]["labels"]["app.kubernetes.io/version"] == expected_image_values["tag"]
+
+            pod_template = template["spec"]["template"]
+            assert pod_template["metadata"]["labels"]["app.kubernetes.io/version"] == expected_image_values["tag"]
+
+            for container in pod_template["spec"].get("initContainers", []) + pod_template["spec"]["containers"]:
+                assert "image" in container, f"{template_id(template)} has container {container['name']} without image"
+
+                deployable_details = template_to_deployable_details(template, container["name"])
+                container_image = container["image"]
+                if deployable_details.has_image and f"/{matrix_tools_marker}:" not in container_image:
+                    expected_image_values = deployable_details.get_helm_values(values, PropertyType.Image)
+                else:
+                    expected_image_values = values["matrixTools"]["image"]
+
+                assert expected_image_values["tag"] == container["image"].split(":")[1], (
+                    f"{template_id(template)} has container {container['name']} "
+                    "which doesn't have the expected image tag"
+                )
+                assert container["imagePullPolicy"] == "Always"
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_pods_with_digests_and_tags(release_name, values, make_templates, template_to_deployable_details):
+    counter = 1
+    matrix_tools_marker = f"matrix-tools-marker={release_name}"
+    values.setdefault("matrixTools", {}).setdefault("image", {}).update(
+        {
+            "repository": matrix_tools_marker,
+            "tag": f"image-tag-{counter}",
+            "digest": f"sha256:digest{counter}",
+        }
+    )
+
+    def set_tag(deployable_details: DeployableDetails):
+        nonlocal counter
+        counter += 1
+        deployable_details.set_helm_values(
+            values, PropertyType.Image, {"tag": f"image-tag-{counter}", "digest": f"sha256:digest{counter}"}
+        )
+
+    iterate_deployables_parts(set_tag, lambda deployable_details: deployable_details.has_image)
+    for template in await make_templates(values):
+        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+            deployable_details = template_to_deployable_details(template)
+            if deployable_details.has_image:
+                expected_image_values = deployable_details.get_helm_values(values, PropertyType.Image)
+            else:
+                expected_image_values = values["matrixTools"]["image"]
+            assert template["metadata"]["labels"]["app.kubernetes.io/version"] == expected_image_values["tag"]
+
+            pod_template = template["spec"]["template"]
+            assert pod_template["metadata"]["labels"]["app.kubernetes.io/version"] == expected_image_values["tag"]
+
+            for container in pod_template["spec"].get("initContainers", []) + pod_template["spec"]["containers"]:
+                assert "image" in container, f"{template_id(template)} has container {container['name']} without image"
+
+                deployable_details = template_to_deployable_details(template, container["name"])
+                container_image = container["image"]
+                if deployable_details.has_image and f"/{matrix_tools_marker}@sha256" not in container_image:
+                    expected_image_values = deployable_details.get_helm_values(values, PropertyType.Image)
+                else:
+                    expected_image_values = values["matrixTools"]["image"]
+
+                assert expected_image_values["digest"] == container["image"].split("@")[1], (
+                    f"{template_id(template)} has container {container['name']} "
+                    "which doesn't have the expected image digest"
+                )
+                assert container["imagePullPolicy"] == "IfNotPresent"
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_pods_with_digest_and_no_tags(release_name, values, make_templates, template_to_deployable_details):
+    counter = 1
+    matrix_tools_marker = f"matrix-tools-marker={release_name}"
+    values.setdefault("matrixTools", {}).setdefault("image", {}).update(
+        {
+            "repository": matrix_tools_marker,
+            "tag": None,
+            "digest": f"sha256:digest{counter}",
+        }
+    )
+
+    def set_tag(deployable_details: DeployableDetails):
+        nonlocal counter
+        counter += 1
+        deployable_details.set_helm_values(
+            values, PropertyType.Image, {"tag": None, "digest": f"sha256:digest{counter}"}
+        )
+
+    iterate_deployables_parts(set_tag, lambda deployable_details: deployable_details.has_image)
+    for template in await make_templates(values):
+        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+            assert template["metadata"]["labels"]["app.kubernetes.io/version"] is None
+
+            pod_template = template["spec"]["template"]
+            assert pod_template["metadata"]["labels"]["app.kubernetes.io/version"] is None
+
+            for container in pod_template["spec"].get("initContainers", []) + pod_template["spec"]["containers"]:
+                assert "image" in container, f"{template_id(template)} has container {container['name']} without image"
+
+                deployable_details = template_to_deployable_details(template, container["name"])
+                container_image = container["image"]
+                if deployable_details.has_image and f"/{matrix_tools_marker}@sha256" not in container_image:
+                    expected_image_values = deployable_details.get_helm_values(values, PropertyType.Image)
+                else:
+                    expected_image_values = values["matrixTools"]["image"]
+
+                assert expected_image_values["digest"] == container["image"].split("@")[1], (
+                    f"{template_id(template)} has container {container['name']} "
+                    "which doesn't have the expected image digest"
+                )
+                assert container["imagePullPolicy"] == "IfNotPresent"


### PR DESCRIPTION
Enforce setting the image tag and/or image digest in the schema. It is not acceptable to unset both.

The 1st commit is an internal test refactor to allow us to read Helm values from elsewhere in the values file. This means that sub-components and sidecars can now express that they don't support setting e.g. images themselves but they do have an image sourced from the parent component. This means that the manifest tests don't need to construct mappings of `DeployableDetails` to expected values, they can simply be fetched. Several tests are simplified and some exceptions removed as a result

The 2nd commit does the schema tightening and adds a test that images are passed through correctly