### PR TITLE
Synapse: fix requests being routed to initial-synchrotron incorrectly

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -105,7 +105,7 @@ jobs:
 
     - name: On upgrade, Synapse can restart, expect 429 to occur
       run: |
-        export PYTEST_EXPECTED_HTTP_STATUS_CODES="429"
+        echo "PYTEST_EXPECTED_HTTP_STATUS_CODES=429" >> "$GITHUB_ENV"
       if: ${{ matrix.test-from-ref != github.event.pull_request.head.sha }}
 
     - name: Test with pytest (upgrade or idempotent setup)

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -136,7 +136,7 @@ jobs:
       if: ${{ failure() }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       with:
-        name: ess-helm-logs-${{ matrix.test-component }}
+        name: ess-helm-logs-${{ matrix.test-component }}-${{ matrix.test-from-ref }}
         path: ess-helm-logs
         retention-days: 1
 

--- a/charts/matrix-stack/ci/fragments/synapse-pytest-self-extras.yaml
+++ b/charts/matrix-stack/ci/fragments/synapse-pytest-self-extras.yaml
@@ -20,9 +20,15 @@ synapse:
     # A non-HTTP worker & a stream writer
     event-persister:
       enabled: true
+    # initial-synchrotron & synchrotron have non-trivial routing behaviour
+    initial-synchrotron:
+      enabled: true
     # A standard HTTP worker
     sliding-sync:
       replicas: 2
+      enabled: true
+    # initial-synchrotron & synchrotron have non-trivial routing behaviour
+    synchrotron:
       enabled: true
     # Media repo is fairly distinct from other workers
     media-repository:

--- a/charts/matrix-stack/ci/pytest-synapse-values.yaml
+++ b/charts/matrix-stack/ci/pytest-synapse-values.yaml
@@ -58,6 +58,9 @@ synapse:
     # A non-HTTP worker & a stream writer
     event-persister:
       enabled: true
+    # initial-synchrotron & synchrotron have non-trivial routing behaviour
+    initial-synchrotron:
+      enabled: true
     # Media repo is fairly distinct from other workers
     media-repository:
       enabled: true
@@ -65,5 +68,8 @@ synapse:
     sliding-sync:
       enabled: true
       replicas: 2
+    # initial-synchrotron & synchrotron have non-trivial routing behaviour
+    synchrotron:
+      enabled: true
 wellKnownDelegation:
   enabled: false

--- a/newsfragments/632.fixed.md
+++ b/newsfragments/632.fixed.md
@@ -1,0 +1,1 @@
+Synapse: fix requests being routed to initial-synchrotron incorrectly.

--- a/tests/integration/lib/utils.py
+++ b/tests/integration/lib/utils.py
@@ -29,7 +29,6 @@ retry_options = JitterRetry(
     }
     | set(int(code) for code in os.environ.get("PYTEST_EXPECTED_HTTP_STATUS_CODES", "").split(",") if code),
     retry_all_server_errors=False,
-    exceptions={aiohttp.client_exceptions.ClientResponseError},
 )
 
 

--- a/tests/integration/test_synapse.py
+++ b/tests/integration/test_synapse.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 import pyhelm3
 import pytest
+from aiohttp.client_exceptions import ClientResponseError
+from lightkube import AsyncClient
+from lightkube.resources.core_v1 import Pod
 
 from .fixtures import ESSData, User
 from .lib.helpers import deploy_with_values_patch, get_deployment_marker
