### PR TITLE
Fix initial-synchrotron paths not falling back to main if the worker is unavailable

### DIFF
--- a/charts/matrix-stack/templates/synapse/_synapse_details.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_details.tpl
@@ -346,13 +346,7 @@ responsibleForMedia
 ) }}
 {{- end }}
 
-{{- /* Route these paths to the initial-synchrotron is available otherwise use the standard synchrotron if we have it */}}
-{{- if or (eq .workerType "initial-synchrotron") (and (eq .workerType "synchrotron") (not (has "initial-synchrotron" .enabledWorkerTypes))) }}
-{{ $workerPaths = concat $workerPaths (list
-  "^/_matrix/client/(api/v1|r0|v3)/initialSync$"
-  "^/_matrix/client/(api/v1|r0|v3)/rooms/[^/]+/initialSync$"
-) }}
-{{- end }}
+{{- /* initial-synchrotron routing is done in configs/synapse/partial-haproxy.cfg.tpl so that it can fallback -> synchrotron -> main */}}
 
 {{- if eq .workerType "media-repository" }}
 {{ $workerPaths = concat $workerPaths (list
@@ -421,6 +415,8 @@ responsibleForMedia
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(r0|v3)/sync$"
   "^/_matrix/client/(api/v1|r0|v3)/events$"
+  "^/_matrix/client/(api/v1|r0|v3)/initialSync$"
+  "^/_matrix/client/(api/v1|r0|v3)/rooms/[^/]+/initialSync$"
 ) }}
 {{- end }}
 

--- a/newsfragments/508.fixed.md
+++ b/newsfragments/508.fixed.md
@@ -1,0 +1,1 @@
+Fix initial-synchrotron paths not falling back to main if the worker is unavailable.


### PR DESCRIPTION
If no workers are configured:
* Initial sync paths go to main
* Sync paths go to main

If synchrotron worker only is configured:
* Initial sync paths go to synchrotron
* Sync paths go to synchtron
* Falling back to main if synchrotron servers are down

If initial-synchrotron worker only is configured:
* Initial sync paths go to initial-synchrotron
* Falling back to main if initial-synchrotron servers are down
* Sync paths go to main

If both synchrotron and initial-synchrotron workers are configured:
* Initial sync paths go to initial-synchrotron
* Falling back to synchrotron if initial-synchrotron servers are down
* Falling back to main if synchrotron servers are down
* Sync paths go to synchrotron
* Falling back to main for if synchrotron servers are down

```sh
$ curl -k https://synapse.ess.localhost/_matrix/client/r0/sync
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}%

$ curl -k https://synapse.ess.localhost/_matrix/client/r0/initialSync
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}%
```

```
192.168.112.1:37486 [03/Jun/2025:09:54:40.116] synapse-http-in synapse-initial-synchrotron/initial-sync1 0/0/0/0/2/2 401 484 - - ---- 1/1/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "GET /_matrix/client/r0/sync HTTP/1.1"
192.168.112.1:39344 [03/Jun/2025:09:54:45.820] synapse-http-in synapse-initial-synchrotron/initial-sync1 0/0/0/0/1/1 401 484 - - ---- 2/2/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "GET /_matrix/client/r0/initialSync HTTP/1.1"
```

```sh
$ kubectl -n ess scale --replicas=0 sts/ess-synapse-initial-sync sts/ess-synapse-synchrotron
statefulset.apps/ess-synapse-initial-sync scaled
statefulset.apps/ess-synapse-synchrotron scaled

$ curl -k https://synapse.ess.localhost/_matrix/client/r0/initialSync
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}%

$ curl -k https://synapse.ess.localhost/_matrix/client/r0/sync       
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}%   
```

```
192.168.112.1:39344 [03/Jun/2025:09:54:59.874] synapse-http-in synapse-initial-synchrotron/<NOSRV> 0/0/0/-1/-1/5002 503 0 - - sC-- 2/2/0/0/+1 0/0 {synapse.ess.localhost||curl/8.5.0} "GET /_matrix/client/r0/initialSync HTTP/1.1"
192.168.112.1:59004 [03/Jun/2025:09:55:04.877] synapse-http-in synapse-main-failover/main1 0/0/0/0/4/4 401 484 - - ---- 2/2/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "GET /_matrix/client/r0/initialSync HTTP/1.1"
192.168.112.1:59018 [03/Jun/2025:09:55:09.855] synapse-http-in synapse-main-failover/main1 0/0/0/0/3/3 401 484 - - ---- 3/3/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "GET /_matrix/client/r0/sync HTTP/1.1"
```

```sh
kubectl -n ess scale --replicas=1 sts/ess-synapse-synchrotron
statefulset.apps/ess-synapse-synchrotron scaled

$ curl -k https://synapse.ess.localhost/_matrix/client/r0/initialSync
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}%

$ curl -k https://synapse.ess.localhost/_matrix/client/r0/sync
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}%
```

```
192.168.112.1:49960 [03/Jun/2025:10:04:34.972] synapse-http-in synapse-initial-synchrotron/<NOSRV> 0/0/0/-1/-1/10002 503 345 - - sC-- 3/3/0/0/+2 0/0 {synapse.ess.localhost||curl/8.5.0} "GET /_matrix/client/r0/initialSync HTTP/1.1"
192.168.112.1:38478 [03/Jun/2025:10:04:46.258] synapse-http-in synapse-synchrotron/synchrotron2 0/0/0/0/3/3 401 484 - - ---- 3/3/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "GET /_matrix/client/r0/initialSync HTTP/1.1"
192.168.112.1:38484 [03/Jun/2025:10:04:49.615] synapse-http-in synapse-synchrotron/synchrotron2 0/0/0/0/2/2 401 484 - - ---- 3/3/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "GET /_matrix/client/r0/sync HTTP/1.1"

```
