### PR TITLE
ci: fix showing warning about tags

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
       with:
         fetch-depth: 0
-        tags: true
+        fetch-tags: true
     - id: data
       run: |
         echo "envFiles=$(find tests/integration/env -name '*.rc' | sed 's|tests/integration/env/||' | sed 's/.rc$//' | jq -ncR '{envFiles: [inputs]}')" | tee -a "$GITHUB_OUTPUT"

--- a/newsfragments/636.internal.md
+++ b/newsfragments/636.internal.md
@@ -1,0 +1,1 @@
+CI: Fix warnings about wrong checkout action parameters.


### PR DESCRIPTION
Noticed : 
<img width="1248" height="118" alt="image" src="https://github.com/user-attachments/assets/7232be48-1544-4283-a9b2-fcfbb1a31c4b" />
