### PR TITLE
Synapse: default to TLS 1.2 or later for outbound federation

### DIFF
--- a/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
@@ -9,6 +9,8 @@ report_stats: false
 
 require_auth_for_profile_requests: true
 
+federation_client_minimum_tls_version: '1.2'
+
 {{- if $root.Values.matrixRTC.enabled }}
 # The maximum allowed duration by which sent events can be delayed, as
 # per MSC4140.

--- a/newsfragments/609.changed.md
+++ b/newsfragments/609.changed.md
@@ -1,0 +1,3 @@
+Default Synapse to requiring TLS 1.2 or later.
+
+This can be overridden in additional configuration.


### PR DESCRIPTION
Implemented as an underride, so can be overridden by additional configuration. Just setting a more appropriate default