### PR TITLE
Pytest aiohttp retry on exceptions : handle ClientResponseErrors

### DIFF
--- a/newsfragments/531.internal.md
+++ b/newsfragments/531.internal.md
@@ -1,0 +1,1 @@
+CI: Fix an internal issue where aiohttp expected errors were not retried.

--- a/tests/integration/lib/utils.py
+++ b/tests/integration/lib/utils.py
@@ -29,6 +29,7 @@ retry_options = JitterRetry(
     }
     | set(int(code) for code in os.environ.get("PYTEST_EXPECTED_HTTP_STATUS_CODES", "").split(",") if code),
     retry_all_server_errors=False,
+    exceptions={aiohttp.client_exceptions.ClientResponseError},
 )
 
 


### PR DESCRIPTION
https://github.com/inyutin/aiohttp_retry/issues/114