### PR TITLE
Update test-cluster-mixin.yaml to allow Matrix RTC authoriser to make calls to itself

### DIFF
--- a/charts/matrix-stack/ci/test-cluster-mixin.yaml
+++ b/charts/matrix-stack/ci/test-cluster-mixin.yaml
@@ -17,9 +17,10 @@ matrixRTC:
   extraEnv:
   - name: LIVEKIT_INSECURE_SKIP_VERIFY_TLS
     value: YES_I_KNOW_WHAT_I_AM_DOING
-  # Because the authoriser service does well-known and the userinfo API calls via the frontdoor
+  # Because the authoriser service does well-known, Matrix userinfo and self API calls via the frontdoor
   hostAliases:
   - hostnames:
     - ess.localhost
+    - mrtc.ess.localhost
     - synapse.ess.localhost
     ip: '{{ ( (lookup "v1" "Service" "ingress-nginx" "ingress-nginx-controller") | default (dict "spec" (dict "clusterIP" "127.0.0.1")) ).spec.clusterIP }}'

--- a/newsfragments/687.fixed.md
+++ b/newsfragments/687.fixed.md
@@ -1,0 +1,1 @@
+Ensure Matrix RTC authoriser can contact itself in the test cluster.


### PR DESCRIPTION
Was the change I required locally to get Matrix RTC working when investigating https://github.com/element-hq/ess-helm/issues/681.

Looks like this should have been added in https://github.com/element-hq/ess-helm/pull/635, as can be seen from the change in `tests/integration/fixtures/helm.py` in that PR