### PR TITLE
Tweak CI values files

### DIFF
--- a/charts/matrix-stack/ci/example-default-enabled-components-checkov-values.yaml
+++ b/charts/matrix-stack/ci/example-default-enabled-components-checkov-values.yaml
@@ -1,0 +1,64 @@
+# Copyright 2024-2025 New Vector Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# source_fragments: deployment-markers-minimal.yaml deployment-markers-checkov.yaml element-web-minimal.yaml element-web-checkov.yaml synapse-minimal.yaml synapse-checkov.yaml matrix-authentication-service-minimal.yaml matrix-authentication-service-checkov.yaml init-secrets-minimal.yaml init-secrets-checkov.yaml postgres-minimal.yaml postgres-checkov.yaml well-known-minimal.yaml haproxy-checkov.yaml
+# DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
+
+# wellKnownDelegation don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  annotations:
+    checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
+    checkov.io/skip2: CKV_K8S_43=No digests
+    checkov.io/skip3: CKV2_K8S_6=No network policy yet
+    checkov.io/skip4: CKV_K8S_38=The job needs a service account
+elementWeb:
+  annotations:
+    checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
+    checkov.io/skip2: CKV_K8S_43=No digests
+    checkov.io/skip3: CKV2_K8S_6=No network policy yet
+  ingress:
+    host: element.ess.localhost
+haproxy:
+  annotations:
+    checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
+    checkov.io/skip2: CKV_K8S_43=No digests
+    checkov.io/skip3: CKV2_K8S_6=No network policy yet
+initSecrets:
+  annotations:
+    checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
+    checkov.io/skip2: CKV_K8S_43=No digests
+    checkov.io/skip3: CKV2_K8S_6=No network policy yet
+    checkov.io/skip4: CKV_K8S_38=The job needs a service account
+matrixAuthenticationService:
+  annotations:
+    checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
+    checkov.io/skip2: CKV_K8S_43=No digests
+    checkov.io/skip3: CKV2_K8S_6=No network policy yet
+  ingress:
+    host: mas.ess.localhost
+matrixRTC:
+  enabled: false
+postgres:
+  annotations:
+    checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
+    checkov.io/skip2: CKV_K8S_43=No digests
+    checkov.io/skip3: CKV2_K8S_6=No network policy yet
+serverName: ess.localhost
+synapse:
+  annotations:
+    checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
+    checkov.io/skip2: CKV_K8S_43=No digests
+    checkov.io/skip3: CKV2_K8S_6=No network policy yet
+  checkConfigHook:
+    annotations:
+      checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
+      checkov.io/skip2: CKV_K8S_43=No digests
+      checkov.io/skip3: CKV2_K8S_6=No network policy yet
+  ingress:
+    host: synapse.ess.localhost
+  redis:
+    annotations:
+      checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
+      checkov.io/skip2: CKV_K8S_43=No digests
+      checkov.io/skip3: CKV2_K8S_6=No network policy yet

--- a/charts/matrix-stack/ci/matrix-authentication-service-checkov-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-checkov-values.yaml
@@ -2,15 +2,11 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-checkov.yaml init-secrets-minimal.yaml init-secrets-checkov.yaml postgres-minimal.yaml postgres-checkov.yaml deployment-markers-minimal.yaml deployment-markers-checkov.yaml
+# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-checkov.yaml init-secrets-minimal.yaml init-secrets-checkov.yaml postgres-minimal.yaml postgres-checkov.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:
-  annotations:
-    checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
-    checkov.io/skip2: CKV_K8S_43=No digests
-    checkov.io/skip3: CKV2_K8S_6=No network policy yet
-    checkov.io/skip4: CKV_K8S_38=The job needs a service account
+  enabled: false
 elementWeb:
   enabled: false
 initSecrets:

--- a/charts/matrix-stack/ci/matrix-authentication-service-minimal-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-minimal-values.yaml
@@ -2,10 +2,12 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-authentication-service-minimal.yaml init-secrets-minimal.yaml postgres-minimal.yaml deployment-markers-minimal.yaml
+# source_fragments: matrix-authentication-service-minimal.yaml init-secrets-minimal.yaml postgres-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# deploymentMarkers, initSecrets, postgres don't have any required properties to be set and defaults to enabled
+# initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/charts/matrix-stack/ci/pytest-matrix-rtc-synapse-wellknown-values.yaml
+++ b/charts/matrix-stack/ci/pytest-matrix-rtc-synapse-wellknown-values.yaml
@@ -2,14 +2,11 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-rtc-minimal.yaml matrix-rtc-pytest-extras.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml synapse-pytest-base-extras.yaml init-secrets-minimal.yaml init-secrets-pytest-extras.yaml postgres-minimal.yaml well-known-minimal.yaml well-known-pytest-extras.yaml deployment-markers-minimal.yaml deployment-markers-pytest-extras.yaml
+# source_fragments: matrix-rtc-minimal.yaml matrix-rtc-pytest-extras.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml synapse-pytest-base-extras.yaml init-secrets-minimal.yaml init-secrets-pytest-extras.yaml postgres-minimal.yaml well-known-minimal.yaml well-known-pytest-extras.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:
-  annotations:
-    has-no-service-monitor: "true"
-  podSecurityContext:
-    runAsGroup: 0
+  enabled: false
 elementWeb:
   enabled: false
 global:

