### PR TITLE
Improve upgrade test tag detection

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         echo "envFiles=$(find tests/integration/env -name '*.rc' | sed 's|tests/integration/env/||' | sed 's/.rc$//' | jq -ncR '{envFiles: [inputs]}')" | tee -a "$GITHUB_OUTPUT"
         echo "manifestTests=$(find tests/manifests -name 'test_*.py' | sed 's|tests/manifests/||' | sed 's/.py$//' | jq -ncR '{manifestTests: [inputs]}')" | tee -a "$GITHUB_OUTPUT"
-        LATEST_TAG=$(git tag | grep -E '^([0-9]+)\.([0-9]+)\.([0-9]+)$' | sort -V | tail -n 1)
+        LATEST_TAG=$(git describe --abbrev=0 --tags --match '[0-9]*.[0-9]*.[0-9]*')
         echo "upgradeFrom=$LATEST_TAG" | tee -a "$GITHUB_OUTPUT"
 
   pytest-integration:

--- a/newsfragments/547.internal.md
+++ b/newsfragments/547.internal.md
@@ -1,0 +1,1 @@
+CI: Test upgrades against the nearest reachable tag and not the most recently created.


### PR DESCRIPTION
We may not want to test against the most recently created tag if that isn't in the history for a given commit. We want the nearest reachable tag.

Does `--match` so that we exclude anything that doesn't look like a release or is `matrix-tools-<version>`