### PR TITLE
golang lint ci action: dont set go-version

### DIFF
--- a/.github/workflows/matrix-tools.yml
+++ b/.github/workflows/matrix-tools.yml
@@ -36,7 +36,6 @@ jobs:
     - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8
       with:
         working-directory: matrix-tools
-        go-version: "${{ env.GO_VERSION }}"
         args: -v --show-stats --no-config --modules-download-mode readonly
 
     - uses: GoTestTools/gotestfmt-action@8b4478c7019be847373babde9300210e7de34bfb  # v2

--- a/newsfragments/521.internal.md
+++ b/newsfragments/521.internal.md
@@ -1,0 +1,1 @@
+CI: Dont pass `go-version` to golanglint-ci action.


### PR DESCRIPTION
According to the examples in the README of https://github.com/golangci/golangci-lint-action , it will use the go version used in `setup-go` action.