### PR TITLE
Matrix RTC: correct setting of the container name for the keys.yaml renderer

### DIFF
--- a/charts/matrix-stack/templates/ess-library/_render_config.tpl
+++ b/charts/matrix-stack/templates/ess-library/_render_config.tpl
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- with required "element-io.ess-library.render-config-container missing context" .context -}}
 {{- $context := . -}}
 {{- $nameSuffix := required "element-io.ess-library.render-config-container missing context.nameSuffix" .nameSuffix -}}
-{{- $containerName := (.containerName | default "render-config") -}}
+{{- $containerName := required "element-io.ess-library.render-config-container missing context.containerName" .containerName -}}
 {{- $templatesVolume := (.templatesVolume | default "plain-config") -}}
 {{- $additionalPath := .additionalPath -}}
 {{- $additionalProperty := dict -}}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
@@ -43,7 +43,7 @@ spec:
         (dict "nameSuffix" "matrix-rtc-sfu"
               "underrides" list
               "overrides" (list "keys-template.yaml")
-              "contaierName" "render-config-keys-yaml"
+              "containerName" "render-config-keys-yaml"
               "outputFile" "keys.yaml"
               "resources" .resources
               "containersSecurityContext" .containersSecurityContext

--- a/newsfragments/535.changed.md
+++ b/newsfragments/535.changed.md
@@ -1,0 +1,1 @@
+`MatrixRTC.sfu.additional` now uses the same `additional` properties schema as Matrix Authentication Service and Synapse.


### PR DESCRIPTION
And make `containerName` non-optional now as everything else here seems to set it