### PR TITLE
Simplify Synapse worker helpers

### DIFF
--- a/charts/matrix-stack/configs/synapse/path_map_file.tpl
+++ b/charts/matrix-stack/configs/synapse/path_map_file.tpl
@@ -11,7 +11,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 {{ $enabledWorkerTypes := keys ((include "element-io.synapse.enabledWorkers" (dict "root" $root)) | fromJson) }}
 {{- range $workerType := $enabledWorkerTypes | sortAlpha }}
-{{- $workersPaths := (include "element-io.synapse.process.workerPaths" (dict "root" $root "context" (dict "workerType" $workerType "enabledWorkerTypes" $enabledWorkerTypes))) | fromJsonArray }}
+{{- $workersPaths := (include "element-io.synapse.process.workerPaths" (dict "root" $root "context" $workerType)) | fromJsonArray }}
 {{- if len $workersPaths }}
 # {{ $workerType }}
 {{- range $path := $workersPaths }}

--- a/charts/matrix-stack/templates/synapse/_synapse_details.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_details.tpl
@@ -7,25 +7,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- define "element-io.synapse.process.hasHttp" -}}
 {{- $root := .root -}}
 {{- with required "element-io.synapse.process.hasHttp missing context" .context -}}
-{{ $hasHttp := (list "main"
-                     "account-data"
-                     "client-reader"
-                     "device-lists"
-                     "encryption"
-                     "event-creator"
-                     "federation-inbound"
-                     "federation-reader"
-                     "initial-synchrotron"
-                     "media-repository"
-                     "presence-writer"
-                     "push-rules"
-                     "receipts"
-                     "sliding-sync"
-                     "sso-login"
-                     "synchrotron"
-                     "typing-persister"
-                     "user-dir") }}
-{{- if has . $hasHttp -}}
+{{- /* initial-synchrotron routing is done in configs/synapse/partial-haproxy.cfg.tpl so that it can fallback -> synchrotron -> main */}}
+{{- if or (has . (list "main" "initial-synchrotron")) (gt (len ((include "element-io.synapse.process.workerPaths" (dict "root" $root "context" .)) | fromJsonArray)) 0) -}}
 hasHttp
 {{- end -}}
 {{- end -}}

--- a/charts/matrix-stack/templates/synapse/_synapse_details.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_details.tpl
@@ -211,14 +211,14 @@ responsibleForMedia
 {{- with required "element-io.synapse.process.workerPaths missing context" .context -}}
 {{ $workerPaths := list }}
 
-{{- if eq .workerType "account-data" }}
+{{- if eq . "account-data" }}
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(r0|v3|unstable)/.*/tags"
   "^/_matrix/client/(r0|v3|unstable)/.*/account_data"
 ) }}
 {{- end }}
 
-{{- if eq .workerType "client-reader" }}
+{{- if eq . "client-reader" }}
 {{- /* Client API requests (apart from createRoom which is eventCreator) */}}
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(api/v1|r0|v3|unstable)/publicRooms$"
@@ -280,7 +280,7 @@ responsibleForMedia
 ) }}
 {{- end }}
 
-{{- if eq .workerType "device-lists" }}
+{{- if eq . "device-lists" }}
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(r0|v3)/delete_devices$"
   "^/_matrix/client/(api/v1|r0|v3|unstable)/devices(/|$)"
@@ -290,13 +290,13 @@ responsibleForMedia
 ) }}
 {{- end }}
 
-{{- if eq .workerType "encryption" }}
+{{- if eq . "encryption" }}
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(r0|v3|unstable)/sendToDevice/"
 ) }}
 {{- end }}
 
-{{- if eq .workerType "event-creator" }}
+{{- if eq . "event-creator" }}
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/redact"
   "^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/send"
@@ -309,7 +309,7 @@ responsibleForMedia
 ) }}
 {{- end }}
 
