### PR TITLE
Consistently use template_id helper for identifying manifests.

### DIFF
--- a/newsfragments/500.internal.md
+++ b/newsfragments/500.internal.md
@@ -1,0 +1,1 @@
+Consistently use template_id helper for identifying manifests.

--- a/tests/manifests/test_configs_and_mounts_consistency.py
+++ b/tests/manifests/test_configs_and_mounts_consistency.py
@@ -8,7 +8,7 @@ import re
 import pytest
 
 from . import secret_values_files_to_test, values_files_to_test
-from .utils import get_or_empty, template_to_deployable_details
+from .utils import get_or_empty, template_id, template_to_deployable_details
 
 
 def get_configmap(templates, configmap_name):
@@ -109,8 +109,7 @@ def get_key_from_render_config(template):
                 if cmd == "-output":
                     return container["command"][idx + 1].split("/")[-1]
     raise AssertionError(
-        f"{template['kind']}/{template['metadata']['name']} has a rendered-config volume, "
-        "but no render-config output file could be found"
+        f"{template_id(template)} has a rendered-config volume, but no render-config output file could be found"
     )
 
 
@@ -197,9 +196,7 @@ def get_keys_from_container_using_rendered_config(template, templates, other_sec
                     parent, keys = get_mounts_part(configmap, volume_mount)
                     mounted_keys += keys
                     mounted_keys_to_parents.update({k: parent for k in keys})
-    assert len(mounted_keys) > 0, (
-        f"No secret or config map is mounted in the template {template['kind']}/{template['metadata']['name']}"
-    )
+    assert len(mounted_keys) > 0, f"No secret or config map is mounted in the template {template_id(template)}"
     return mounted_keys, mounted_keys_to_parents
 
 
@@ -361,7 +358,7 @@ async def test_secrets_consistency(templates, other_secrets):
                 for cm in mounted_config_maps:
                     for data, content in cm["data"].items():
                         if find_mount_paths_and_assert_key_is_consistent(
-                            f"configmap {cm['metadata']['name']}/{data} mounted in {container['name']}",
+                            f"{template_id(cm)}/{data} mounted in {container['name']}",
                             mounted_keys,
                             mounted_keys_to_parents[mounted_key],
                             [content],

--- a/tests/manifests/test_pod_securityContext.py
+++ b/tests/manifests/test_pod_securityContext.py
@@ -5,7 +5,7 @@
 import pytest
 
 from . import PropertyType, values_files_to_test
-from .utils import iterate_deployables_workload_parts
+from .utils import iterate_deployables_workload_parts, template_id
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -13,7 +13,7 @@ from .utils import iterate_deployables_workload_parts
 async def test_sets_nonRoot_uids_gids_in_pod_securityContext_by_default(templates):
     for template in templates:
         if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = f"{template['kind']}/{template['metadata']['name']}"
+            id = template_id(template)
 
             assert "securityContext" in template["spec"]["template"]["spec"], (
                 f"Pod securityContext unexpectedly absent for {id}"
@@ -47,7 +47,7 @@ async def test_can_nuke_pod_securityContext_ids(values, make_templates):
 
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = f"{template['kind']}/{template['metadata']['name']}"
+            id = template_id(template)
 
             assert "securityContext" in template["spec"]["template"]["spec"], (
                 f"Pod securityContext unexpectedly absent for {id}"
@@ -64,7 +64,7 @@ async def test_can_nuke_pod_securityContext_ids(values, make_templates):
 async def test_sets_seccompProfile_in_pod_securityContext_by_default(templates):
     for template in templates:
         if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = f"{template['kind']}/{template['metadata']['name']}"
+            id = template_id(template)
 
             assert "securityContext" in template["spec"]["template"]["spec"], (
                 f"Pod securityContext unexpectedly absent for {id}"
@@ -92,7 +92,7 @@ async def test_can_nuke_pod_securityContext_seccompProfile(values, make_template
 
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = f"{template['kind']}/{template['metadata']['name']}"
+            id = template_id(template)
 
             assert "securityContext" in template["spec"]["template"]["spec"], (
                 f"Pod securityContext unexpectedly absent for {id}"

--- a/tests/manifests/test_secrets.py
+++ b/tests/manifests/test_secrets.py
@@ -5,6 +5,7 @@
 import pytest
 
 from . import values_files_to_test
+from .utils import template_id
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -12,6 +13,7 @@ from . import values_files_to_test
 async def test_all_secrets_have_type(templates):
     for template in templates:
         if template["kind"] == "Secret":
-            id = f"{template['kind']}/{template['metadata']['name']}"
-            assert "type" in template, f"{id} has not set the Secret type"
-            assert template["type"] in ["Opaque"], f"{id} has an unexpected Secret type {template['type']}"
+            assert "type" in template, f"{template_id(template)} has not set the Secret type"
+            assert template["type"] in ["Opaque"], (
+                f"{template_id(template)} has an unexpected Secret type {template['type']}"
+            )

--- a/tests/manifests/test_serviceaccounts.py
+++ b/tests/manifests/test_serviceaccounts.py
@@ -7,7 +7,7 @@ import copy
 import pytest
 
 from . import DeployableDetails, PropertyType, all_deployables_details, values_files_to_test
-from .utils import iterate_deployables_workload_parts
+from .utils import iterate_deployables_workload_parts, template_id
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -15,10 +15,8 @@ from .utils import iterate_deployables_workload_parts
 async def test_dont_automount_serviceaccount_tokens(templates):
     for template in templates:
         if template["kind"] in ["Deployment", "StatefulSet"]:
-            id = f"{template['kind']}/{template['metadata']['name']}"
-
             assert not template["spec"]["template"]["spec"]["automountServiceAccountToken"], (
-                f"ServiceAccount token automounted for {id}"
+                f"ServiceAccount token automounted for {template_id(template)}"
             )
 
 
@@ -30,7 +28,7 @@ async def test_uses_serviceaccount_named_as_per_pod_controller_by_default(templa
     covered_serviceaccount_names = set()
     for template in templates:
         if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            workloads_by_id[f"{template['kind']}/{template['metadata']['name']}"] = template
+            workloads_by_id[template_id(template)] = template
         elif template["kind"] == "ServiceAccount":
             serviceaccount_names.add(template["metadata"]["name"])
 
@@ -72,7 +70,7 @@ async def test_uses_serviceaccount_named_as_values_if_specified(values, make_tem
     serviceaccount_names = []
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            workloads_by_id[f"{template['kind']}/{template['metadata']['name']}"] = template
+            workloads_by_id[template_id(template)] = template
         elif template["kind"] == "ServiceAccount":
             serviceaccount_names.append(template["metadata"]["name"])
 
@@ -106,7 +104,7 @@ async def test_does_not_create_serviceaccounts_if_configured_not_to(values, make
         for template in await make_templates(values_to_modify):
             if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
                 id_suffix = f" (for {deployable_details.name})"
-                workloads_by_id[f"{template['kind']}/{template['metadata']['name']}{id_suffix}"] = template
+                workloads_by_id[f"{template_id(template)}{id_suffix}"] = template
             elif template["kind"] == "ServiceAccount":
                 serviceaccount_names.add(template["metadata"]["name"])
 

--- a/tests/manifests/test_services.py
+++ b/tests/manifests/test_services.py
@@ -5,6 +5,7 @@
 import pytest
 
 from . import services_values_files_to_test
+from .utils import template_id
 
 
 @pytest.mark.parametrize("values_file", services_values_files_to_test)
@@ -12,7 +13,7 @@ from . import services_values_files_to_test
 async def test_ports_in_services_are_named(templates):
     for template in templates:
         if template["kind"] == "Service":
-            id = f"{template['kind']}/{template['metadata']['name']}"
+            id = template_id(template)
             assert "ports" in template["spec"], f"{id} does not specify a ports list"
             assert len(template["spec"]["ports"]) > 0, f"{id} does not include any ports"
 

--- a/tests/manifests/test_tolerations.py
+++ b/tests/manifests/test_tolerations.py
@@ -5,7 +5,7 @@
 import pytest
 
 from . import PropertyType, values_files_to_test
-from .utils import iterate_deployables_workload_parts
+from .utils import iterate_deployables_workload_parts, template_id
 
 specific_toleration = {
     "key": "component",
@@ -27,10 +27,8 @@ global_toleration = {
 async def test_no_tolerations_by_default(templates):
     for template in templates:
         if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = f"{template['kind']}/{template['metadata']['name']}"
-
             assert "tolerations" not in template["spec"]["template"]["spec"], (
-                f"Tolerations unexpectedly present for {id}"
+                f"Tolerations unexpectedly present for {template_id(template)}"
             )
 
 
@@ -45,7 +43,7 @@ async def test_all_components_and_sub_components_render_tolerations(values, make
 
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = f"{template['kind']}/{template['metadata']['name']}"
+            id = template_id(template)
 
             pod_spec = template["spec"]["template"]["spec"]
             assert "tolerations" in pod_spec, f"No tolerations for {id}"
@@ -60,7 +58,7 @@ async def test_global_tolerations_render(values, make_templates):
 
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = f"{template['kind']}/{template['metadata']['name']}"
+            id = template_id(template)
 
             pod_spec = template["spec"]["template"]["spec"]
             assert "tolerations" in pod_spec, f"No tolerations for {id}"
@@ -83,7 +81,7 @@ async def test_merges_global_and_specific_tolerations(values, make_templates):
 
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = f"{template['kind']}/{template['metadata']['name']}"
+            id = template_id(template)
 
             pod_spec = template["spec"]["template"]["spec"]
             assert "tolerations" in pod_spec, f"No tolerations for {id}"

--- a/tests/manifests/test_topology_spread_constraints.py
+++ b/tests/manifests/test_topology_spread_constraints.py
@@ -5,7 +5,7 @@
 import pytest
 
 from . import DeployableDetails, PropertyType, values_files_to_test
-from .utils import iterate_deployables_parts, template_to_deployable_details
+from .utils import iterate_deployables_parts, template_id, template_to_deployable_details
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -13,10 +13,8 @@ from .utils import iterate_deployables_parts, template_to_deployable_details
 async def test_sets_no_topology_spread_constraint_default(templates):
     for template in templates:
         if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = f"{template['kind']}/{template['metadata']['name']}"
-
             assert "topologySpreadConstraintss" not in template["spec"]["template"]["spec"], (
-                f"Pod securityContext unexpectedly present for {id}"
+                f"Pod securityContext unexpectedly present for {template_id(template)}"
             )
 
 
@@ -43,10 +41,9 @@ async def test_topology_spread_constraint_has_default(values, make_templates):
 
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = f"{template['kind']}/{template['metadata']['name']}"
             if template_to_deployable_details(template).has_topology_spread_constraints:
                 assert "topologySpreadConstraints" in template["spec"]["template"]["spec"], (
-                    f"Pod topologySpreadConstraints unexpectedly absent for {id}"
+                    f"Pod topologySpreadConstraints unexpectedly absent for {template_id(template)}"
                 )
 
                 pod_topologySpreadConstraints = template["spec"]["template"]["spec"]["topologySpreadConstraints"]
@@ -62,7 +59,7 @@ async def test_topology_spread_constraint_has_default(values, make_templates):
                     assert pod_topologySpreadConstraints[0]["matchLabelKeys"] == []
             else:
                 assert "topologySpreadConstraints" not in template["spec"]["template"]["spec"], (
-                    f"Pod topologySpreadConstraints unexpectedly present for {id}"
+                    f"Pod topologySpreadConstraints unexpectedly present for {template_id(template)}"
                 )
 
 
@@ -96,10 +93,9 @@ async def test_can_nuke_topology_spread_constraint_defaults(values, make_templat
 
     for template in await make_templates(values):
         if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = f"{template['kind']}/{template['metadata']['name']}"
             if template_to_deployable_details(template).has_topology_spread_constraints:
                 assert "topologySpreadConstraints" in template["spec"]["template"]["spec"], (
-                    f"Pod topologySpreadConstraints unexpectedly absent for {id}"
+                    f"Pod topologySpreadConstraints unexpectedly absent for {template_id(template)}"
                 )
 
                 pod_topologySpreadConstraints = template["spec"]["template"]["spec"]["topologySpreadConstraints"]
@@ -112,5 +108,5 @@ async def test_can_nuke_topology_spread_constraint_defaults(values, make_templat
                 assert pod_topologySpreadConstraints[0]["matchLabelKeys"] == ["app.kubernetes.io/testlabel"]
             else:
                 assert "topologySpreadConstraints" not in template["spec"]["template"]["spec"], (
-                    f"Pod topologySpreadConstraints unexpectedly present for {id}"
+                    f"Pod topologySpreadConstraints unexpectedly present for {template_id(template)}"
                 )


### PR DESCRIPTION
Rough rule of thumb is that I've kept an intermediate variable if used > 2 times