### PR TITLE
CI: sort and ensure uniqeness of source_fragments

### DIFF
--- a/charts/matrix-stack/ci/element-web-checkov-values.yaml
+++ b/charts/matrix-stack/ci/element-web-checkov-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: element-web-minimal.yaml element-web-checkov.yaml
+# source_fragments: element-web-checkov.yaml element-web-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/example-default-enabled-components-checkov-values.yaml
+++ b/charts/matrix-stack/ci/example-default-enabled-components-checkov-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: deployment-markers-minimal.yaml deployment-markers-checkov.yaml element-web-minimal.yaml element-web-checkov.yaml synapse-minimal.yaml synapse-checkov.yaml matrix-authentication-service-minimal.yaml matrix-authentication-service-checkov.yaml init-secrets-minimal.yaml init-secrets-checkov.yaml postgres-minimal.yaml postgres-checkov.yaml well-known-minimal.yaml haproxy-checkov.yaml
+# source_fragments: deployment-markers-checkov.yaml deployment-markers-minimal.yaml element-web-checkov.yaml element-web-minimal.yaml haproxy-checkov.yaml init-secrets-checkov.yaml init-secrets-minimal.yaml matrix-authentication-service-checkov.yaml matrix-authentication-service-minimal.yaml postgres-checkov.yaml postgres-minimal.yaml synapse-checkov.yaml synapse-minimal.yaml well-known-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # wellKnownDelegation don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/example-default-enabled-components-values.yaml
+++ b/charts/matrix-stack/ci/example-default-enabled-components-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: deployment-markers-minimal.yaml element-web-minimal.yaml synapse-minimal.yaml matrix-authentication-service-minimal.yaml init-secrets-minimal.yaml postgres-minimal.yaml well-known-minimal.yaml
+# source_fragments: deployment-markers-minimal.yaml element-web-minimal.yaml init-secrets-minimal.yaml matrix-authentication-service-minimal.yaml postgres-minimal.yaml synapse-minimal.yaml well-known-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # deploymentMarkers, initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/matrix-authentication-service-checkov-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-checkov-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-checkov.yaml init-secrets-minimal.yaml init-secrets-checkov.yaml postgres-minimal.yaml postgres-checkov.yaml
+# source_fragments: init-secrets-checkov.yaml init-secrets-minimal.yaml matrix-authentication-service-checkov.yaml matrix-authentication-service-minimal.yaml postgres-checkov.yaml postgres-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:

--- a/charts/matrix-stack/ci/matrix-authentication-service-external-synapse-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-external-synapse-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-external-synapse.yaml init-secrets-minimal.yaml postgres-minimal.yaml
+# source_fragments: init-secrets-minimal.yaml matrix-authentication-service-external-synapse.yaml matrix-authentication-service-minimal.yaml postgres-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/matrix-authentication-service-minimal-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-minimal-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-authentication-service-minimal.yaml init-secrets-minimal.yaml postgres-minimal.yaml
+# source_fragments: init-secrets-minimal.yaml matrix-authentication-service-minimal.yaml postgres-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/matrix-authentication-service-postgres-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-postgres-secrets-externally-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-secrets-externally.yaml postgres-secrets-externally.yaml postgres-matrix-authentication-service-secrets-externally.yaml init-secrets-disabled.yaml
+# source_fragments: init-secrets-disabled.yaml matrix-authentication-service-minimal.yaml matrix-authentication-service-secrets-externally.yaml postgres-matrix-authentication-service-secrets-externally.yaml postgres-secrets-externally.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:

--- a/charts/matrix-stack/ci/matrix-authentication-service-postgres-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-postgres-secrets-in-helm-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-secrets-externally.yaml postgres-secrets-in-helm.yaml postgres-matrix-authentication-service-secrets-in-helm.yaml init-secrets-disabled.yaml
+# source_fragments: init-secrets-disabled.yaml matrix-authentication-service-minimal.yaml matrix-authentication-service-secrets-externally.yaml postgres-matrix-authentication-service-secrets-in-helm.yaml postgres-secrets-in-helm.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:

