### PR TITLE
manifests tests: fix test does not create service account

### DIFF
--- a/newsfragments/659.internal.md
+++ b/newsfragments/659.internal.md
@@ -1,0 +1,1 @@
+Speed-up the tests asserting the possibility not to create service accounts per components.

--- a/tests/manifests/test_serviceaccounts.py
+++ b/tests/manifests/test_serviceaccounts.py
@@ -104,6 +104,8 @@ async def test_does_not_create_serviceaccounts_if_configured_not_to(values, make
         serviceaccount_names = set()
         covered_serviceaccount_names = set()
         for template in await make_templates(values_to_modify):
+            if template_to_deployable_details(template) != deployable_details:
+                continue
             if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
                 id_suffix = f" (for {deployable_details.name})"
                 workloads_by_id[f"{template_id(template)}{id_suffix}"] = template
@@ -123,6 +125,6 @@ async def test_does_not_create_serviceaccounts_if_configured_not_to(values, make
             else:
                 covered_serviceaccount_names.add(serviceaccount_name)
 
-        assert serviceaccount_names == covered_serviceaccount_names, (
+        assert serviceaccount_names.intersection(covered_serviceaccount_names) == set(), (
             f"{id} created ServiceAccounts that it shouldn't have"
         )


### PR DESCRIPTION
This simplifies the tests drastically by disabling all SA creation and checking that none exists.

We already verify `test_uses_serviceaccount_named_as_values_if_specified` and `test_uses_serviceaccount_named_as_per_pod_controller_by_default` so we dont need to check SA creation individually per component.
