### PR TITLE
Improve validation messages for values that are templated.

### DIFF
--- a/charts/matrix-stack/configs/matrix-authentication-service/config.yaml.tpl
+++ b/charts/matrix-stack/configs/matrix-authentication-service/config.yaml.tpl
@@ -42,8 +42,6 @@ database:
 {{- end }}
 {{- else if $root.Values.postgres.enabled }}
   uri: "postgresql://matrixauthenticationservice_user:${POSTGRES_PASSWORD}@{{ $root.Release.Name }}-postgres.{{ $root.Release.Namespace }}.svc.cluster.local:5432/matrixauthenticationservice?sslmode=prefer&application_name=matrix-authentication-service"
-{{ else }}
-  {{ fail "MAS requires matrixAuthenticationService.postgres.* to be configured, or the internal chart Postgres to be enabled with postgres.enabled: true" }}
 {{ end }}
 
 telemetry:

--- a/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- with required "synapse/synapse-04-homeserver-overrides.yaml.tpl missing context" .context }}
 {{- $isHook := required "element-io.synapse.config.shared-overrides requires context.isHook" .isHook -}}
 public_baseurl: https://{{ tpl .ingress.host $root }}/
-server_name: {{ tpl (required "Synapse requires serverName set" $root.Values.serverName) $root }}
+server_name: {{ tpl $root.Values.serverName $root }}
 signing_key_path: /secrets/{{
   include "element-io.ess-library.init-secret-path" (
     dict "root" $root "context" (
@@ -56,8 +56,6 @@ database:
     host: "{{ $root.Release.Name }}-postgres.{{ $root.Release.Namespace }}.svc.cluster.local"
     port: 5432
     sslmode: prefer
-{{ else }}
-  {{ fail "Synapse requires synapse.postgres.* to be configured, or the internal chart Postgres to be enabled with postgres.enabled: true" }}
 {{ end }}
 
     application_name: ${APPLICATION_NAME}

--- a/charts/matrix-stack/configs/well-known/partial-haproxy.cfg.tpl
+++ b/charts/matrix-stack/configs/well-known/partial-haproxy.cfg.tpl
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2024 New Vector Ltd
+Copyright 2024-2025 New Vector Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -24,7 +24,7 @@ frontend well-known-in
 {{ if .baseDomainRedirect.enabled }}
 {{- if $root.Values.elementWeb.enabled }}
 {{- with $root.Values.elementWeb }}
-{{- $elementWebHttps := include "element-io.ess-library.ingress.tlsHostsSecret" (dict "root" $root "context" (dict "hosts" (list (required "elementWeb.ingress.host is required" .ingress.host)) "tlsSecret" .ingress.tlsSecret "ingressName" "element-web")) }}
+{{- $elementWebHttps := include "element-io.ess-library.ingress.tlsHostsSecret" (dict "root" $root "context" (dict "hosts" (list .ingress.host) "tlsSecret" .ingress.tlsSecret "ingressName" "element-web")) }}
   http-request redirect  code 301  location http{{ if $elementWebHttps }}s{{ end }}://{{ tpl .ingress.host $root }} unless well-known
 {{- end }}
 {{- else if .baseDomainRedirect.url }}

--- a/charts/matrix-stack/templates/element-web/_helpers.tpl
+++ b/charts/matrix-stack/templates/element-web/_helpers.tpl
@@ -1,8 +1,19 @@
 {{- /*
-Copyright 2024 New Vector Ltd
+Copyright 2024-2025 New Vector Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
+
+{{- define "element-io.element-web.validations" }}
+{{- $root := .root -}}
+{{- with required "element-io.element-web.validations missing context" .context -}}
+{{ $messages := list }}
+{{- if not .ingress.host -}}
+{{ $messages = append $messages "elementWeb.ingress.host is required when elementWeb.enabled=true" }}
+{{- end }}
+{{ $messages | toJson }}
+{{- end }}
+{{- end }}
 
 {{- define "element-io.element-web.labels" -}}
 {{- $root := .root -}}

--- a/charts/matrix-stack/templates/matrix-authentication-service/_helpers.tpl
+++ b/charts/matrix-stack/templates/matrix-authentication-service/_helpers.tpl
@@ -4,6 +4,20 @@ Copyright 2025 New Vector Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 
+{{- define "element-io.matrix-authentication-service.validations" }}
+{{- $root := .root -}}
+{{- with required "element-io.matrix-authentication-service.validations missing context" .context -}}
+{{ $messages := list }}
+{{- if not .ingress.host -}}
+{{ $messages = append $messages "matrixAuthenticationService.ingress.host is required when matrixAuthenticationService.enabled=true" }}
+{{- end }}
+{{- if and (not $root.Values.postgres.enabled) (not .postgres) -}}
+{{ $messages = append $messages "matrixAuthenticationService.postgres is required when matrixAuthenticationService.enabled=true but postgres.enabled=false" }}
+{{- end }}
+{{ $messages | toJson }}
+{{- end }}
+{{- end }}
+
 {{- define "element-io.matrix-authentication-service.labels" -}}
 {{- $root := .root -}}
 {{- with required "element-io.matrix-authentication-service.labels missing context" .context -}}

--- a/charts/matrix-stack/templates/matrix-rtc/_helpers.tpl
+++ b/charts/matrix-stack/templates/matrix-rtc/_helpers.tpl
@@ -4,6 +4,17 @@ Copyright 2024-2025 New Vector Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 
+{{- define "element-io.matrix-rtc.validations" }}
+{{- $root := .root -}}
+{{- with required "element-io.matrix-rtc.validations missing context" .context -}}
+{{ $messages := list }}
+{{- if not .ingress.host -}}
+{{ $messages = append $messages "matrixRTC.ingress.host is required when matrixRTC.enabled=true" }}
+{{- end }}
+{{ $messages | toJson }}
+{{- end }}
+{{- end }}
+
 {{- define "element-io.matrix-rtc-ingress.labels" -}}
 {{- $root := .root -}}
 {{- with required "element-io.matrix-rtc.labels missing context" .context -}}

--- a/charts/matrix-stack/templates/synapse/_helpers.tpl
+++ b/charts/matrix-stack/templates/synapse/_helpers.tpl
@@ -1,8 +1,25 @@
 {{- /*
-Copyright 2024 New Vector Ltd
+Copyright 2024-2025 New Vector Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
+
+{{- define "element-io.synapse.validations" }}
+{{ $root := .root }}
+{{- with required "element-io.synapse.validations missing context" .context -}}
+{{ $messages := list }}
+{{- if not .ingress.host -}}
+{{ $messages = append $messages "synapse.ingress.host is required when synapse.enabled=true" }}
+{{- end }}
+{{- if not $root.Values.serverName -}}
+{{ $messages = append $messages "serverName is required when synapse.enabled=true" }}
+{{- end }}
+{{- if and (not $root.Values.postgres.enabled) (not .postgres) -}}
+{{ $messages = append $messages "synapse.postgres is required when synapse.enabled=true but postgres.enabled=false" }}
+{{- end }}
+{{ $messages | toJson }}
+{{- end }}
+{{- end }}
 
 {{- define "element-io.synapse.labels" -}}
 {{- $root := .root -}}

--- a/charts/matrix-stack/templates/well-known/_helpers.tpl
+++ b/charts/matrix-stack/templates/well-known/_helpers.tpl
@@ -1,8 +1,19 @@
 {{- /*
-Copyright 2024 New Vector Ltd
+Copyright 2024-2025 New Vector Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
+
+{{- define "element-io.well-known-delegation.validations" }}
+{{ $root := .root }}
+{{- with required "element-io.well-known-delegation.validations missing context" .context -}}
+{{- $messages := list }}
+{{- if not $root.Values.serverName -}}
+{{ $messages = append $messages "serverName is required when wellKnownDelegation.enabled=true" }}
+{{- end }}
+{{ $messages | toJson }}
+{{- end }}
+{{- end }}
 
 {{- define "element-io.well-known-delegation.labels" -}}
 {{- $root := .root -}}

--- a/charts/matrix-stack/templates/z_validation/validation.txt
+++ b/charts/matrix-stack/templates/z_validation/validation.txt
@@ -1,0 +1,41 @@
+{{- /*
+Copyright 2025 New Vector Ltd
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/ -}}
+
+{{ $messages := list }}
+
+{{- with $.Values.elementWeb }}
+{{- if .enabled }}
+{{- $messages = concat $messages (include "element-io.element-web.validations" (dict "root" $ "context" .) | fromJsonArray) }}
+{{- end }}
+{{- end }}
+
+{{- with $.Values.matrixAuthenticationService }}
+{{- if .enabled }}
+{{- $messages = concat $messages (include "element-io.matrix-authentication-service.validations" (dict "root" $ "context" .) | fromJsonArray) }}
+{{- end }}
+{{- end }}
+
+{{- with $.Values.matrixRTC }}
+{{- if .enabled }}
+{{- $messages = concat $messages (include "element-io.matrix-rtc.validations" (dict "root" $ "context" .) | fromJsonArray) }}
+{{- end }}
+{{- end }}
+
+{{- with $.Values.synapse }}
+{{- if .enabled }}
+{{- $messages = concat $messages (include "element-io.synapse.validations" (dict "root" $ "context" .) | fromJsonArray) }}
+{{- end }}
+{{- end }}
+
+{{- with $.Values.wellKnownDelegation }}
+{{- if .enabled }}
+{{- $messages = concat $messages (include "element-io.well-known-delegation.validations" (dict "root" $ "context" .) | fromJsonArray) }}
+{{- end }}
+{{- end }}
+
+{{- if gt (len $messages) 0 }}
+{{ fail (printf "\n- %s" ($messages | join "\n- " )) }}
+{{- end }}

--- a/newsfragments/497.changed.md
+++ b/newsfragments/497.changed.md
@@ -1,0 +1,1 @@
+Improve validation messages for values that are templated.


### PR DESCRIPTION
If we have values that are passed to `tpl` but are absent we get appalling errors, even if other templates `require` them. Add a blank template that is evaluated first that collects basic validation errors and if any are present `fail`s prior to `tpl` being called.

Before:

`$ helm template ess charts/matrix-stack`
> Error: template: matrix-stack/templates/well-known/ingress.yaml:18:4: executing "matrix-stack/templates/well-known/ingress.yaml" at <include "element-io.ess-library.ingress.tls" (dict "root" $ "context" (dict "host" $.Values.serverName "ingress" .ingress "ingressName" "well-known"))>: error calling include: template: matrix-stack/templates/ess-library/_ingress.tpl:42:10: executing "element-io.ess-library.ingress.tls" at <include "element-io.ess-library.ingress.tlsHostsSecret" (dict "root" $root "context" (dict "hosts" (list $host) "tlsSecret" $ingress.tlsSecret "ingressName" $ingressName))>: error calling include: template: matrix-stack/templates/ess-library/_ingress.tpl:57:12: executing "element-io.ess-library.ingress.tlsHostsSecret" at <$host>: wrong type for value; expected string; got interface {}
> 
> Use --debug flag to render out invalid YAML

After:
`$ helm template ess charts/matrix-stack`

> Error: execution error at (matrix-stack/templates/z_validation/validation.txt:40:3): 
> - elementWeb.ingress.host is required when elementWeb.enabled=true
> - matrixAuthenticationService.ingress.host is required when matrixAuthenticationService.enabled=true
> - matrixRTC.ingress.host is required when matrixRTC.enabled=true
> - synapse.ingress.host is required when synapse.enabled=true
> - serverName is required when synapse.enabled=true
> - serverName is required when wellKnownDelegation.enabled=true
> 
> Use --debug flag to render out invalid YAML