--- a/charts/matrix-stack/ci/matrix-authentication-service-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-secrets-externally-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-additional-secrets-externally.yaml matrix-authentication-service-postgres.yaml matrix-authentication-service-postgres-secrets-externally.yaml matrix-authentication-service-secrets-externally.yaml
+# source_fragments: matrix-authentication-service-additional-secrets-externally.yaml matrix-authentication-service-minimal.yaml matrix-authentication-service-postgres-secrets-externally.yaml matrix-authentication-service-postgres.yaml matrix-authentication-service-secrets-externally.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/matrix-authentication-service-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-secrets-in-helm-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-postgres.yaml matrix-authentication-service-additional-in-helm.yaml matrix-authentication-service-postgres.yaml matrix-authentication-service-postgres-secrets-in-helm.yaml  matrix-authentication-service-secrets-in-helm.yaml
+# source_fragments: matrix-authentication-service-additional-in-helm.yaml matrix-authentication-service-minimal.yaml matrix-authentication-service-postgres-secrets-in-helm.yaml matrix-authentication-service-postgres.yaml matrix-authentication-service-secrets-in-helm.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/matrix-authentication-service-synapse-syn2mas-dry-run-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-synapse-syn2mas-dry-run-secrets-externally-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-postgres.yaml matrix-authentication-service-postgres-secrets-externally.yaml matrix-authentication-service-secrets-externally.yaml synapse-minimal.yaml synapse-postgres.yaml synapse-postgres-secrets-externally.yaml synapse-secrets-externally.yaml matrix-authentication-service-syn2mas-dryrun.yaml
+# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-postgres-secrets-externally.yaml matrix-authentication-service-postgres.yaml matrix-authentication-service-secrets-externally.yaml matrix-authentication-service-syn2mas-dryrun.yaml synapse-minimal.yaml synapse-postgres-secrets-externally.yaml synapse-postgres.yaml synapse-secrets-externally.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/matrix-authentication-service-synapse-syn2mas-dry-run-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-synapse-syn2mas-dry-run-secrets-in-helm-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-postgres.yaml matrix-authentication-service-postgres-secrets-in-helm.yaml  matrix-authentication-service-secrets-in-helm.yaml synapse-minimal.yaml synapse-postgres.yaml synapse-postgres-secrets-in-helm.yaml synapse-secrets-in-helm.yaml matrix-authentication-service-syn2mas-dryrun.yaml
+# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-postgres-secrets-in-helm.yaml matrix-authentication-service-postgres.yaml matrix-authentication-service-secrets-in-helm.yaml matrix-authentication-service-syn2mas-dryrun.yaml synapse-minimal.yaml synapse-postgres-secrets-in-helm.yaml synapse-postgres.yaml synapse-secrets-in-helm.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/matrix-authentication-service-synapse-syn2mas-migrate-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-synapse-syn2mas-migrate-secrets-externally-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-postgres.yaml matrix-authentication-service-postgres-secrets-externally.yaml matrix-authentication-service-secrets-externally.yaml synapse-minimal.yaml synapse-postgres.yaml synapse-postgres-secrets-externally.yaml synapse-secrets-externally.yaml matrix-authentication-service-syn2mas-dryrun.yaml matrix-authentication-service-syn2mas-migrate.yaml
+# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-postgres-secrets-externally.yaml matrix-authentication-service-postgres.yaml matrix-authentication-service-secrets-externally.yaml matrix-authentication-service-syn2mas-dryrun.yaml matrix-authentication-service-syn2mas-migrate.yaml synapse-minimal.yaml synapse-postgres-secrets-externally.yaml synapse-postgres.yaml synapse-secrets-externally.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/matrix-authentication-service-synapse-syn2mas-migrate-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/matrix-authentication-service-synapse-syn2mas-migrate-secrets-in-helm-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-postgres.yaml matrix-authentication-service-postgres-secrets-in-helm.yaml  matrix-authentication-service-secrets-in-helm.yaml synapse-minimal.yaml synapse-postgres.yaml synapse-postgres-secrets-in-helm.yaml synapse-secrets-in-helm.yaml matrix-authentication-service-syn2mas-dryrun.yaml matrix-authentication-service-syn2mas-migrate.yaml
+# source_fragments: matrix-authentication-service-minimal.yaml matrix-authentication-service-postgres-secrets-in-helm.yaml matrix-authentication-service-postgres.yaml matrix-authentication-service-secrets-in-helm.yaml matrix-authentication-service-syn2mas-dryrun.yaml matrix-authentication-service-syn2mas-migrate.yaml synapse-minimal.yaml synapse-postgres-secrets-in-helm.yaml synapse-postgres.yaml synapse-secrets-in-helm.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/matrix-rtc-checkov-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-checkov-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-rtc-minimal.yaml matrix-rtc-checkov.yaml init-secrets-checkov.yaml
+# source_fragments: init-secrets-checkov.yaml init-secrets-minimal.yaml matrix-rtc-checkov.yaml matrix-rtc-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/matrix-rtc-exposed-services-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-exposed-services-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-rtc-minimal.yaml matrix-rtc-exposed-services.yaml
+# source_fragments: matrix-rtc-exposed-services.yaml matrix-rtc-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/matrix-rtc-external-livekit-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-external-livekit-secrets-externally-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-rtc-minimal.yaml matrix-rtc-external-livekit.yaml matrix-rtc-external-livekit-secrets-externally.yaml
+# source_fragments: matrix-rtc-external-livekit-secrets-externally.yaml matrix-rtc-external-livekit.yaml matrix-rtc-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/matrix-rtc-external-livekit-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-external-livekit-secrets-in-helm-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-rtc-minimal.yaml matrix-rtc-external-livekit.yaml matrix-rtc-external-livekit-secrets-in-helm.yaml
+# source_fragments: matrix-rtc-external-livekit-secrets-in-helm.yaml matrix-rtc-external-livekit.yaml matrix-rtc-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/matrix-rtc-host-mode-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-host-mode-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-rtc-minimal.yaml matrix-rtc-host-mode.yaml
+# source_fragments: matrix-rtc-host-mode.yaml matrix-rtc-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/matrix-rtc-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-secrets-externally-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-rtc-minimal.yaml matrix-rtc-secrets-externally.yaml matrix-rtc-additional-secrets-externally.yaml
+# source_fragments: matrix-rtc-additional-secrets-externally.yaml matrix-rtc-minimal.yaml matrix-rtc-secrets-externally.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/matrix-rtc-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-secrets-in-helm-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-rtc-minimal.yaml matrix-rtc-secrets-in-helm.yaml matrix-rtc-additional-in-helm.yaml
+# source_fragments: matrix-rtc-additional-in-helm.yaml matrix-rtc-minimal.yaml matrix-rtc-secrets-in-helm.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/pytest-matrix-authentication-service-syn2mas-values.yaml
+++ b/charts/matrix-stack/ci/pytest-matrix-authentication-service-syn2mas-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: deployment-markers-minimal.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml matrix-authentication-service-pytest-extras.yaml matrix-authentication-service-syn2mas-dryrun.yaml init-secrets-minimal.yaml init-secrets-pytest-extras.yaml postgres-minimal.yaml deployment-markers-pytest-extras.yaml matrix-authentication-service-migrated-password-scheme.yaml
+# source_fragments: deployment-markers-minimal.yaml deployment-markers-pytest-extras.yaml init-secrets-minimal.yaml init-secrets-pytest-extras.yaml matrix-authentication-service-migrated-password-scheme.yaml matrix-authentication-service-pytest-extras.yaml matrix-authentication-service-syn2mas-dryrun.yaml postgres-minimal.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:

