### PR TITLE
Upgrade to Synapse v1.135.0

### DIFF
--- a/charts/matrix-stack/ci/fragments/synapse-all-workers-running.yaml
+++ b/charts/matrix-stack/ci/fragments/synapse-all-workers-running.yaml
@@ -12,6 +12,8 @@ synapse:
       enabled: true
     client-reader:
       enabled: true
+    device-lists:
+      enabled: true
     encryption:
       enabled: true
     event-creator:

--- a/charts/matrix-stack/ci/synapse-worker-example-values.yaml
+++ b/charts/matrix-stack/ci/synapse-worker-example-values.yaml
@@ -27,6 +27,8 @@ synapse:
       enabled: true
     client-reader:
       enabled: true
+    device-lists:
+      enabled: true
     encryption:
       enabled: true
     event-creator:

--- a/charts/matrix-stack/configs/matrix-authentication-service/config.yaml.tpl
+++ b/charts/matrix-stack/configs/matrix-authentication-service/config.yaml.tpl
@@ -64,6 +64,9 @@ We don't want MAS to change data in Synapse
 */}}
 {{- if and .syn2mas.enabled .syn2mas.dryRun }}
   kind: synapse_read_only
+{{- else }}
+{{- /* Switch to synapse_modern after a release or 2 so that we're more likely to have a Synapse that supports this API on redeploying MAS. */}}
+  kind: synapse_legacy
 {{- end }}
 {{- end }}
 

--- a/charts/matrix-stack/configs/synapse/path_map_file_get.tpl
+++ b/charts/matrix-stack/configs/synapse/path_map_file_get.tpl
@@ -26,7 +26,6 @@ workers instead if these requests path are under high load.
 ^/\_matrix/client/(api/v1|r0|v3|unstable)/presence/
 */}}
 ^/_matrix/client/unstable/org.matrix.msc4140/delayed_events client-reader
-^/_matrix/client/(api/v1|r0|v3|unstable)/devices/ client-reader
 {{- end }}
 {{ if dig "sso-login" "enabled" false $root.Values.synapse.workers }}
 {{- if (and $root.Values.matrixAuthenticationService.enabled (not $root.Values.matrixAuthenticationService.preMigrationSynapseHandlesAuth)) }}

--- a/charts/matrix-stack/configs/synapse/path_map_file_get.tpl
+++ b/charts/matrix-stack/configs/synapse/path_map_file_get.tpl
@@ -27,8 +27,3 @@ workers instead if these requests path are under high load.
 */}}
 ^/_matrix/client/unstable/org.matrix.msc4140/delayed_events client-reader
 {{- end }}
-{{ if dig "sso-login" "enabled" false $root.Values.synapse.workers }}
-{{- if (and $root.Values.matrixAuthenticationService.enabled (not $root.Values.matrixAuthenticationService.preMigrationSynapseHandlesAuth)) }}
-^/_synapse/admin/v1/users/[^/]+/devices$ sso-login
-{{- end }}
-{{- end }}

--- a/charts/matrix-stack/source/synapse.json
+++ b/charts/matrix-stack/source/synapse.json
@@ -199,6 +199,9 @@
         "encryption": {
           "$ref": "file://synapse/single_worker.json"
         },
+        "device-lists": {
+          "$ref": "file://synapse/scalable_worker.json"
+        },
         "event-creator": {
           "$ref": "file://synapse/scalable_worker.json"
         },

--- a/charts/matrix-stack/source/synapse.yaml.j2
+++ b/charts/matrix-stack/source/synapse.yaml.j2
@@ -55,6 +55,7 @@ workers:
 {{- synapse_sub_schema_values.single_worker('appservice') | indent(2) }}
 {{- synapse_sub_schema_values.single_worker('background') | indent(2) }}
 {{- synapse_sub_schema_values.scalable_worker('client-reader') | indent(2) }}
+{{- synapse_sub_schema_values.scalable_worker('device-lists') | indent(2) }}
 {{- synapse_sub_schema_values.single_worker('encryption') | indent(2) }}
 {{- synapse_sub_schema_values.scalable_worker('event-creator') | indent(2) }}
 {{- synapse_sub_schema_values.scalable_worker('event-persister') | indent(2) }}

