### PR TITLE
Set ipFamilyPolicy on RTC SFU NodePorts

### DIFF
--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_tcp_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_tcp_service.yaml
@@ -18,6 +18,7 @@ metadata:
 spec:
   type: NodePort
   externalTrafficPolicy: Local
+  ipFamilyPolicy: PreferDualStack
   ports:
   - name: "rtc-tcp"
     protocol: "TCP"

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_muxer_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_muxer_service.yaml
@@ -18,6 +18,7 @@ metadata:
 spec:
   type: NodePort
   externalTrafficPolicy: Local
+  ipFamilyPolicy: PreferDualStack
   ports:
   - name: "rtc-muxed-udp"
     protocol: "UDP"

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_range_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_range_service.yaml
@@ -24,6 +24,7 @@ metadata:
 spec:
   type: NodePort
   externalTrafficPolicy: Local
+  ipFamilyPolicy: PreferDualStack
   ports:
 {{- $segment_start := ((add $range_start (mul 250 $port_segment)) | int) }}
 {{- $segment_end := ((min (add $range_end 1) (add $segment_start 250)) | int) }}


### PR DESCRIPTION
If the cluster is IPv6 [enabled](https://docs.k3s.io/networking/basic-network-options#dual-stack-ipv4--ipv6-networking), NodePorts created for RTC SFU will still default to SingleStack. Set ipFamilyPolicy on these ports to PreferDualStack instead so we can connect with both IPv4 and v6.

This should cause no change in behavior on an IPv4-only install.