### PR TITLE
Rename `synapse-check-config-hook` to `synapse-check-config` for consistency with `init-secrets` and `deployment-markers`

### DIFF
--- a/charts/matrix-stack/templates/synapse/_helpers.tpl
+++ b/charts/matrix-stack/templates/synapse/_helpers.tpl
@@ -33,15 +33,15 @@ k8s.element.io/synapse-instance: {{ $root.Release.Name }}-synapse
 {{- end }}
 {{- end }}
 
-{{- define "element-io.synapse-check-config-hook.labels" -}}
+{{- define "element-io.synapse-check-config.labels" -}}
 {{- $root := .root -}}
 {{- with required "element-io.synapse.labels missing context" .context -}}
 {{ include "element-io.ess-library.labels.common" (dict "root" $root "context" (dict "labels" .labels "withChartVersion" .withChartVersion)) }}
 app.kubernetes.io/component: matrix-server
-app.kubernetes.io/name: synapse-check-config-hook
-app.kubernetes.io/instance: {{ $root.Release.Name }}-synapse-check-config-hook
+app.kubernetes.io/name: synapse-check-config
+app.kubernetes.io/instance: {{ $root.Release.Name }}-synapse-check-config
 app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" $root.Values.synapse.image.tag }}
-k8s.element.io/synapse-instance: {{ $root.Release.Name }}-synapse-check-config-hook
+k8s.element.io/synapse-instance: {{ $root.Release.Name }}-synapse-check-config
 {{- end }}
 {{- end }}
 
@@ -67,7 +67,7 @@ app.kubernetes.io/name: synapse-{{ .processType }}
 app.kubernetes.io/instance: {{ $root.Release.Name }}-synapse-{{ .processType }}
 app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .image.tag }}
 {{ if required "element-io.synapse.process.labels missing context.isHook" .isHook }}
-k8s.element.io/synapse-instance: {{ $root.Release.Name }}-synapse-check-config-hook
+k8s.element.io/synapse-instance: {{ $root.Release.Name }}-synapse-check-config
 {{ else }}
 k8s.element.io/synapse-instance: {{ $root.Release.Name }}-synapse
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/_synapse_details.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_details.tpl
@@ -109,7 +109,7 @@ typing
 synapse.app.homeserver
 {{- else if eq . "media-repository" -}}
 synapse.app.media_repository
-{{- else if eq . "check-config-hook" -}}
+{{- else if eq . "check-config" -}}
 synapse.config
 {{- else -}}
 synapse.app.generic_worker

--- a/charts/matrix-stack/templates/synapse/_synapse_pod.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_pod.tpl
@@ -14,7 +14,7 @@ template:
   metadata:
     labels:
 {{- if $isHook }}
-      {{- include "element-io.synapse-check-config-hook.labels" (dict "root" $root "context" (dict "labels" .labels "withChartVersion" false)) | nindent 6 }}
+      {{- include "element-io.synapse-check-config.labels" (dict "root" $root "context" (dict "labels" .labels "withChartVersion" false)) | nindent 6 }}
 {{- else }}
       {{- include "element-io.synapse.process.labels" (dict "root" $root "context" (dict "image" .image "labels" .labels "withChartVersion" false "isHook" $isHook "processType" $processType)) | nindent 6 }}
 {{- end }}
@@ -43,8 +43,8 @@ template:
 {{- include "element-io.ess-library.pods.commonSpec"
             (dict "root" $root "context"
                                     (dict "componentValues" .
-                                          "instanceSuffix" ($isHook | ternary "synapse-check-config-hook" (printf "synapse-%s" $processType))
-                                          "serviceAccountNameSuffix" ($isHook | ternary "synapse-check-config-hook" "synapse")
+                                          "instanceSuffix" ($isHook | ternary "synapse-check-config" (printf "synapse-%s" $processType))
+                                          "serviceAccountNameSuffix" ($isHook | ternary "synapse-check-config" "synapse")
                                           "deployment" false
                                           "usesMatrixTools" true)
                                     ) | nindent 4 }}
@@ -65,13 +65,13 @@ We have an init container to render & merge the config for several reasons:
                   "nameSuffix" "synapse"
                   "underrides" (list "01-homeserver-underrides.yaml")
                   "overrides" (list "04-homeserver-overrides.yaml"
-                                    (eq $processType "check-config-hook" | ternary "05-main.yaml" (printf "05-%s.yaml" $processType)))
+                                    (eq $processType "check-config" | ternary "05-main.yaml" (printf "05-%s.yaml" $processType)))
                   "outputFile" "homeserver.yaml"
                   "resources" .resources
                   "containersSecurityContext" .containersSecurityContext
                   "extraEnv" .extraEnv
                   "isHook" $isHook)) | nindent 4 }}
