### PR TITLE
Sort source_fragments before assembly to remove the chance of differences being generated on a subsequent run

### DIFF
--- a/newsfragments/623.internal.md
+++ b/newsfragments/623.internal.md
@@ -1,0 +1,1 @@
+CI: sort list of `source_fragments` in CI values files.

--- a/scripts/assemble_ci_values_files_from_fragments.sh
+++ b/scripts/assemble_ci_values_files_from_fragments.sh
@@ -26,6 +26,7 @@ for values_file in "$values_file_root"/$values_file_prefix-values.yaml "$user_va
     echo "$values_file doesn't have a source_fragments header comment. Skipping"
     continue
   fi
+  source_fragments=$(echo "$source_fragments" | tr " " "\n" | sort | uniq | tr "\n" " " | sed 's/^\s*//' | sed 's/\s*$//')
 
   yq_command='.'
   for fragment_name in ${source_fragments}; do
@@ -62,7 +63,7 @@ for values_file in "$values_file_root"/$values_file_prefix-values.yaml "$user_va
 
   cat << EOF >> "$values_file"
 #
-# source_fragments: $(echo "$source_fragments" | tr " " "\n" | sort | uniq | tr "\n" " " | sed 's/^\s*//' | sed 's/\s*$//')
+# source_fragments: $source_fragments
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 EOF


### PR DESCRIPTION
If the order of fragments does matter, we don't want `no-changes-after-building` to fail because the fragments are now being applied in a different order, so sort before applying