### PR TITLE
Reorder changelog sections

### DIFF
--- a/newsfragments/544.internal.md
+++ b/newsfragments/544.internal.md
@@ -1,0 +1,1 @@
+Reorder changelog sections.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,26 +75,40 @@ filename = "CHANGELOG.md"
 # See artifacthub changes kinds https://artifacthub.io/docs/topics/annotations/helm/
 # "When using the list of objects option the valid supported kinds are added, changed, deprecated, removed, fixed and security."
 
-[tool.towncrier.fragment.added]
-name = "Added"
-
-[tool.towncrier.fragment.changed]
-name = "Changed"
-
-[tool.towncrier.fragment.deprecated]
-name = "Deprecated"
-
-[tool.towncrier.fragment.removed]
-name = "Removed"
-
-[tool.towncrier.fragment.fixed]
-name = "Fixed"
-
-[tool.towncrier.fragment.security]
+[[tool.towncrier.type]]
+directory = "security"
 name = "Security"
+showcontent = true
 
-[tool.towncrier.fragment.internal]
+[[tool.towncrier.type]]
+directory = "deprecated"
+name = "Deprecated"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removed"
+name = "Removed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "internal"
 name = "Internal"
+showcontent = true
 
 [[tool.mypy.overrides]]
 module = ["pyhelm3.*", "pytest_kubernetes.*"]

--- a/scripts/towncrier_to_helm_annotation.py
+++ b/scripts/towncrier_to_helm_annotation.py
@@ -25,7 +25,7 @@ def find_news_fragments(root_dir):
                     )
                 )
     new_fragments = list({"description": description, "kind": kind} for description, kind in unique_new_fragments)
-    kind_order = ["added", "changed", "deprecated", "removed", "fixed", "security"]
+    kind_order = ["security", "deprecated", "added", "fixed", "changed", "removed"]
     # We order the list by kind and description alphabetically
     new_fragments.sort(key=lambda x: str(kind_order.index(x["kind"])) + x["description"])
     return new_fragments


### PR DESCRIPTION
Rather than alphabetical order, put the most important sections first
* `Security`
* `Deprecated`
* `Added`
* `Fixed`
* `Changed`
* `Removed`

Then finally for GitHub releases we also have `Internal`