--- a/charts/matrix-stack/source/synapse.yaml.j2
+++ b/charts/matrix-stack/source/synapse.yaml.j2
@@ -83,7 +83,7 @@ logging:
   ## levelOverrides:
   ##   synapse.util.caches.lrucache: WARNING
   levelOverrides: {}
-{{- sub_schema_values.image(registry='ghcr.io', repository='element-hq/synapse', tag='v1.134.0') }}
+{{- sub_schema_values.image(registry='ghcr.io', repository='element-hq/synapse', tag='v1.135.0') }}
 {{- sub_schema_values.ingress() }}
 {{- sub_schema_values.labels() }}
 {{- sub_schema_values.workloadAnnotations() }}

--- a/charts/matrix-stack/templates/synapse/_synapse_details.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_details.tpl
@@ -422,7 +422,7 @@ responsibleForMedia
   "^/_synapse/client/saml2/authn_response$"
   "^/_matrix/client/(api/v1|r0|v3|unstable)/login/cas/ticket$"
 ) }}
-{{- if (and $root.Values.matrixAuthenticationService.enabled (not $root.Values.matrixAuthenticationService.preMigrationSynapseHandlesAuth)) }}
+{{- if include "element-io.matrix-authentication-service.readyToHandleAuth" (dict "root" $root) }}
 {{ $workerPaths = concat $workerPaths (list
     "^/_synapse/admin/v2/users/[^/]+$"
     "^/_synapse/admin/v1/username_available$"

--- a/charts/matrix-stack/templates/synapse/_synapse_details.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_details.tpl
@@ -10,6 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{ $hasHttp := (list "main"
                      "account-data"
                      "client-reader"
+                     "device-lists"
                      "encryption"
                      "event-creator"
                      "federation-inbound"
@@ -35,6 +36,7 @@ hasHttp
 {{- with required "element-io.synapse.process.hasReplication missing context" .context -}}
 {{- $hasReplication := (list "main"
                              "account-data"
+                             "device-lists"
                              "encryption"
                              "event-persister"
                              "push-rules"
@@ -134,6 +136,8 @@ responsibleForMedia
 {{- with required "element-io.synapse.process.streamWriters missing context" .context -}}
 {{- if eq . "account-data" }}
 {{ list "account_data" | toJson }}
+{{- else if eq . "device-lists" }}
+{{ list "device_lists" | toJson }}
 {{- else if eq . "encryption" }}
 {{ list "to_device" | toJson }}
 {{- else if eq . "event-persister" }}
@@ -293,7 +297,16 @@ responsibleForMedia
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(r0|v3|unstable)/keys/claim$"
   "^/_matrix/client/(r0|v3|unstable)/room_keys/"
+) }}
+{{- end }}
+
+{{- if eq .workerType "device-lists" }}
+{{ $workerPaths = concat $workerPaths (list
+  "^/_matrix/client/(r0|v3)/delete_devices$"
+  "^/_matrix/client/(api/v1|r0|v3|unstable)/devices(/|$)"
   "^/_matrix/client/(r0|v3|unstable)/keys/upload"
+  "^/_matrix/client/(api/v1|r0|v3|unstable)/keys/device_signing/upload$"
+  "^/_matrix/client/(api/v1|r0|v3|unstable)/keys/signatures/upload$"
 ) }}
 {{- end }}
 

--- a/charts/matrix-stack/templates/synapse/_synapse_details.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_details.tpl
@@ -311,9 +311,9 @@ responsibleForMedia
 {{- end }}
 
 {{- if eq .workerType "encryption" }}
-{{ $workerPaths = append $workerPaths
+{{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(r0|v3|unstable)/sendToDevice/"
-}}
+) }}
 {{- end }}
 
 {{- if eq .workerType "event-creator" }}
@@ -386,9 +386,9 @@ responsibleForMedia
 {{- end }}
 
 {{- if eq .workerType "presence-writer" }}
-{{ $workerPaths = append $workerPaths
+{{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(api/v1|r0|v3|unstable)/presence/"
-}}
+) }}
 {{- end }}
 
 {{- if eq .workerType "push-rules" }}
@@ -405,9 +405,9 @@ responsibleForMedia
 {{- end }}
 
 {{- if eq .workerType "sliding-sync" }}
-{{ $workerPaths = append $workerPaths
+{{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/unstable/org.matrix.simplified_msc3575/.*"
-}}
+) }}
 {{- end }}
 
 {{- if eq .workerType "sso-login" }}
@@ -441,15 +441,15 @@ responsibleForMedia
 {{- end }}
 
 {{- if eq .workerType "typing-persister" }}
-{{ $workerPaths = append $workerPaths
+{{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/typing"
-}}
+) }}
 {{- end }}
 
 {{- if eq .workerType "user-dir" }}
-{{ $workerPaths = append $workerPaths
+{{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(r0|v3|unstable)/user_directory/search$"
-}}
+) }}
 {{- end }}
 {{ $workerPaths | toJson }}
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/_synapse_details.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_details.tpl
@@ -261,6 +261,7 @@ responsibleForMedia
   "^/_matrix/client/unstable/im.nheko.summary/summary/.*$"
   "^/_matrix/client/(r0|v3|unstable)/account/3pid$"
   "^/_matrix/client/(r0|v3|unstable)/account/whoami$"
