### PR TITLE
document deploymentMarkers  in ci values examples

### DIFF
--- a/charts/matrix-stack/ci/element-web-checkov-values.yaml
+++ b/charts/matrix-stack/ci/element-web-checkov-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   annotations:
     checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed

--- a/charts/matrix-stack/ci/element-web-minimal-values.yaml
+++ b/charts/matrix-stack/ci/element-web-minimal-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   ingress:
     host: element.ess.localhost

--- a/charts/matrix-stack/ci/example-default-enabled-components-values.yaml
+++ b/charts/matrix-stack/ci/example-default-enabled-components-values.yaml
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: element-web-minimal.yaml synapse-minimal.yaml matrix-authentication-service-minimal.yaml init-secrets-minimal.yaml postgres-minimal.yaml well-known-minimal.yaml
+# source_fragments: deployment-markers-minimal.yaml element-web-minimal.yaml synapse-minimal.yaml matrix-authentication-service-minimal.yaml init-secrets-minimal.yaml postgres-minimal.yaml well-known-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
+# deploymentMarkers, initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
 elementWeb:
   ingress:
     host: element.ess.localhost

--- a/charts/matrix-stack/ci/fragments/deployment-markers-minimal.yaml
+++ b/charts/matrix-stack/ci/fragments/deployment-markers-minimal.yaml
@@ -1,3 +1,6 @@
 # Copyright 2025 New Vector Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
+
+deploymentMarkers:
+  enabled: true

--- a/charts/matrix-stack/ci/fragments/quick-setup-all-enabled.yaml
+++ b/charts/matrix-stack/ci/fragments/quick-setup-all-enabled.yaml
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
+deploymentMarkers:
+  enabled: true
+
 elementWeb:
   enabled: true
 

--- a/charts/matrix-stack/ci/matrix-authentication-service-external-synapse-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-external-synapse-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/matrix-authentication-service-minimal-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-minimal-values.yaml
@@ -5,7 +5,7 @@
 # source_fragments: matrix-authentication-service-minimal.yaml init-secrets-minimal.yaml postgres-minimal.yaml deployment-markers-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# initSecrets, postgres don't have any required properties to be set and defaults to enabled
+# deploymentMarkers, initSecrets, postgres don't have any required properties to be set and defaults to enabled
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/matrix-authentication-service-postgres-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-postgres-secrets-externally-values.yaml
@@ -5,6 +5,8 @@
 # source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-secrets-externally.yaml postgres-secrets-externally.yaml postgres-matrix-authentication-service-secrets-externally.yaml init-secrets-disabled.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 initSecrets:

--- a/charts/matrix-stack/ci/matrix-authentication-service-postgres-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-postgres-secrets-in-helm-values.yaml
@@ -5,6 +5,8 @@
 # source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-secrets-externally.yaml postgres-secrets-in-helm.yaml postgres-matrix-authentication-service-secrets-in-helm.yaml init-secrets-disabled.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 initSecrets:

--- a/charts/matrix-stack/ci/matrix-authentication-service-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-secrets-externally-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/matrix-authentication-service-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-secrets-in-helm-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/matrix-authentication-service-synapse-syn2mas-dry-run-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-synapse-syn2mas-dry-run-secrets-externally-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/matrix-authentication-service-synapse-syn2mas-dry-run-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-synapse-syn2mas-dry-run-secrets-in-helm-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/matrix-authentication-service-synapse-syn2mas-migrate-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-synapse-syn2mas-migrate-secrets-externally-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/matrix-authentication-service-synapse-syn2mas-migrate-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-synapse-syn2mas-migrate-secrets-in-helm-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/matrix-rtc-checkov-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-checkov-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 initSecrets:

--- a/charts/matrix-stack/ci/matrix-rtc-exposed-services-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-exposed-services-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/matrix-rtc-external-livekit-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-external-livekit-secrets-externally-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/matrix-rtc-external-livekit-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-external-livekit-secrets-in-helm-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/matrix-rtc-host-mode-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-host-mode-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/matrix-rtc-minimal-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-minimal-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/matrix-rtc-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-secrets-externally-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/matrix-rtc-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-secrets-in-helm-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/nothing-enabled-values.yaml
+++ b/charts/matrix-stack/ci/nothing-enabled-values.yaml
@@ -1,6 +1,9 @@
-# Copyright 2024 New Vector Ltd
+# Copyright 2024-2025 New Vector Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
+
+deploymentMarkers:
+  enabled: false
 
 matrixRTC:
   enabled: false

--- a/charts/matrix-stack/ci/pytest-element-web-values.yaml
+++ b/charts/matrix-stack/ci/pytest-element-web-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   additional:
     user-config.json: |