--- a/charts/matrix-stack/ci/pytest-matrix-authentication-service-values.yaml
+++ b/charts/matrix-stack/ci/pytest-matrix-authentication-service-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: synapse-minimal.yaml synapse-pytest-base-extras.yaml matrix-authentication-service-minimal.yaml matrix-authentication-service-pytest-extras.yaml init-secrets-minimal.yaml init-secrets-pytest-extras.yaml postgres-minimal.yaml deployment-markers-minimal.yaml deployment-markers-pytest-extras.yaml
+# source_fragments: deployment-markers-minimal.yaml deployment-markers-pytest-extras.yaml init-secrets-minimal.yaml init-secrets-pytest-extras.yaml matrix-authentication-service-minimal.yaml matrix-authentication-service-pytest-extras.yaml postgres-minimal.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:

--- a/charts/matrix-stack/ci/pytest-matrix-rtc-standalone-values.yaml
+++ b/charts/matrix-stack/ci/pytest-matrix-rtc-standalone-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-rtc-minimal.yaml matrix-rtc-pytest-extras.yaml init-secrets-minimal.yaml init-secrets-pytest-extras.yaml
+# source_fragments: init-secrets-minimal.yaml init-secrets-pytest-extras.yaml matrix-rtc-minimal.yaml matrix-rtc-pytest-extras.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/pytest-matrix-rtc-synapse-wellknown-values.yaml
+++ b/charts/matrix-stack/ci/pytest-matrix-rtc-synapse-wellknown-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: matrix-rtc-minimal.yaml matrix-rtc-pytest-extras.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml synapse-pytest-base-extras.yaml init-secrets-minimal.yaml init-secrets-pytest-extras.yaml postgres-minimal.yaml well-known-minimal.yaml well-known-pytest-extras.yaml
+# source_fragments: init-secrets-minimal.yaml init-secrets-pytest-extras.yaml matrix-rtc-minimal.yaml matrix-rtc-pytest-extras.yaml postgres-minimal.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml well-known-minimal.yaml well-known-pytest-extras.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:

