### PR TITLE
Validate external Postgres via schema

### DIFF
--- a/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
@@ -43,10 +43,10 @@ database:
   name: psycopg2
   args:
 {{- if .postgres }}
-    user: {{ required "Synapse requires postgres.user set" .postgres.user }}
+    user: {{ .postgres.user }}
     password: ${SYNAPSE_POSTGRES_PASSWORD}
-    database: {{ required "Synapse requires postgres.database set" .postgres.database }}
-    host: {{ required "Synapse requires postgres.host set" (tpl .postgres.host $root) }}
+    database: {{ .postgres.database }}
+    host: {{ (tpl .postgres.host $root) }}
     port: {{ .postgres.port | default 5432 }}
     sslmode: {{ .postgres.sslMode | default "prefer" }}
 {{- else if $root.Values.postgres.enabled }}

--- a/charts/matrix-stack/source/common/postgres-libpq.json
+++ b/charts/matrix-stack/source/common/postgres-libpq.json
@@ -1,5 +1,10 @@
 {
   "type": "object",
+  "required": [
+    "host",
+    "user",
+    "database"
+  ],
   "properties": {
     "host": {
       "type": "string"

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -257,8 +257,9 @@ labels: {}
 {%- endmacro %}
 
 {% macro postgresLibPQ(key="postgres") %}
-## Details of the Postgres Database to use
-{{ key }}: {}
+## Details of the external Postgres Database to use
+## Does not need to be set if postgres.enabled=True
+# {{ key }}:
   ## PostgreSQL database host
   # host:
 

--- a/charts/matrix-stack/templates/ess-library/_labels.tpl
+++ b/charts/matrix-stack/templates/ess-library/_labels.tpl
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2024 New Vector Ltd
+Copyright 2024-2025 New Vector Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -38,7 +38,7 @@ app.kubernetes.io/part-of: matrix-stack
 {{- $root := .root -}}
 {{- with required "element-io.ess-library.postgres-label requires context" .context -}}
 {{- $essPassword := required "element-io.ess-library.postgres-label context missing essPassword" .essPassword -}}
-{{- $postgresProperty := required "elment-io.ess-library.postgres-label context missing postgresProperty" .postgresProperty -}}
+{{- $postgresProperty := .postgresProperty -}}
 k8s.element.io/postgres-password-hash: {{ if $postgresProperty -}}
     {{- if $postgresProperty.password.value -}}
     {{- $postgresProperty.password.value | sha1sum -}}

--- a/charts/matrix-stack/templates/matrix-authentication-service/_helpers.tpl
+++ b/charts/matrix-stack/templates/matrix-authentication-service/_helpers.tpl
@@ -214,7 +214,7 @@ config.yaml: |
 {{- end }}
 {{- end }}
 {{- end }}
-{{- with .postgres.password }}
+{{- with (.postgres).password }}
 {{- include "element-io.ess-library.check-credential" (dict "root" $root "context" (dict "secretPath" "matrixAuthenticationService.postgres.password" "initIfAbsent" false)) }}
 {{- with .value }}
   POSTGRES_PASSWORD: {{ . | b64enc }}

--- a/charts/matrix-stack/templates/synapse/_synapse_secret.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_secret.tpl
@@ -32,7 +32,7 @@ data:
 {{- with .macaroon.value }}
   MACAROON: {{ . | b64enc }}
 {{- end }}
-{{- with .postgres.password }}
+{{- with (.postgres).password }}
 {{- include "element-io.ess-library.check-credential" (dict "root" $root "context" (dict "secretPath" "synapse.postgres.password" "initIfAbsent" false)) -}}
 {{- with .value }}
   POSTGRES_PASSWORD: {{ . | b64enc }}

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -2900,6 +2900,11 @@
         },
         "postgres": {
           "type": "object",
+          "required": [
+            "host",
+            "user",
+            "database"
+          ],
           "properties": {
             "host": {
               "type": "string"
@@ -4506,6 +4511,11 @@
         },
         "postgres": {
           "type": "object",
+          "required": [
+            "host",
+            "user",
+            "database"
+          ],
           "properties": {
             "host": {
               "type": "string"

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -1225,8 +1225,9 @@ matrixAuthenticationService:
   preMigrationSynapseHandlesAuth: false
 
 
-  ## Details of the Postgres Database to use
-  postgres: {}
+  ## Details of the external Postgres Database to use
+  ## Does not need to be set if postgres.enabled=True
+  # postgres:
     ## PostgreSQL database host
     # host:
 
@@ -1982,8 +1983,9 @@ synapse:
 
       ## Annotations to add to the service account
       annotations: {}
-  ## Details of the Postgres Database to use
-  postgres: {}
+  ## Details of the external Postgres Database to use
+  ## Does not need to be set if postgres.enabled=True
+  # postgres:
     ## PostgreSQL database host
     # host:
 

--- a/newsfragments/485.changed.md
+++ b/newsfragments/485.changed.md
@@ -1,0 +1,1 @@
+Improve the validation on set properties for external Postgreses.


### PR DESCRIPTION
Add validation on the external Postgres details via schema so that all Postgres using components get the same level of validation. i.e. MAS wasn't validating `host`/`database`/`user` for external Postgres