### PR TITLE
Improve the test cluster setup for Matrix RTC

### DIFF
--- a/charts/matrix-stack/ci/test-cluster-mixin.yaml
+++ b/charts/matrix-stack/ci/test-cluster-mixin.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 New Vector Ltd
+# Copyright 2024-2025 New Vector Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -8,3 +8,15 @@
 
 certManager:
   clusterIssuer: ess-selfsigned
+
+matrixRTC:
+  # Because the authoriser service won't trust certificates issued by the above self-signed CA
+  extraEnv:
+  - name: LIVEKIT_INSECURE_SKIP_VERIFY_TLS
+    value: YES_I_KNOW_WHAT_I_AM_DOING
+  # Because the authoriser service does well-known and the userinfo API calls via the frontdoor
+  hostAliases:
+  - hostnames:
+    - ess.localhost
+    - synapse.ess.localhost
+    ip: '{{ ( (lookup "v1" "Service" "ingress-nginx" "ingress-nginx-controller") | default (dict "spec" (dict "clusterIP" "127.0.0.1")) ).spec.clusterIP }}'

--- a/newsfragments/579.internal.md
+++ b/newsfragments/579.internal.md
@@ -1,0 +1,1 @@
+Improve the test cluster setup for Matrix RTC.

--- a/tests/integration/fixtures/files/clusters/kind.yml
+++ b/tests/integration/fixtures/files/clusters/kind.yml
@@ -51,6 +51,13 @@ nodes:
   - containerPort: 443
     hostPort: 443
     protocol: TCP
+  # Matrix RTC SFU TCP and Muxed UDP
+  - containerPort: 30881
+    hostPort: 30881
+    protocol: TCP
+  - containerPort: 30882
+    hostPort: 30882
+    protocol: UDP
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry]


### PR DESCRIPTION
Makes it so that the authoriser service will work in the test cluster and that ports are open to work with the default SFU config