-{{- if eq .workerType "federation-inbound" }}
+{{- if eq . "federation-inbound" }}
 {{- /* Inbound federation transaction request */}}
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/federation/v1/send/"
@@ -317,7 +317,7 @@ responsibleForMedia
 }}
 {{- end }}
 
-{{- if eq .workerType "federation-reader" }}
+{{- if eq . "federation-reader" }}
 {{- /* All Federation REST requests for generic_worker */}}
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/federation/v1/version$"
@@ -351,7 +351,7 @@ responsibleForMedia
 
 {{- /* initial-synchrotron routing is done in configs/synapse/partial-haproxy.cfg.tpl so that it can fallback -> synchrotron -> main */}}
 
-{{- if eq .workerType "media-repository" }}
+{{- if eq . "media-repository" }}
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/media/"
   "^/_matrix/client/v1/media/"
@@ -365,32 +365,32 @@ responsibleForMedia
 ) }}
 {{- end }}
 
-{{- if eq .workerType "presence-writer" }}
+{{- if eq . "presence-writer" }}
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(api/v1|r0|v3|unstable)/presence/"
 ) }}
 {{- end }}
 
-{{- if eq .workerType "push-rules" }}
+{{- if eq . "push-rules" }}
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(api/v1|r0|v3|unstable)/pushrules/"
 ) }}
 {{- end }}
 
-{{- if eq .workerType "receipts" }}
+{{- if eq . "receipts" }}
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(r0|v3|unstable)/rooms/.*/receipt"
   "^/_matrix/client/(r0|v3|unstable)/rooms/.*/read_markers"
 ) }}
 {{- end }}
 
-{{- if eq .workerType "sliding-sync" }}
+{{- if eq . "sliding-sync" }}
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/unstable/org.matrix.simplified_msc3575/.*"
 ) }}
 {{- end }}
 
-{{- if eq .workerType "sso-login" }}
+{{- if eq . "sso-login" }}
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(api/v1|r0|v3|unstable)/login/sso/redirect"
   "^/_synapse/client/pick_idp$"
@@ -411,7 +411,7 @@ responsibleForMedia
 {{- end }}
 {{- end }}
 
-{{- if eq .workerType "synchrotron" }}
+{{- if eq . "synchrotron" }}
 {{- /* Update the initial-synchrotron handling in the haproxy.cfg frontend when updating this */}}
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(r0|v3)/sync$"
@@ -421,13 +421,13 @@ responsibleForMedia
 ) }}
 {{- end }}
 
-{{- if eq .workerType "typing-persister" }}
+{{- if eq . "typing-persister" }}
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/typing"
 ) }}
 {{- end }}
 
-{{- if eq .workerType "user-dir" }}
+{{- if eq . "user-dir" }}
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/client/(r0|v3|unstable)/user_directory/search$"
 ) }}

--- a/charts/matrix-stack/templates/synapse/_synapse_details.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_details.tpl
@@ -17,16 +17,7 @@ hasHttp
 {{- define "element-io.synapse.process.hasReplication" -}}
 {{- $root := .root -}}
 {{- with required "element-io.synapse.process.hasReplication missing context" .context -}}
-{{- $hasReplication := (list "main"
-                             "account-data"
-                             "device-lists"
-                             "encryption"
-                             "event-persister"
-                             "push-rules"
-                             "presence-writer"
-                             "receipts"
-                             "typing-persister") }}
-{{- if has . $hasReplication -}}
+{{- if or (eq . "main") (gt (len ((include "element-io.synapse.process.streamWriters" (dict "root" $root "context" .)) | fromJsonArray)) 0) -}}
 hasReplication
 {{- end -}}
 {{- end -}}

--- a/newsfragments/645.changed.md
+++ b/newsfragments/645.changed.md
@@ -1,0 +1,1 @@
+Source whether Synapse workers serve HTTP endpoints or have replication from other configuration to improve consistency of configuration.


### PR DESCRIPTION
Noticed whilst doing #644 that we don't need to maintain some lists, we can infer this from other (more vital) named templates.

This should be a no-op in terms of `dyff` or expose bugs