@@ -35,7 +38,9 @@ async def test_synapse_can_access_client_api(
 @pytest.mark.skipif(value_file_has("synapse.enabled", False), reason="Synapse not deployed")
 @pytest.mark.parametrize("users", [(User(name="sliding-sync-user"),)], indirect=True)
 @pytest.mark.asyncio_cooperative
-async def test_simplified_sliding_sync_syncs(ssl_context, users, generated_data: ESSData):
+async def test_simplified_sliding_sync_syncs(ingress_ready, ssl_context, users, generated_data: ESSData):
+    await ingress_ready("synapse")
+
     access_token = users[0].access_token
 
     sync_result = await aiohttp_post_json(
@@ -46,6 +51,73 @@ async def test_simplified_sliding_sync_syncs(ssl_context, users, generated_data:
     )
 
     assert "pos" in sync_result
+
+
+@pytest.mark.skipif(value_file_has("synapse.enabled", False), reason="Synapse not deployed")
+@pytest.mark.asyncio_cooperative
+async def test_routes_to_synapse_workers_correctly(
+    ingress_ready, kube_client: AsyncClient, ssl_context, generated_data: ESSData
+):
+    await ingress_ready("synapse")
+
+    main_backend = "main/main"
+    if value_file_has("synapse.workers.sliding-sync.enabled", True):
+        sliding_sync_backend = "sliding-sync/sliding-sync"
+    else:
+        sliding_sync_backend = main_backend
+
+    if value_file_has("synapse.workers.synchrotron.enabled", True):
+        synchrotron_backend = "synchrotron/synchrotron"
+    else:
+        synchrotron_backend = main_backend
+
+    if value_file_has("synapse.workers.initial-synchrotron.enabled", True):
+        initial_synchrotron_backend = "initial-synchrotron/initial-sync"
+    else:
+        initial_synchrotron_backend = synchrotron_backend
+
+    # We don't care about any of these succeeding, only that the requests are made and HAProxy dispatches correctly
+    # So no auth required and parameters can be made up
+    paths_to_backends = {
+        # initial-synchrotron
+        "/_matrix/client/v3/initialSync": initial_synchrotron_backend,
+        "/_matrix/client/v3/rooms/aroomid/initialSync": initial_synchrotron_backend,
+        "/_matrix/client/v3/sync?full_state=true": initial_synchrotron_backend,
+        "/_matrix/client/v3/sync": initial_synchrotron_backend,
+        "/_matrix/client/v3/events": initial_synchrotron_backend,
+        # synchrotron
+        "/_matrix/client/v3/sync?since=recently": synchrotron_backend,
+        "/_matrix/client/v3/events?from=recently": synchrotron_backend,
+        # sliding-sync
+        "/_matrix/client/unstable/org.matrix.simplified_msc3575/sync": sliding_sync_backend,
+        # Would be client-reader but not configured in tests
+        "/_matrix/client/versions": main_backend,
+    }
+
+    for path in paths_to_backends:
+        try:
+            await aiohttp_get_json(f"https://synapse.{generated_data.server_name}{path}", ssl_context)
+        except ClientResponseError as e:
+            # We can't use pytest.raises as no exception (200) is valid
+            assert e.status in [401, 405], f"{path} had an unexpected status. {e=}"  # noqa P1017
+
+    http_log_lines = []
+    async for haproxy_pod in kube_client.list(
+        Pod, namespace=generated_data.ess_namespace, labels={"app.kubernetes.io/name": "haproxy"}
+    ):
+        assert haproxy_pod.metadata
+        assert haproxy_pod.metadata.name
+        assert haproxy_pod.metadata.namespace
+        async for log_line in kube_client.log(haproxy_pod.metadata.name, namespace=haproxy_pod.metadata.namespace):
+            if "HTTP/1.1" in log_line:
+                http_log_lines.append(log_line)
+
+    for path, backend in paths_to_backends.items():
+        matching_lines = [line for line in http_log_lines if f"GET {path} HTTP/1.1" in line]
+
+        assert len(matching_lines) > 0, f"Requests for {path} did not appear in the HAProxy logs"
+        for matching_line in matching_lines:
+            assert f"synapse-http-in synapse-{backend}" in matching_line, f"{path} was routed unexpectedly"
 
 
 @pytest.mark.skipif(value_file_has("synapse.enabled", False), reason="Synapse not deployed")


### PR DESCRIPTION
Fixes #631. Regression from #508

HAProxy `acl`s don't appear to support multiple matches. It appears if multiple matches are specified (attempting to do ANDs), HAProxy silently accepts and just uses the final matcher.

Replace the `is_initial_sync` ACLs with multiple `http-request set-var(req.backend) str('initial-synchrotron')` to resolve.

Re-running the tests from #508 and adding a test based on #631 (logs and commands lightly edited for readability):
```
$ helm upgrade -i -n ess ess charts/matrix-stack -f charts/matrix-stack/ci/synapse-minimal-values.yaml --set 'synapse.workers.receipts-account.enabled=true' --set 'synapse.workers.initial-synchrotron.enabled=true' --set 'synapse.workers.synchrotron.enabled=true'
Release "ess" has been upgraded. Happy Helming!
...

$ curl -X POST 'https://synapse.ess.localhost/_matrix/client/v3/rooms/!vaZLnlZZLicjbBJZZb:my.domain/receipt/m.read/$gK0lCxB9qUN666ZhW3qzNJe1x8l_GDkbPzU6hfa-mzc' -k
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}
$ curl -k https://synapse.ess.localhost/_matrix/client/r0/sync
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}%
$ curl -k https://synapse.ess.localhost/_matrix/client/r0/initialSync
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}%
$ curl -k 'https://synapse.ess.localhost/_matrix/client/r0/sync?since=fwibble'
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}%

$ kubectl -n ess scale --replicas=0 sts/ess-synapse-initial-sync sts/ess-synapse-synchrotron
statefulset.apps/ess-synapse-initial-sync scaled
statefulset.apps/ess-synapse-synchrotron scaled

$ curl -k https://synapse.ess.localhost/_matrix/client/r0/sync
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}
$ curl -k https://synapse.ess.localhost/_matrix/client/r0/initialSync
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}
$ curl -k 'https://synapse.ess.localhost/_matrix/client/r0/sync?since=fwibble'
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}

$ kubectl -n ess scale --replicas=1 sts/ess-synapse-synchrotron
statefulset.apps/ess-synapse-synchrotron scaled

$ curl -X POST 'https://synapse.ess.localhost/_matrix/client/v3/rooms/!vaZLnlZZLicjbBJZZb:my.domain/receipt/m.read/$gK0lCxB9qUN666ZhW3qzNJe1x8l_GDkbPzU6hfa-mzc' -k
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}
$ curl -k 'https://synapse.ess.localhost/_matrix/client/r0/sync?since=fwibble'
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}
$ curl -k https://synapse.ess.localhost/_matrix/client/r0/sync
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}
$ curl -k https://synapse.ess.localhost/_matrix/client/r0/initialSync
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}
$ curl -X POST 'https://synapse.ess.localhost/_matrix/client/v3/rooms/!vaZLnlZZLicjbBJZZb:my.domain/receipt/m.read/$gK0lCxB9qUN666ZhW3qzNJe1x8l_GDkbPzU6hfa-mzc' -k
{"errcode":"M_MISSING_TOKEN","error":"Missing access token"}%
```

Results in
```
$ kubectl -n ess logs -f --tail=-1 -l app.kubernetes.io/name=haproxy
...
192.168.112.1:39022 [29/Jul/2025:08:32:17.206] synapse-http-in synapse-receipts-account/receipts-accnt1 0/0/0/0/2/2 401 484 - - ---- 1/1/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "POST /_matrix/client/v3/rooms/!vaZLnlZZLicjbBJZZb:my.domain/receipt/m.read/$gK0lCxB9qUN666ZhW3qzNJe1x8l_GDkbPzU6hfa-mzc HTTP/1.1"
192.168.112.1:39034 [29/Jul/2025:08:32:22.666] synapse-http-in synapse-initial-synchrotron/initial-sync1 0/0/0/0/2/2 401 484 - - ---- 2/2/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "GET /_matrix/client/r0/sync HTTP/1.1"
192.168.112.1:39022 [29/Jul/2025:08:32:26.906] synapse-http-in synapse-initial-synchrotron/initial-sync1 0/0/0/0/1/1 401 484 - - ---- 2/2/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "GET /_matrix/client/r0/initialSync HTTP/1.1"
192.168.112.1:39792 [29/Jul/2025:08:32:50.077] synapse-http-in synapse-synchrotron/synchrotron1 0/0/0/0/2/2 401 484 - - ---- 3/3/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "GET /_matrix/client/r0/sync?since=fwibble HTTP/1.1"
backend synapse-synchrotron has no server available!
backend synapse-initial-synchrotron has no server available!
192.168.112.1:41684 [29/Jul/2025:08:33:16.105] synapse-http-in synapse-main-failover/main1 0/0/0/0/2/2 401 484 - - ---- 4/4/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "GET /_matrix/client/r0/sync HTTP/1.1"
192.168.112.1:41694 [29/Jul/2025:08:33:20.885] synapse-http-in synapse-main-failover/main1 0/0/0/0/2/2 401 484 - - ---- 5/5/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "GET /_matrix/client/r0/initialSync HTTP/1.1"
192.168.112.1:41696 [29/Jul/2025:08:33:22.844] synapse-http-in synapse-main-failover/main1 0/0/0/0/1/1 401 484 - - ---- 5/5/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "GET /_matrix/client/r0/sync?since=fwibble HTTP/1.1"
192.168.112.1:60174 [29/Jul/2025:08:33:34.680] synapse-http-in synapse-receipts-account/receipts-accnt1 0/0/0/0/1/1 401 484 - - ---- 5/5/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "POST /_matrix/client/v3/rooms/!vaZLnlZZLicjbBJZZb:my.domain/receipt/m.read/$gK0lCxB9qUN666ZhW3qzNJe1x8l_GDkbPzU6hfa-mzc HTTP/1.1"
Server synapse-synchrotron/synchrotron2 administratively READY thanks to valid DNS answer.
192.168.112.1:34574 [29/Jul/2025:08:33:44.406] synapse-http-in synapse-synchrotron/synchrotron2 0/0/0/0/4/4 401 484 - - ---- 8/8/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "GET /_matrix/client/r0/sync?since=fwibble HTTP/1.1"
192.168.112.1:60184 [29/Jul/2025:08:33:52.917] synapse-http-in synapse-synchrotron/synchrotron2 0/0/0/0/2/2 401 484 - - ---- 7/7/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "GET /_matrix/client/r0/sync HTTP/1.1"
192.168.112.1:41756 [29/Jul/2025:08:33:54.164] synapse-http-in synapse-synchrotron/synchrotron2 0/0/0/0/2/2 401 484 - - ---- 8/8/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "GET /_matrix/client/r0/initialSync HTTP/1.1"
192.168.112.1:41762 [29/Jul/2025:08:34:01.614] synapse-http-in synapse-receipts-account/receipts-accnt1 0/0/0/0/1/1 401 484 - - ---- 9/9/0/0/0 0/0 {synapse.ess.localhost||curl/8.5.0} "POST /_matrix/client/v3/rooms/!vaZLnlZZLicjbBJZZb:my.domain/receipt/m.read/$gK0lCxB9qUN666ZhW3qzNJe1x8l_GDkbPzU6hfa-mzc HTTP/1.1"
```