+  "^/_matrix/client/(r0|v3|unstable)/account/deactivate$"
   "^/_matrix/client/(r0|v3|unstable)/devices$"
   "^/_matrix/client/versions$"
   "^/_matrix/client/(api/v1|r0|v3|unstable)/voip/turnServer$"

--- a/charts/matrix-stack/templates/synapse/_synapse_details.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_details.tpl
@@ -427,6 +427,7 @@ responsibleForMedia
     "^/_synapse/admin/v2/users/[^/]+$"
     "^/_synapse/admin/v1/username_available$"
     "^/_synapse/admin/v1/users/[^/]+/_allow_cross_signing_replacement_without_uia$"
+    "^/_synapse/admin/v1/users/[^/]+/devices$"
 ) }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -7270,6 +7270,282 @@
               "type": "object",
               "additionalProperties": false
             },
+            "device-lists": {
+              "required": [
+                "replicas"
+              ],
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "replicas": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "resources": {
+                  "properties": {
+                    "limits": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                      },
+                      "type": "object"
+                    },
+                    "requests": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "topologySpreadConstraints": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "maxSkew",
+                      "topologyKey"
+                    ],
+                    "properties": {
+                      "labelSelector": {
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "enum": [
+                                    "In",
+                                    "NotIn",
+                                    "Exists",
+                                    "DoesNotExist"
+                                  ]
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "matchLabels": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "maxSkew": {
+                        "type": "integer",
+                        "minium": 1
+                      },
+                      "minDomains": {
+                        "type": "integer",
+                        "minium": 0
+                      },
+                      "nodeAffinityPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "nodeTaintsPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "type": "string",
+                        "enum": [
+                          "DoNotSchedule",
+                          "ScheduleAnyway"
+                        ]
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "livenessProbe": {
+                  "type": "object",
+                  "properties": {
+                    "failureThreshold": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "initialDelaySeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 0
+                    },
+                    "periodSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "successThreshold": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "timeoutSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "readinessProbe": {
+                  "type": "object",
+                  "properties": {
+                    "failureThreshold": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "initialDelaySeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 0
+                    },
+                    "periodSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "successThreshold": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "timeoutSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "startupProbe": {
+                  "type": "object",
+                  "properties": {
+                    "failureThreshold": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "initialDelaySeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 0
+                    },
+                    "periodSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "successThreshold": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "timeoutSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "event-creator": {
               "required": [
                 "replicas"

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -3664,7 +3664,7 @@ synapse:
 
     ## The tag of the container image to use.
     ## One of tag or digest must be provided.
-    tag: "v1.134.0"
+    tag: "v1.135.0"
 
     ## Container digest to use. Used to pull the image instead of the image tag if set
     ## The tag will still be set as the app.kubernetes.io/version label

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -2677,6 +2677,64 @@ synapse:
 
         ## Number of seconds after which the probe times out
         timeoutSeconds: 1
+    device-lists:
+      ## Set to true to deploy this worker
+      enabled: false
+
+      ## The number of replicas of this worker to run
+      replicas: 1
+
+      ## Resources for this worker.
+      ## If omitted the global Synapse resources are used
+      # resources: {}
+      ## Configuration of the thresholds and frequencies of the livenessProbe
+      livenessProbe:
+        ## How many consecutive failures for the probe to be considered failed
+        failureThreshold: 3
+
+        ## Number of seconds after the container has started before the probe starts
+        initialDelaySeconds: 0
+
+        ## How often (in seconds) to perform the probe
+        periodSeconds: 6
+
+        ## How many consecutive successes for the probe to be consider successful after having failed
+        successThreshold: 1
+
+        ## Number of seconds after which the probe times out
+        timeoutSeconds: 2
+      ## Configuration of the thresholds and frequencies of the readinessProbe
+      readinessProbe:
+        ## How many consecutive failures for the probe to be considered failed
+        failureThreshold: 3
+
+        ## Number of seconds after the container has started before the probe starts
+        initialDelaySeconds: 0
+
+        ## How often (in seconds) to perform the probe
+        periodSeconds: 2
+
+        ## How many consecutive successes for the probe to be consider successful after having failed
+        successThreshold: 2
+
+        ## Number of seconds after which the probe times out
+        timeoutSeconds: 2
+      ## Configuration of the thresholds and frequencies of the startupProbe
+      startupProbe:
+        ## How many consecutive failures for the probe to be considered failed
+        failureThreshold: 21
+
+        ## Number of seconds after the container has started before the probe starts
+        initialDelaySeconds: 0
+
+        ## How often (in seconds) to perform the probe
+        periodSeconds: 2
+
+        ## How many consecutive successes for the probe to be consider successful after having failed
+        successThreshold: 1
+
+        ## Number of seconds after which the probe times out
+        timeoutSeconds: 1
     encryption:
       ## Set to true to deploy this worker
       enabled: false

--- a/newsfragments/639.changed.1.md
+++ b/newsfragments/639.changed.1.md
@@ -1,0 +1,1 @@
+Introduce a `device-lists` worker for Synapse.

--- a/newsfragments/639.changed.2.md
+++ b/newsfragments/639.changed.2.md
@@ -1,0 +1,1 @@
+Update worker capable paths for Synapse v1.135.0.

--- a/newsfragments/639.changed.md
+++ b/newsfragments/639.changed.md
@@ -1,0 +1,9 @@
+Upgrade Synapse to v1.135.0.
+
+Highlights:
+* Advertise support for Matrix v1.12
+* Add ability to limit amount of media uploaded by a user in a given time period
+* Support arbitrary profile fields
+
+Full Changelog:
+* [v1.135.0](https://github.com/element-hq/synapse/releases/tag/v1.135.0)

--- a/newsfragments/639.fixed.md
+++ b/newsfragments/639.fixed.md
@@ -1,0 +1,1 @@
+Fix incorrect routing for Matrix Authentication Service related Synapse Admin API paths during migration.

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -377,6 +377,7 @@ synapse_workers_details = tuple(
         "appservice": "single",
         "background": "single",
         "client-reader": "scalable",
+        "device-lists": "scalable",
         "encryption": "single",
         "event-creator": "scalable",
         "event-persister": "scalable",


### PR DESCRIPTION
Relies on the following PRs:
* https://github.com/element-hq/synapse/pull/18581
  * Some of the changes here show that the `receipts` event stream supports multiple workers, but it isn't documented as such. The `account_data` event stream doesn't and we currently bundle these 2 together. Enabling `receipts` as a scalable worker would require splitting the 2. Updating the documentation to make this obvious in https://github.com/element-hq/synapse/pull/18760 and implementing this in ESS in https://github.com/element-hq/ess-helm/pull/640
  * Incorporates the pending documentation changes in https://github.com/element-hq/synapse/pull/18761 given matrix.org's configuration
* https://github.com/element-hq/synapse/pull/18716
* https://github.com/element-hq/synapse/pull/18520
* <del>https://github.com/element-hq/matrix-authentication-service/pull/4801</del> we're explicitly using `synapse_legacy` for a few releases