### PR TITLE
Don't run the Synapse routing test with syn2mas

### DIFF
--- a/newsfragments/643.fixed.md
+++ b/newsfragments/643.fixed.md
@@ -1,0 +1,1 @@
+Synapse: fix requests being routed to initial-synchrotron incorrectly.

--- a/tests/integration/test_synapse.py
+++ b/tests/integration/test_synapse.py
@@ -54,6 +54,10 @@ async def test_simplified_sliding_sync_syncs(ingress_ready, ssl_context, users, 
 
 
 @pytest.mark.skipif(value_file_has("synapse.enabled", False), reason="Synapse not deployed")
+@pytest.mark.skipif(
+    value_file_has("matrixAuthenticationService.syn2mas.enabled", True),
+    reason="Syn2Mas is being run and so HAProxy logs may disappear as it restarts",
+)
 @pytest.mark.asyncio_cooperative
 async def test_routes_to_synapse_workers_correctly(
     ingress_ready, kube_client: AsyncClient, ssl_context, generated_data: ESSData


### PR DESCRIPTION
Fixes https://github.com/element-hq/ess-helm/actions/runs/16678784911/job/47212049888.

Changlog entry as per #632 as that isn't in a release yet