### PR TITLE
CI: Accept routing to the failover backends in the Synapse routing test.

### DIFF
--- a/newsfragments/646.internal.md
+++ b/newsfragments/646.internal.md
@@ -1,0 +1,1 @@
+CI: Accept routing to the failover backends in the Synapse routing test.


### PR DESCRIPTION
`initial-synchtrotron` can fallback to `synchrotron` (if configured) or `main`. Other workers can fallback to `main`