### PR TITLE
CI: run the preview-changelog job on main and manually as well as PRs.

### DIFF
--- a/.github/workflows/changelog_check.yml
+++ b/.github/workflows/changelog_check.yml
@@ -5,13 +5,17 @@
 name: Changelog
 on:
   pull_request:
+  push:
+    branches:
+    - main
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
   check-newsfile:
-    if: ${{ (github.base_ref == 'main'  || contains(github.base_ref, 'release-')) && github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' }}
+    if: ${{ (github.event_name == 'pull_request') && (github.base_ref == 'main' || contains(github.base_ref, 'release-')) && github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4

--- a/.github/workflows/matrix-tools.yml
+++ b/.github/workflows/matrix-tools.yml
@@ -6,12 +6,12 @@ name: Build matrix-tool Docker Images
 
 on:
   pull_request:
-  workflow_dispatch:
   push:
     branches:
     - main
     tags:
     - 'matrix-tools-*'
+  workflow_dispatch:
 
 env:
   REGISTRY_IMAGE: ghcr.io/${{ github.repository }}/matrix-tools

--- a/newsfragments/599.internal.md
+++ b/newsfragments/599.internal.md
@@ -1,0 +1,1 @@
+CI: run the preview-changelog job on main and manually as well as PRs.


### PR DESCRIPTION
So that we don't need to find a recent PR to see the changelog