### PR TITLE
Don't send set changelog entries in the artifacthub metadata

### DIFF
--- a/charts/matrix-stack/Chart.yaml
+++ b/charts/matrix-stack/Chart.yaml
@@ -8,3 +8,15 @@ description: A Helm meta-chart for deploying a Matrix Stack from Element
 type: application
 version: 25.6.1-dev
 dependencies: []
+annotations:
+  artifacthub.io/changes: |
+    - description: Add support for Syn2Mas migration. See `matrixAuthenticationService.syn2mas`
+        documentation in values file for more information.
+      kind: added
+    - description: Name secrets mounted based on a hash of their names instead of an index.
+      kind: changed
+    - description: '`MatrixRTC.sfu.additional` now uses the same `additional` properties
+        schema as Matrix Authentication Service and Synapse.'
+      kind: changed
+    - description: 'matrix-tools: Update to 0.5.2 to support syn2mas migration command.'
+      kind: changed

--- a/newsfragments/542.internal.md
+++ b/newsfragments/542.internal.md
@@ -1,0 +1,1 @@
+Don't send set changelog entries in the artifacthub metadata.

--- a/scripts/towncrier_to_helm_annotation.py
+++ b/scripts/towncrier_to_helm_annotation.py
@@ -12,18 +12,19 @@ import yaml as pyyaml
 
 
 def find_news_fragments(root_dir):
-    new_fragments = []
+    unique_new_fragments = set()
 
     for path in Path(root_dir).glob("*"):
         if path.is_file() and path.name != ".gitkeep":
             kind = path.name.split(".")[1]
             if kind != "internal":
-                new_fragments.append(
-                    {
-                        "description": path.read_text().splitlines()[0].strip(),
-                        "kind": kind,
-                    }
+                unique_new_fragments.add(
+                    (
+                        path.read_text().splitlines()[0].strip(),
+                        kind,
+                    )
                 )
+    new_fragments = list({"description": description, "kind": kind} for description, kind in unique_new_fragments)
     kind_order = ["added", "changed", "deprecated", "removed", "fixed", "security"]
     # We order the list by kind and description alphabetically
     new_fragments.sort(key=lambda x: str(kind_order.index(x["kind"])) + x["description"])


### PR DESCRIPTION
Noticed whilst checking the changelog in #541 

We can include the same changelog fragments multiple times so that the GitHub release links to multiple PRs. This doesn't make sense for artifacthub metadata