--- a/charts/matrix-stack/ci/pytest-matrix-authentication-service-syn2mas-values.yaml
+++ b/charts/matrix-stack/ci/pytest-matrix-authentication-service-syn2mas-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: synapse-minimal.yaml synapse-pytest-base-extras.yaml matrix-authentication-service-pytest-extras.yaml matrix-authentication-service-syn2mas-dryrun.yaml init-secrets-minimal.yaml init-secrets-pytest-extras.yaml postgres-minimal.yaml deployment-markers-pytest-extras.yaml matrix-authentication-service-migrated-password-scheme.yaml
+# source_fragments: deployment-markers-minimal.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml matrix-authentication-service-pytest-extras.yaml matrix-authentication-service-syn2mas-dryrun.yaml init-secrets-minimal.yaml init-secrets-pytest-extras.yaml postgres-minimal.yaml deployment-markers-pytest-extras.yaml matrix-authentication-service-migrated-password-scheme.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:

--- a/charts/matrix-stack/ci/pytest-matrix-rtc-standalone-values.yaml
+++ b/charts/matrix-stack/ci/pytest-matrix-rtc-standalone-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 initSecrets:

--- a/charts/matrix-stack/ci/pytest-well-known-values.yaml
+++ b/charts/matrix-stack/ci/pytest-well-known-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 global:

--- a/charts/matrix-stack/ci/quick-setup-certificates-pg-external-values.yaml
+++ b/charts/matrix-stack/ci/quick-setup-certificates-pg-external-values.yaml
@@ -5,7 +5,7 @@
 # source_fragments: quick-setup-all-enabled.yaml quick-setup-hostnames.yaml quick-setup-certificates.yaml quick-setup-postgresql.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# initSecrets, postgres don't have any required properties to be set and defaults to enabled
+# deploymentMarkers, initSecrets, postgres don't have any required properties to be set and defaults to enabled
 elementWeb:
   ingress:
     host: chat.your.tld

--- a/charts/matrix-stack/ci/quick-setup-certificates-pg-with-helm-values.yaml
+++ b/charts/matrix-stack/ci/quick-setup-certificates-pg-with-helm-values.yaml
@@ -5,7 +5,7 @@
 # source_fragments: quick-setup-all-enabled.yaml quick-setup-hostnames.yaml quick-setup-certificates.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# initSecrets, postgres don't have any required properties to be set and defaults to enabled
+# deploymentMarkers, initSecrets, postgres don't have any required properties to be set and defaults to enabled
 elementWeb:
   ingress:
     host: chat.your.tld

--- a/charts/matrix-stack/ci/quick-setup-external-cert-pg-external-values.yaml
+++ b/charts/matrix-stack/ci/quick-setup-external-cert-pg-external-values.yaml
@@ -5,7 +5,7 @@
 # source_fragments: quick-setup-all-enabled.yaml quick-setup-hostnames.yaml quick-setup-external-cert.yaml quick-setup-postgresql.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
+# deploymentMarkers, initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
 elementWeb:
   ingress:
     host: chat.your.tld

--- a/charts/matrix-stack/ci/quick-setup-external-cert-pg-with-helm-values.yaml
+++ b/charts/matrix-stack/ci/quick-setup-external-cert-pg-with-helm-values.yaml
@@ -5,7 +5,7 @@
 # source_fragments: quick-setup-all-enabled.yaml quick-setup-hostnames.yaml quick-setup-external-cert.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
+# deploymentMarkers, initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
 elementWeb:
   ingress:
     host: chat.your.tld

--- a/charts/matrix-stack/ci/quick-setup-letsencrypt-pg-external-values.yaml
+++ b/charts/matrix-stack/ci/quick-setup-letsencrypt-pg-external-values.yaml
@@ -5,7 +5,7 @@
 # source_fragments: quick-setup-all-enabled.yaml quick-setup-hostnames.yaml quick-setup-letsencrypt.yaml quick-setup-postgresql.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
+# deploymentMarkers, initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
 certManager:
   clusterIssuer: letsencrypt-prod
 elementWeb:

--- a/charts/matrix-stack/ci/quick-setup-letsencrypt-pg-with-helm-values.yaml
+++ b/charts/matrix-stack/ci/quick-setup-letsencrypt-pg-with-helm-values.yaml
@@ -5,7 +5,7 @@
 # source_fragments: quick-setup-all-enabled.yaml quick-setup-hostnames.yaml quick-setup-letsencrypt.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
+# deploymentMarkers, initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
 certManager:
   clusterIssuer: letsencrypt-prod
 elementWeb:

--- a/charts/matrix-stack/ci/quick-setup-wildcard-cert-pg-external-values.yaml
+++ b/charts/matrix-stack/ci/quick-setup-wildcard-cert-pg-external-values.yaml
@@ -5,7 +5,7 @@
 # source_fragments: quick-setup-all-enabled.yaml quick-setup-hostnames.yaml quick-setup-wildcard-cert.yaml quick-setup-postgresql.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
+# deploymentMarkers, initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
 elementWeb:
   ingress:
     host: chat.your.tld

