### PR TITLE
SFU: Fix ingress needs to set proxy-timeouts and disable buffering

### DIFF
--- a/charts/matrix-stack/templates/matrix-rtc/ingress.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2024 New Vector Ltd
+Copyright 2024-2025 New Vector Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -8,7 +8,15 @@ SPDX-License-Identifier: AGPL-3.0-only
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress)) | nindent 2 }}
+{{- $extraAnnotations := dict }}
+{{- if .sfu.enabled }}
+{{- if eq "ingress-nginx" (include "element-io.ess-library.ingress-controller-type" (dict "root" $ "context" .ingress.controllerType)) }}
+{{- $_ := set $extraAnnotations "nginx.ingress.kubernetes.io/proxy-send-timeout" "120" }}
+{{- $_ := set $extraAnnotations "nginx.ingress.kubernetes.io/proxy-read-timeout" "120" }}
+{{- $_ := set $extraAnnotations "nginx.ingress.kubernetes.io/proxy-buffering" "off" }}
+{{- end }}
+{{- end }}
+{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress "extraAnnotations" $extraAnnotations)) | nindent 2 }}
   labels:
     {{- include "element-io.matrix-rtc-ingress.labels" (dict "root" $ "context" .) | nindent 4 }}
   name: {{ $.Release.Name }}-matrix-rtc

--- a/newsfragments/514.fixed.md
+++ b/newsfragments/514.fixed.md
@@ -1,0 +1,1 @@
+Matrix RTC: Set proxy timeout and enforce disabled buffering `nginx-ingress` `controllerType` annotations if SFU is enabled.


### PR DESCRIPTION
According to https://github.com/element-hq/element-call/blob/livekit/docs/self-hosting.md#matrix-site-endpoint-routing