-{{- if ne $processType "check-config-hook" }}
+{{- if not $isHook }}
     - name: db-wait
 {{- with $root.Values.matrixTools.image -}}
 {{- if .digest }}

--- a/charts/matrix-stack/templates/synapse/synapse_check_config_job_hook.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_check_config_job_hook.yaml
@@ -7,12 +7,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- with .Values.synapse -}}
 {{- if and .enabled .checkConfigHook.enabled -}}
 {{- $enabledWorkers := (include "element-io.synapse.enabledWorkers" (dict "root" $)) | fromJson }}
-{{- $processType := "check-config-hook" }}
+{{- $processType := "check-config" }}
 {{- $perProcessRoot := mustMergeOverwrite ($.Values.synapse | deepCopy) (.checkConfigHook | deepCopy) (dict "processType" $processType "isHook" true) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $.Release.Name }}-synapse-check-config-hook
+  name: {{ $.Release.Name }}-synapse-check-config
   namespace: {{ $.Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
@@ -27,7 +27,7 @@ Hook Weights are
     {{- toYaml . | nindent 4 }}
 {{- end }}
   labels:
-    {{- include "element-io.synapse-check-config-hook.labels" (dict "root" $ "context" .checkConfigHook) | nindent 4 }}
+    {{- include "element-io.synapse-check-config.labels" (dict "root" $ "context" .checkConfigHook) | nindent 4 }}
     k8s.element.io/synapse-config-hash: "{{ include "element-io.synapse.configmap-data"  (dict "root" $ "context" $perProcessRoot) | sha1sum }}"
     k8s.element.io/synapse-secret-hash: "{{ include "element-io.synapse.secret-data"  (dict "root" $ "context" $perProcessRoot) | sha1sum }}"
 {{- range $index, $appservice := .appservices }}

--- a/charts/matrix-stack/templates/synapse/synapse_configmap_hook.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_configmap_hook.yaml
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    {{- include "element-io.synapse-check-config-hook.labels" (dict "root" $ "context" .) | nindent 4 }}
+    {{- include "element-io.synapse-check-config.labels" (dict "root" $ "context" .) | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"

--- a/charts/matrix-stack/templates/synapse/synapse_secret_hook.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_secret_hook.yaml
@@ -11,7 +11,7 @@ kind: Secret
 type: Opaque
 metadata:
   labels:
-    {{- include "element-io.synapse-check-config-hook.labels" (dict "root" $ "context" .) | nindent 4 }}
+    {{- include "element-io.synapse-check-config.labels" (dict "root" $ "context" .) | nindent 4 }}
   name: {{ include "element-io.synapse.secret-name" (dict "root" $ "context" (dict "isHook" true)) }}
   namespace: {{ $.Release.Namespace }}
   annotations:

--- a/charts/matrix-stack/templates/synapse/synapse_serviceaccount_hook.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_serviceaccount_hook.yaml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- if .enabled }}
 {{- with .checkConfigHook }}
 {{ if and .enabled -}}
-{{- include "element-io.ess-library.serviceAccount" (dict "root" $ "context" (dict "componentValues" . "nameSuffix" "synapse-check-config-hook" "extraAnnotations" (dict "helm.sh/hook" "pre-install,pre-upgrade" "helm.sh/hook-weight" "0"))) }}
+{{- include "element-io.ess-library.serviceAccount" (dict "root" $ "context" (dict "componentValues" . "nameSuffix" "synapse-check-config" "extraAnnotations" (dict "helm.sh/hook" "pre-install,pre-upgrade" "helm.sh/hook-weight" "0"))) }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/newsfragments/501.changed.md
+++ b/newsfragments/501.changed.md
@@ -1,0 +1,1 @@
+Rename `synapse-check-config-hook` to `synapse-check-config` for consistency with `init-secrets` and `deployment-markers`.

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -490,7 +490,7 @@ all_components_details = [
                 has_topology_spread_constraints=False,
             ),
             SubComponentDetails(
-                name="synapse-check-config-hook",
+                name="synapse-check-config",
                 values_file_path=ValuesFilePath.read_write("synapse", "checkConfigHook"),
                 values_file_path_overrides={
                     PropertyType.Env: ValuesFilePath.read_elsewhere("synapse", "extraEnv"),


### PR DESCRIPTION
Neither `init-secrets` or `deployment-markers` put `-hook` in their k8s manifests, Synapse check config shouldn't either.

The values have not been renamed from `synapse.checkConfigHook` to `synapse.checkConfig` however. Open to doing that but has compatibility concerns