--- a/charts/matrix-stack/ci/quick-setup-wildcard-cert-pg-with-helm-values.yaml
+++ b/charts/matrix-stack/ci/quick-setup-wildcard-cert-pg-with-helm-values.yaml
@@ -5,7 +5,7 @@
 # source_fragments: quick-setup-all-enabled.yaml quick-setup-hostnames.yaml quick-setup-wildcard-cert.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
+# deploymentMarkers, initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
 elementWeb:
   ingress:
     host: chat.your.tld

--- a/charts/matrix-stack/ci/synapse-ingress-additional-paths-values.yaml
+++ b/charts/matrix-stack/ci/synapse-ingress-additional-paths-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/synapse-minimal-values.yaml
+++ b/charts/matrix-stack/ci/synapse-minimal-values.yaml
@@ -5,7 +5,7 @@
 # source_fragments: synapse-minimal.yaml init-secrets-minimal.yaml postgres-minimal.yaml deployment-markers-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# initSecrets, postgres don't have any required properties to be set and defaults to enabled
+# deploymentMarkers, initSecrets, postgres don't have any required properties to be set and defaults to enabled
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/synapse-postgres-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/synapse-postgres-secrets-externally-values.yaml
@@ -5,6 +5,8 @@
 # source_fragments: synapse-minimal.yaml synapse-secrets-externally.yaml postgres-secrets-externally.yaml postgres-synapse-secrets-externally.yaml init-secrets-disabled.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 initSecrets:

--- a/charts/matrix-stack/ci/synapse-postgres-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/synapse-postgres-secrets-in-helm-values.yaml
@@ -5,6 +5,8 @@
 # source_fragments: synapse-minimal.yaml synapse-secrets-in-helm.yaml postgres-secrets-in-helm.yaml postgres-synapse-secrets-in-helm.yaml init-secrets-disabled.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 initSecrets:

--- a/charts/matrix-stack/ci/synapse-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/synapse-secrets-externally-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/synapse-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/synapse-secrets-in-helm-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/synapse-worker-example-values.yaml
+++ b/charts/matrix-stack/ci/synapse-worker-example-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/well-known-checkov-values.yaml
+++ b/charts/matrix-stack/ci/well-known-checkov-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 haproxy:

--- a/charts/matrix-stack/ci/well-known-element-web-values.yaml
+++ b/charts/matrix-stack/ci/well-known-element-web-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   ingress:
     host: element.ess.localhost

--- a/charts/matrix-stack/ci/well-known-mas-values.yaml
+++ b/charts/matrix-stack/ci/well-known-mas-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/well-known-minimal-values.yaml
+++ b/charts/matrix-stack/ci/well-known-minimal-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 initSecrets:

--- a/charts/matrix-stack/ci/well-known-synapse-mas-values.yaml
+++ b/charts/matrix-stack/ci/well-known-synapse-mas-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/well-known-synapse-values.yaml
+++ b/charts/matrix-stack/ci/well-known-synapse-values.yaml
@@ -6,6 +6,8 @@
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/newsfragments/620.changed.md
+++ b/newsfragments/620.changed.md
@@ -1,0 +1,1 @@
+Document in ci values example that `deploymentMarkers` is default enabled.

--- a/scripts/assemble_ci_values_files_from_fragments.sh
+++ b/scripts/assemble_ci_values_files_from_fragments.sh
@@ -43,6 +43,7 @@ for values_file in "$values_file_root"/$values_file_prefix-values.yaml "$user_va
   # Remove any fields with null values so we have a way of removing things
   yq_command+=" | del(... | select(. == null))"
   # We could remove enabled: true for all default enabled components by setting enabled: null in their minimal values file,
+  yq_command+=" | del(.deploymentMarkers.enabled | select(.))"
   yq_command+=" | del(.matrixRTC.enabled | select(.))"
   yq_command+=" | del(.elementWeb.enabled | select(.))"
   yq_command+=" | del(.initSecrets.enabled | select(.))"
@@ -51,7 +52,7 @@ for values_file in "$values_file_root"/$values_file_prefix-values.yaml "$user_va
   yq_command+=" | del(.synapse.enabled | select(.))"
   yq_command+=" | del(.wellKnownDelegation.enabled | select(.))"
   yq_command+=' | del(.. | select(tag == "!!map" and length == 0))'
-  yq_command+=" | select((. | [\"initSecrets\", \"postgres\", \"wellKnownDelegation\"] - keys) | length > 0) head_comment=([\"initSecrets\", \"postgres\", \"wellKnownDelegation\"] - keys | join(\", \"))  + \" don't have any required properties to be set and defaults to enabled\""
+  yq_command+=" | select((. | [\"deploymentMarkers\", \"initSecrets\", \"postgres\", \"wellKnownDelegation\"] - keys) | length > 0) head_comment=([\"deploymentMarkers\", \"initSecrets\", \"postgres\", \"wellKnownDelegation\"] - keys | join(\", \"))  + \" don't have any required properties to be set and defaults to enabled\""
 
   echo "Generating $values_file from $source_fragments";
   echo "" > "$values_file"


### PR DESCRIPTION
This got missed when building deploymentMarkers for syn2mas.