--- a/charts/matrix-stack/ci/pytest-synapse-values.yaml
+++ b/charts/matrix-stack/ci/pytest-synapse-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: synapse-minimal.yaml synapse-pytest-base-extras.yaml synapse-pytest-self-extras.yaml init-secrets-minimal.yaml init-secrets-pytest-extras.yaml postgres-minimal.yaml
+# source_fragments: init-secrets-minimal.yaml init-secrets-pytest-extras.yaml postgres-minimal.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml synapse-pytest-self-extras.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:

--- a/charts/matrix-stack/ci/quick-setup-certificates-pg-external-values.yaml
+++ b/charts/matrix-stack/ci/quick-setup-certificates-pg-external-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: quick-setup-all-enabled.yaml quick-setup-hostnames.yaml quick-setup-certificates.yaml quick-setup-postgresql.yaml
+# source_fragments: quick-setup-all-enabled.yaml quick-setup-certificates.yaml quick-setup-hostnames.yaml quick-setup-postgresql.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # deploymentMarkers, initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/quick-setup-certificates-pg-with-helm-values.yaml
+++ b/charts/matrix-stack/ci/quick-setup-certificates-pg-with-helm-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: quick-setup-all-enabled.yaml quick-setup-hostnames.yaml quick-setup-certificates.yaml
+# source_fragments: quick-setup-all-enabled.yaml quick-setup-certificates.yaml quick-setup-hostnames.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # deploymentMarkers, initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/quick-setup-external-cert-pg-external-values.yaml
+++ b/charts/matrix-stack/ci/quick-setup-external-cert-pg-external-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: quick-setup-all-enabled.yaml quick-setup-hostnames.yaml quick-setup-external-cert.yaml quick-setup-postgresql.yaml
+# source_fragments: quick-setup-all-enabled.yaml quick-setup-external-cert.yaml quick-setup-hostnames.yaml quick-setup-postgresql.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # deploymentMarkers, initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/quick-setup-external-cert-pg-with-helm-values.yaml
+++ b/charts/matrix-stack/ci/quick-setup-external-cert-pg-with-helm-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: quick-setup-all-enabled.yaml quick-setup-hostnames.yaml quick-setup-external-cert.yaml
+# source_fragments: quick-setup-all-enabled.yaml quick-setup-external-cert.yaml quick-setup-hostnames.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # deploymentMarkers, initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/quick-setup-wildcard-cert-pg-external-values.yaml
+++ b/charts/matrix-stack/ci/quick-setup-wildcard-cert-pg-external-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: quick-setup-all-enabled.yaml quick-setup-hostnames.yaml quick-setup-wildcard-cert.yaml quick-setup-postgresql.yaml
+# source_fragments: quick-setup-all-enabled.yaml quick-setup-hostnames.yaml quick-setup-postgresql.yaml quick-setup-wildcard-cert.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # deploymentMarkers, initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/synapse-checkov-with-workers-values.yaml
+++ b/charts/matrix-stack/ci/synapse-checkov-with-workers-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: synapse-minimal.yaml synapse-some-workers-running.yaml synapse-checkov.yaml haproxy-checkov.yaml init-secrets-minimal.yaml init-secrets-checkov.yaml postgres-minimal.yaml postgres-checkov.yaml
+# source_fragments: haproxy-checkov.yaml init-secrets-checkov.yaml init-secrets-minimal.yaml postgres-checkov.yaml postgres-minimal.yaml synapse-checkov.yaml synapse-minimal.yaml synapse-some-workers-running.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:

--- a/charts/matrix-stack/ci/synapse-ingress-additional-paths-values.yaml
+++ b/charts/matrix-stack/ci/synapse-ingress-additional-paths-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: synapse-minimal.yaml synapse-ingress-additional-paths.yaml init-secrets-minimal.yaml postgres-minimal.yaml
+# source_fragments: init-secrets-minimal.yaml postgres-minimal.yaml synapse-ingress-additional-paths.yaml synapse-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/synapse-minimal-values.yaml
+++ b/charts/matrix-stack/ci/synapse-minimal-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: synapse-minimal.yaml init-secrets-minimal.yaml postgres-minimal.yaml
+# source_fragments: init-secrets-minimal.yaml postgres-minimal.yaml synapse-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/synapse-postgres-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/synapse-postgres-secrets-externally-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: synapse-minimal.yaml synapse-secrets-externally.yaml postgres-secrets-externally.yaml postgres-synapse-secrets-externally.yaml init-secrets-disabled.yaml
+# source_fragments: init-secrets-disabled.yaml postgres-secrets-externally.yaml postgres-synapse-secrets-externally.yaml synapse-minimal.yaml synapse-secrets-externally.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:

--- a/charts/matrix-stack/ci/synapse-postgres-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/synapse-postgres-secrets-in-helm-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: synapse-minimal.yaml synapse-secrets-in-helm.yaml postgres-secrets-in-helm.yaml postgres-synapse-secrets-in-helm.yaml init-secrets-disabled.yaml
+# source_fragments: init-secrets-disabled.yaml postgres-secrets-in-helm.yaml postgres-synapse-secrets-in-helm.yaml synapse-minimal.yaml synapse-secrets-in-helm.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:

--- a/charts/matrix-stack/ci/synapse-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/synapse-secrets-externally-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: synapse-minimal.yaml synapse-postgres.yaml synapse-additional-secrets-externally.yaml synapse-postgres-secrets-externally.yaml synapse-secrets-externally.yaml
+# source_fragments: synapse-additional-secrets-externally.yaml synapse-minimal.yaml synapse-postgres-secrets-externally.yaml synapse-postgres.yaml synapse-secrets-externally.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/synapse-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/synapse-secrets-in-helm-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: synapse-minimal.yaml synapse-postgres.yaml synapse-additional-in-helm.yaml synapse-postgres-secrets-in-helm.yaml synapse-secrets-in-helm.yaml
+# source_fragments: synapse-additional-in-helm.yaml synapse-minimal.yaml synapse-postgres-secrets-in-helm.yaml synapse-postgres.yaml synapse-secrets-in-helm.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/synapse-worker-example-values.yaml
+++ b/charts/matrix-stack/ci/synapse-worker-example-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: synapse-minimal.yaml synapse-all-workers-running.yaml init-secrets-minimal.yaml postgres-minimal.yaml
+# source_fragments: init-secrets-minimal.yaml postgres-minimal.yaml synapse-all-workers-running.yaml synapse-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/well-known-checkov-values.yaml
+++ b/charts/matrix-stack/ci/well-known-checkov-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: well-known-minimal.yaml haproxy-checkov.yaml
+# source_fragments: haproxy-checkov.yaml well-known-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/well-known-element-web-values.yaml
+++ b/charts/matrix-stack/ci/well-known-element-web-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: well-known-minimal.yaml element-web-minimal.yaml init-secrets-minimal.yaml postgres-minimal.yaml
+# source_fragments: element-web-minimal.yaml init-secrets-minimal.yaml postgres-minimal.yaml well-known-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/well-known-mas-values.yaml
+++ b/charts/matrix-stack/ci/well-known-mas-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: well-known-minimal.yaml matrix-authentication-service-minimal.yaml init-secrets-minimal.yaml postgres-minimal.yaml
+# source_fragments: init-secrets-minimal.yaml matrix-authentication-service-minimal.yaml postgres-minimal.yaml well-known-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/well-known-minimal-values.yaml
+++ b/charts/matrix-stack/ci/well-known-minimal-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: well-known-minimal.yaml init-secrets-disabled.yaml
+# source_fragments: init-secrets-disabled.yaml well-known-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/well-known-synapse-mas-values.yaml
+++ b/charts/matrix-stack/ci/well-known-synapse-mas-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: well-known-minimal.yaml synapse-minimal.yaml matrix-authentication-service-minimal.yaml init-secrets-minimal.yaml postgres-minimal.yaml
+# source_fragments: init-secrets-minimal.yaml matrix-authentication-service-minimal.yaml postgres-minimal.yaml synapse-minimal.yaml well-known-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled

--- a/charts/matrix-stack/ci/well-known-synapse-values.yaml
+++ b/charts/matrix-stack/ci/well-known-synapse-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# source_fragments: well-known-minimal.yaml synapse-minimal.yaml init-secrets-minimal.yaml postgres-minimal.yaml
+# source_fragments: init-secrets-minimal.yaml postgres-minimal.yaml synapse-minimal.yaml well-known-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres, wellKnownDelegation don't have any required properties to be set and defaults to enabled

--- a/newsfragments/622.internal.md
+++ b/newsfragments/622.internal.md
@@ -1,0 +1,1 @@
+CI: sort list of `source_fragments` in CI values files.

--- a/scripts/assemble_ci_values_files_from_fragments.sh
+++ b/scripts/assemble_ci_values_files_from_fragments.sh
@@ -62,7 +62,7 @@ for values_file in "$values_file_root"/$values_file_prefix-values.yaml "$user_va
 
   cat << EOF >> "$values_file"
 #
-# source_fragments: $source_fragments
+# source_fragments: $(echo "$source_fragments" | tr " " "\n" | sort | uniq | tr "\n" " " | sed 's/^\s*//' | sed 's/\s*$//')
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 EOF


### PR DESCRIPTION
So that all our values files have consistent ordering for ease of diffing.

Only other changes here is that `charts/matrix-stack/ci/matrix-rtc-checkov-values.yaml` was missing `init-secrets-minimal.yaml` but this file is empty so had no functional impact