### PR TITLE
Fix flakes in Synapse worker routing test

### DIFF
--- a/newsfragments/642.fixed.md
+++ b/newsfragments/642.fixed.md
@@ -1,0 +1,1 @@
+Synapse: fix requests being routed to initial-synchrotron incorrectly.

--- a/tests/integration/test_synapse.py
+++ b/tests/integration/test_synapse.py
@@ -117,6 +117,12 @@ async def test_routes_to_synapse_workers_correctly(
 
         assert len(matching_lines) > 0, f"Requests for {path} did not appear in the HAProxy logs"
         for matching_line in matching_lines:
+            # During the upgrade tests these requests may NOSRV as Synapse processes are down
+            # We eventually succeed, so just ignore the requests that were retried
+            if " 503 " in matching_line and " synapse-main/<NOSRV> " in matching_line:
+                continue
+
+            # We know we end up here at least once as 2xx/401/405 won't match the above check
             assert f"synapse-http-in synapse-{backend}" in matching_line, f"{path} was routed unexpectedly"
 
 


### PR DESCRIPTION
Fixes things like https://github.com/element-hq/ess-helm/actions/runs/16601437557/job/46961925846#step:12:124.

When upgrading Synapse can restart. We retry the 429's (present in the HAProxy logs as 503s), as can be seen by the fact that we don't fail at the `assert e.status in [401, 405]` line, however they will end up in the HAProxy logs, so just filter them out 