### PR TITLE
Ensure example `NodePort` values use ports within `kind`'s `NodePort` range.

### DIFF
--- a/charts/matrix-stack/ci/fragments/matrix-rtc-exposed-services.yaml
+++ b/charts/matrix-stack/ci/fragments/matrix-rtc-exposed-services.yaml
@@ -6,11 +6,11 @@ matrixRTC:
   sfu:
     exposedServices:
       rtcTcp:
-        port: 33000
+        port: 31000
       rtcMuxedUdp:
-        port: 33001
+        port: 31001
       rtcUdp:
         enabled: true
         portRange:
-          startPort: 32500
-          endPort: 32900
+          endPort: 30400
+          startPort: 30000

--- a/charts/matrix-stack/ci/matrix-rtc-exposed-services-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-exposed-services-values.yaml
@@ -16,14 +16,14 @@ matrixRTC:
   sfu:
     exposedServices:
       rtcMuxedUdp:
-        port: 33001
+        port: 31001
       rtcTcp:
-        port: 33000
+        port: 31000
       rtcUdp:
         enabled: true
         portRange:
-          endPort: 32900
-          startPort: 32500
+          endPort: 30400
+          startPort: 30000
 synapse:
   enabled: false
 wellKnownDelegation:

--- a/newsfragments/551.internal.md
+++ b/newsfragments/551.internal.md
@@ -1,0 +1,1 @@
+Ensure example `NodePort` values use ports within `kind`'s `NodePort` range.


### PR DESCRIPTION
Previously:
```sh
$ helm upgrade -i -n ess ess charts/matrix-stack -f charts/matrix-stack/ci/matrix-rtc-exposed-services-values.yaml 
Error: UPGRADE FAILED: failed to create resource: Service "ess-matrix-rtc-sfu-udp-range" is invalid: spec.ports[268].nodePort: Invalid value: 32768: provided port is not in the valid range. The range of valid ports is 30000-32767

# Correct matrixRTC.sfu.exposedServices.rtcUdp.portRange.{start,end}Port

$ helm upgrade -i -n ess ess charts/matrix-stack -f charts/matrix-stack/ci/matrix-rtc-exposed-services-values.yaml
Error: UPGRADE FAILED: cannot patch "ess-matrix-rtc-sfu-tcp" with kind Service: Service "ess-matrix-rtc-sfu-tcp" is invalid: spec.ports[0].nodePort: Invalid value: 33000: provided port is not in the valid range. The range of valid ports is 30000-32767 && cannot patch "ess-matrix-rtc-sfu-muxed-udp" with kind Service: Service "ess-matrix-rtc-sfu-muxed-udp" is invalid: spec.ports[0].nodePort: Invalid value: 33001: provided port is not in the valid range. The range of valid ports is 30000-32767
```