### PR TITLE
document generated secret & deployment marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,8 @@ If you wish to remove ESS Community from your cluster, you can simply run the fo
 
 ```
 helm uninstall ess -n ess
+kubectl delete secrets/ess-generated -n ess # If initSecrets is enabled, you may need to delete this
+kubectl delete configmap/ess-deployment-markers -n ess # If deploymentMarkers is enabled, you may need to delete this
 kubectl delete namespace ess
 ```
 

--- a/newsfragments/567.fixed.md
+++ b/newsfragments/567.fixed.md
@@ -1,0 +1,1 @@
+Document the need for removal of generated secrets & deployment marker configmap when uninstalling.


### PR DESCRIPTION
It was raised in ESS Community room that it was not easy to find out remaining secrets & configmaps when one wants to reinstall without dropping the namespace : https://matrix.to/#/!RkXKfjpGXIVObpCqOI:element.io/$_IyhyBA5emCnVfSKICNL04_MXuHP11UU-YGQfq_VJjw?via=matrix.org&via=element.io&via=k8ekat.dev