### PR TITLE
Remove warning about deprecated  config value in Matrix RTC SFU.

### DIFF
--- a/charts/matrix-stack/configs/matrix-rtc/sfu/config-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/matrix-rtc/sfu/config-overrides.yaml.tpl
@@ -9,7 +9,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 port: 7880
 
-prometheus_port: 6789
+prometheus:
+  port: 6789
 
 # Logging config
 logging:

--- a/newsfragments/550.changed.md
+++ b/newsfragments/550.changed.md
@@ -1,0 +1,1 @@
+Remove warning about deprecated `prometheus_port` config value in Matrix RTC SFU.


### PR DESCRIPTION
`2025-06-11T13:32:20.648Z	WARN	livekit	service/server.go:146	prometheus_port is deprecated, please switch prometheus.port instead`