--- a/charts/matrix-stack/ci/pytest-synapse-values.yaml
+++ b/charts/matrix-stack/ci/pytest-synapse-values.yaml
@@ -2,14 +2,11 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: synapse-minimal.yaml synapse-pytest-base-extras.yaml synapse-pytest-self-extras.yaml init-secrets-minimal.yaml init-secrets-pytest-extras.yaml postgres-minimal.yaml deployment-markers-minimal.yaml deployment-markers-pytest-extras.yaml
+# source_fragments: synapse-minimal.yaml synapse-pytest-base-extras.yaml synapse-pytest-self-extras.yaml init-secrets-minimal.yaml init-secrets-pytest-extras.yaml postgres-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:
-  annotations:
-    has-no-service-monitor: "true"
-  podSecurityContext:
-    runAsGroup: 0
+  enabled: false
 elementWeb:
   enabled: false
 haproxy:

--- a/charts/matrix-stack/ci/synapse-checkov-with-workers-values.yaml
+++ b/charts/matrix-stack/ci/synapse-checkov-with-workers-values.yaml
@@ -2,15 +2,11 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: synapse-minimal.yaml synapse-some-workers-running.yaml synapse-checkov.yaml haproxy-checkov.yaml init-secrets-minimal.yaml init-secrets-checkov.yaml postgres-minimal.yaml postgres-checkov.yaml deployment-markers-minimal.yaml deployment-markers-checkov.yaml
+# source_fragments: synapse-minimal.yaml synapse-some-workers-running.yaml synapse-checkov.yaml haproxy-checkov.yaml init-secrets-minimal.yaml init-secrets-checkov.yaml postgres-minimal.yaml postgres-checkov.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:
-  annotations:
-    checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
-    checkov.io/skip2: CKV_K8S_43=No digests
-    checkov.io/skip3: CKV2_K8S_6=No network policy yet
-    checkov.io/skip4: CKV_K8S_38=The job needs a service account
+  enabled: false
 elementWeb:
   enabled: false
 haproxy:

--- a/charts/matrix-stack/ci/synapse-minimal-values.yaml
+++ b/charts/matrix-stack/ci/synapse-minimal-values.yaml
@@ -2,10 +2,12 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: synapse-minimal.yaml init-secrets-minimal.yaml postgres-minimal.yaml deployment-markers-minimal.yaml
+# source_fragments: synapse-minimal.yaml init-secrets-minimal.yaml postgres-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
-# deploymentMarkers, initSecrets, postgres don't have any required properties to be set and defaults to enabled
+# initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
 elementWeb:
   enabled: false
 matrixAuthenticationService:

--- a/newsfragments/621.internal.1.md
+++ b/newsfragments/621.internal.1.md
@@ -1,0 +1,1 @@
+CI: remove `deploymentMarkers` from `{synapse,matrix-authentication-service}(-checkov)-values.yaml` as no extra values are required if deployment markers aren't enabled.

--- a/newsfragments/621.internal.2.md
+++ b/newsfragments/621.internal.2.md
@@ -1,0 +1,1 @@
+CI: handle `deploymentMarkers` not being enabled in various some PyTests.

--- a/newsfragments/621.internal.md
+++ b/newsfragments/621.internal.md
@@ -1,0 +1,1 @@
+CI: add `checkov` values file that covers all default enabled components.

--- a/tests/integration/test_matrix_authentication_service.py
+++ b/tests/integration/test_matrix_authentication_service.py
@@ -27,6 +27,7 @@ async def test_matrix_authentication_service_graphql_endpoint(ingress_ready, gen
     assert json_content["data"] == {"userByUsername": None}
 
 
+@pytest.mark.skipif(value_file_has("deploymentMarkers.enabled", False), reason="Deployment Markers not enabled")
 @pytest.mark.skipif(value_file_has("matrixAuthenticationService.enabled", False), reason="MAS not deployed")
 @pytest.mark.skipif(value_file_has("matrixAuthenticationService.syn2mas.enabled", True), reason="Syn2Mas is being run")
 @pytest.mark.asyncio_cooperative

--- a/tests/integration/test_synapse.py
+++ b/tests/integration/test_synapse.py
@@ -116,6 +116,7 @@ async def test_rendezvous_cors_headers_are_only_set_with_mas(ingress_ready, gene
         assert ("ETag" in response.headers["Access-Control-Expose-Headers"]) == supports_qr_code_login
 
 
+@pytest.mark.skipif(value_file_has("deploymentMarkers.enabled", False), reason="Deployment Markers not enabled")
 @pytest.mark.skipif(value_file_has("synapse.enabled", False), reason="Synapse not deployed")
 @pytest.mark.skipif(value_file_has("matrixAuthenticationService.enabled", True), reason="MAS is deployed")
 @pytest.mark.skipif(value_file_has("matrixAuthenticationService.syn2mas.enabled", True), reason="Syn2Mas is being run")


### PR DESCRIPTION
* Introduce `charts/matrix-stack/ci/example-default-enabled-components-checkov-values.yaml` so that we've something that covers `deploymentMarkers` explicitly
* Remove `deploymentMarkers` from `{synapse,matrix-authentication-service}-minimal-values.yaml` as removing them doesn't require additional values to be set
  * At which point it also disappears from the corresponding `checkov` values file
* Remove `deploymentMarkers` from the Synapse based PyTests
  * The `syn2mas` test covers starting with legacy auth
  * The MAS PyTest does have `deploymentMarkers` available 