### PR TITLE
syn2mas: fail if pods are still up after statefulset are all down

### DIFF
--- a/matrix-tools/internal/pkg/syn2mas/syn2mas.go
+++ b/matrix-tools/internal/pkg/syn2mas/syn2mas.go
@@ -59,6 +59,19 @@ func scaleDownSynapse(client kubernetes.Interface, namespace string) map[string]
 			break
 		}
 	}
+	podsClient := client.CoreV1().Pods(namespace)
+	pods, err := podsClient.List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/component=matrix-server",
+	})
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	if len(pods.Items) != 0 {
+		fmt.Println("StatefulSet are down, but pods matching matrix-server component are remaining. Something wrong is happening.")
+		os.Exit(1)
+	}
+
 	return stsReplicas
 }
 


### PR DESCRIPTION
If for any reason kubernetes is misbehaving, we might have unsynced issue which might turn wrong. Let's just be extra safe with the process.