### PR TITLE
haproxy: fix haproxy.cfg missing LF on last line

### DIFF
--- a/charts/matrix-stack/templates/haproxy/_helpers.tpl
+++ b/charts/matrix-stack/templates/haproxy/_helpers.tpl
@@ -20,7 +20,7 @@ app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .
 {{- with required "element-io.haproxy.configmap-data missing context" .context -}}
 haproxy.cfg: |
 {{- tpl ($root.Files.Get "configs/haproxy/haproxy.cfg.tpl") (dict "root" $root "context" .) | nindent 2 }}
-{{- end -}}
+{{ end -}}
 {{- end -}}
 
 {{- define "element-io.haproxy.overrideEnv" }}

--- a/charts/matrix-stack/templates/haproxy/configmap.yaml
+++ b/charts/matrix-stack/templates/haproxy/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2024 New Vector Ltd
+Copyright 2024-2025 New Vector Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -14,6 +14,6 @@ metadata:
   name: {{ $.Release.Name }}-haproxy
   namespace: {{ $.Release.Namespace }}
 data:
-  {{- include "element-io.haproxy.configmap-data" (dict "root" $ "context" .) | nindent 2 -}}
+  {{- include "element-io.haproxy.configmap-data" (dict "root" $ "context" .) | nindent 2 }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This was causing ` config : parsing [/usr/local/etc/haproxy/haproxy.cfg:133]: Missing LF on last line, file mig ││ ht have been truncated at position 36.` when using `helm template` to render the manifests before applying them.