### PR TITLE
Fix Helm >= 3.18.5 considering our schema invalid due to a repeated $id.

### DIFF
--- a/charts/matrix-stack/source/deployment-markers.json
+++ b/charts/matrix-stack/source/deployment-markers.json
@@ -1,5 +1,5 @@
 {
-  "$id": "file://init-secrets",
+  "$id": "file://deployment-markers",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -301,7 +301,7 @@
       }
     },
     "deploymentMarkers": {
-      "$id": "file://init-secrets",
+      "$id": "file://deployment-markers",
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {

--- a/newsfragments/682.fixed.md
+++ b/newsfragments/682.fixed.md
@@ -1,0 +1,1 @@
+Fix Helm >= 3.18.5 considering our schema invalid due to a repeated $id.


### PR DESCRIPTION
Fixes #676 

Either https://github.com/helm/helm/commit/cb8595bc650e2ec7459427d2b0430599431a3dbe (Helm 3.18.5) or https://github.com/helm/helm/commit/b9180e674fccb57e6ea6934ed7deb4448a3c9ddb (Helm 3.18.6) didn't like the repeated `$id` in the schema.

I'm not really sure we need to keep the `$id` or `$schema` from the in-lined sub-schemas but let's do a minimal fix for now