### PR TITLE
fix flakes in test_pods_monitored

### DIFF
--- a/newsfragments/628.internal.md
+++ b/newsfragments/628.internal.md
@@ -1,0 +1,1 @@
+Fix flakes in CI tests when checking monitored pods.

--- a/tests/integration/test_networking.py
+++ b/tests/integration/test_networking.py
@@ -123,6 +123,8 @@ async def test_pods_monitored(
     ):
         if pod.metadata and pod.metadata.annotations and "has-no-service-monitor" in pod.metadata.annotations:
             continue
+        if pod.status and pod.status.phase in ("Terminating", "Succeeded"):
+            continue  # Skip terminating pods
         elif pod.metadata:
             assert pod.metadata.name, "Encountered a pod without a name"
             all_monitorable_pods.add(pod.metadata.name)


### PR DESCRIPTION
I expect : 

```

  Extra items in the left set:
  'pytest-sr25rymj-synapse-fed-reader-8467697d74-rq5rz'
  'pytest-sr25rymj-haproxy-54cf68977-ghjwf'
  'pytest-sr25rymj-haproxy-54cf68977-ckdz7'
  'pytest-sr25rymj-synapse-main-0'
  'pytest-sr25rymj-postgres-0'
  
  Full diff:
  - set()
  + {
  +     'pytest-sr25rymj-haproxy-54cf68977-ckdz7',
  +     'pytest-sr25rymj-haproxy-54cf68977-ghjwf',
  +     'pytest-sr25rymj-postgres-0',
  +     'pytest-sr25rymj-synapse-fed-reader-8467697d74-rq5rz',
  +     'pytest-sr25rymj-synapse-main-0',
  + }
  ```

To be a similar problem to https://github.com/element-hq/ess-helm/pull/627