### PR TITLE
Don't block indefinitely waiting for a HAProxy logline. Retry after 1s waiting

### DIFF
--- a/newsfragments/655.internal.md
+++ b/newsfragments/655.internal.md
@@ -1,0 +1,1 @@
+CI: remove flakes in `test_routes_to_synapse_workers_correctly` by streaming logs from all HAProxy `Pods`, not just the current ones.


### PR DESCRIPTION
https://github.com/element-hq/ess-helm/actions/runs/16776723365/job/47504447455 shows the requests making it through to Synapse but not in the HAProxy Pods (which aren't restarted). I suspect `kind` filtering out logs more than I suspect HAProxy dropping them. 