### PR TITLE
Unpin from Helm 3.17.3

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -81,9 +81,6 @@ jobs:
 
 
     - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112  # v4.3.0
-      # Until https://github.com/helm/helm/issues/30878 / https://github.com/helm/helm/issues/30880 are fixed
-      with:
-        version: 3.17.3
 
     - name: Test with pytest
       run: |

--- a/newsfragments/502.internal.md
+++ b/newsfragments/502.internal.md
@@ -1,0 +1,1 @@
+Unpin from Helm 3.17.3 after https://github.com/helm/helm/issues/30878 / https://github.com/helm/helm/issues/30880 are fixed.


### PR DESCRIPTION
If not specified `latest` is used. https://github.com/Azure/setup-helm/blob/main/src/run.ts#L50-L61 fetches the version from https://get.helm.sh/helm-latest-version:

```sh
$ curl https://get.helm.sh/helm-latest-version
v3.18.1
```