### PR TITLE
Support configuring a different cluster domain for internal Service references.

### DIFF
--- a/charts/matrix-stack/configs/matrix-authentication-service/config.yaml.tpl
+++ b/charts/matrix-stack/configs/matrix-authentication-service/config.yaml.tpl
@@ -41,7 +41,7 @@ database:
   uri: "postgresql://{{ .user }}:${POSTGRES_PASSWORD}@{{ tpl .host $root }}:{{ .port }}/{{ .database }}?{{ with .sslMode }}sslmode={{ . }}&{{ end }}application_name=matrix-authentication-service"
 {{- end }}
 {{- else if $root.Values.postgres.enabled }}
-  uri: "postgresql://matrixauthenticationservice_user:${POSTGRES_PASSWORD}@{{ $root.Release.Name }}-postgres.{{ $root.Release.Namespace }}.svc.cluster.local:5432/matrixauthenticationservice?sslmode=prefer&application_name=matrix-authentication-service"
+  uri: "postgresql://matrixauthenticationservice_user:${POSTGRES_PASSWORD}@{{ $root.Release.Name }}-postgres.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}:5432/matrixauthenticationservice?sslmode=prefer&application_name=matrix-authentication-service"
 {{ end }}
 
 telemetry:

--- a/charts/matrix-stack/configs/synapse/partial-haproxy.cfg.tpl
+++ b/charts/matrix-stack/configs/synapse/partial-haproxy.cfg.tpl
@@ -139,7 +139,7 @@ backend synapse-main
   http-check send meth GET uri /health
 
   # Use DNS SRV service discovery on the headless service
-  server-template main 1 _synapse-http._tcp.{{ $root.Release.Name }}-synapse-main.{{ $root.Release.Namespace }}.svc.cluster.local resolvers kubedns init-addr none check
+  server-template main 1 _synapse-http._tcp.{{ $root.Release.Name }}-synapse-main.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }} resolvers kubedns init-addr none check
 
 {{- if $hasFailoverBackend }}
 backend synapse-main-failover
@@ -150,7 +150,7 @@ backend synapse-main-failover
   http-check send meth GET uri /health
 
   # Use DNS SRV service discovery on the headless service
-  server-template main 1 _synapse-http._tcp.{{ $root.Release.Name }}-synapse-main.{{ $root.Release.Namespace }}.svc.cluster.local resolvers kubedns init-addr none check
+  server-template main 1 _synapse-http._tcp.{{ $root.Release.Name }}-synapse-main.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }} resolvers kubedns init-addr none check
 {{- end }}
 
 {{- range $workerType, $workerDetails := (include "element-io.synapse.enabledWorkers" (dict "root" $root)) | fromJson }}
@@ -224,7 +224,7 @@ backend synapse-{{ $workerType }}
 {{- $maxInstances := ternary 20 1 (hasKey $workerDetails "replicas") }}
 {{- $workerTypeName := include "element-io.synapse.process.workerTypeName" (dict "root" $root "context" $workerType) }}
   # Use DNS SRV service discovery on the headless service
-  server-template {{ $workerTypeName }} {{ $maxInstances }} _synapse-http._tcp.{{ $root.Release.Name }}-synapse-{{ $workerTypeName }}.{{ $root.Release.Namespace }}.svc.cluster.local resolvers kubedns init-addr none check
+  server-template {{ $workerTypeName }} {{ $maxInstances }} _synapse-http._tcp.{{ $root.Release.Name }}-synapse-{{ $workerTypeName }}.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }} resolvers kubedns init-addr none check
 {{- end }}
 {{- end }}
 
@@ -233,9 +233,9 @@ backend synapse-{{ $workerType }}
 {{- $additionalPathId := printf "%s_%s" .service.name (.service.port.name | default .service.port.number) }}
 backend synapse-be_{{ $additionalPathId }}
 {{- if .service.port.name }}
-  server-template {{ $additionalPathId }} 10 _{{ .service.port.name }}._tcp.{{ .service.name }}.{{ $root.Release.Namespace }}.svc.cluster.local resolvers kubedns init-addr none
+  server-template {{ $additionalPathId }} 10 _{{ .service.port.name }}._tcp.{{ .service.name }}.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }} resolvers kubedns init-addr none
 {{- else }}
-  server-template {{ $additionalPathId }} 10 _{{ .service.name }}.{{ $root.Release.Namespace }}.svc.cluster.local:{{ .service.port.number }} resolvers kubedns init-addr none
+  server-template {{ $additionalPathId }} 10 _{{ .service.name }}.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}:{{ .service.port.number }} resolvers kubedns init-addr none
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
@@ -53,7 +53,7 @@ database:
     user: "synapse_user"
     password: ${SYNAPSE_POSTGRES_PASSWORD}
     database: "synapse"
-    host: "{{ $root.Release.Name }}-postgres.{{ $root.Release.Namespace }}.svc.cluster.local"
+    host: "{{ $root.Release.Name }}-postgres.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}"
     port: 5432
     sslmode: prefer
 {{ end }}
@@ -100,7 +100,7 @@ experimental_features:
   msc3861:
     enabled: true
 
-    issuer: http://{{ $root.Release.Name }}-matrix-authentication-service.{{ $root.Release.Namespace }}.svc.cluster.local:8080/
+    issuer: http://{{ $root.Release.Name }}-matrix-authentication-service.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}:8080/
     client_id: 0000000000000000000SYNAPSE
     client_auth_method: client_secret_basic
     # client.<client_id> in the MAS secret
@@ -123,7 +123,7 @@ experimental_features:
           "defaultSecretKey" "SYNAPSE_SHARED_SECRET"
           )
       ) }}
-    introspection_endpoint: "http://{{ $root.Release.Name }}-matrix-authentication-service.{{ $root.Release.Namespace }}.svc.cluster.local:8080/oauth2/introspect"
+    introspection_endpoint: "http://{{ $root.Release.Name }}-matrix-authentication-service.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}:8080/oauth2/introspect"
 
   # QR Code Login. Requires MAS
   msc4108_enabled: true
@@ -193,14 +193,14 @@ update_user_directory_from_worker: {{ $root.Release.Name }}-synapse-{{- include 
 
 instance_map:
   main:
-    host: {{ $root.Release.Name }}-synapse-main.{{ $root.Release.Namespace }}.svc.cluster.local.
+    host: {{ $root.Release.Name }}-synapse-main.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}
     port: 9093
 {{- range $workerType, $workerDetails := $enabledWorkers }}
 {{- if include "element-io.synapse.process.hasReplication" (dict "root" $root "context" $workerType) }}
 {{- $workerTypeName := include "element-io.synapse.process.workerTypeName" (dict "root" $root "context" $workerType) }}
 {{- range $index := untilStep 0 ($workerDetails.replicas | int | default 1) 1 }}
   {{ $root.Release.Name }}-synapse-{{ $workerTypeName }}-{{ $index }}:
-    host: {{ $root.Release.Name }}-synapse-{{ $workerTypeName }}-{{ $index }}.{{ $root.Release.Name }}-synapse-{{ $workerTypeName }}.{{ $root.Release.Namespace }}.svc.cluster.local.
+    host: {{ $root.Release.Name }}-synapse-{{ $workerTypeName }}-{{ $index }}.{{ $root.Release.Name }}-synapse-{{ $workerTypeName }}.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}
     port: 9093
 {{- end }}
 {{- end }}
@@ -210,7 +210,7 @@ instance_map:
 
 redis:
   enabled: true
-  host: "{{ $root.Release.Name }}-synapse-redis.{{ $root.Release.Namespace }}.svc.cluster.local"
+  host: "{{ $root.Release.Name }}-synapse-redis.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}"
 {{- if include "element-io.synapse.streamWriterWorkers" (dict "root" $root) | fromJsonArray }}
 
 stream_writers:

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -36,6 +36,11 @@ certManager: {}
 imagePullSecrets: []
 {{ tolerations(global=true) }}
 {{ topologySpreadConstraints(global=true) }}
+
+## The cluster's domain name which will be appended to URLs of internal Services (<name>.<namespace>.svc.<clusterDomain>).
+## It is unusual to need to change this but if you do need to change it,
+## strongly consider having a trailing dot to prevent multiple search domains being queried.
+clusterDomain: "cluster.local."
 {%- endmacro %}
 
 {% macro containersSecurityContext(key='containersSecurityContext') %}

--- a/charts/matrix-stack/source/values.schema.json
+++ b/charts/matrix-stack/source/values.schema.json
@@ -51,6 +51,9 @@
     "topologySpreadConstraints": {
       "$ref": "file://common/topologySpreadConstraints.json"
     },
+    "clusterDomain": {
+      "type": "string"
+    },
     "deploymentMarkers": {
       "$ref": "file://deployment-markers.json"
     },

--- a/charts/matrix-stack/templates/ess-library/_postgres.tpl
+++ b/charts/matrix-stack/templates/ess-library/_postgres.tpl
@@ -12,7 +12,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- if .postgres -}}
 {{ (tpl .postgres.host $root) }}:{{ .postgres.port | default 5432 }}
 {{- else if $root.Values.postgres.enabled -}}
-{{ $root.Release.Name }}-postgres.{{ $root.Release.Namespace }}.svc.cluster.local:5432
+{{ $root.Release.Name }}-postgres.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}:5432
 {{- else }}
 {{- fail "You need to enable the chart Postgres or configure this component postgres" -}}
 {{- end -}}

--- a/charts/matrix-stack/templates/synapse/_helpers.tpl
+++ b/charts/matrix-stack/templates/synapse/_helpers.tpl
@@ -260,7 +260,6 @@ path_map_file_get: |
 {{- with .targetProcessType -}}
 -{{ . }}
 {{- end -}}
-.{{ $root.Release.Namespace }}.svc.cluster.local:8008
+.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}:8008
 {{- end -}}
 {{- end -}}
-

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -300,6 +300,9 @@
         "additionalProperties": false
       }
     },
+    "clusterDomain": {
+      "type": "string"
+    },
     "deploymentMarkers": {
       "$id": "file://deployment-markers",
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -109,6 +109,11 @@ tolerations: []
 ##   # whenUnsatisfiable: DoNotSchedule/ScheduleAnyway
 topologySpreadConstraints: []
 
+## The cluster's domain name which will be appended to URLs of internal Services (<name>.<namespace>.svc.<clusterDomain>).
+## It is unusual to need to change this but if you do need to change it,
+## strongly consider having a trailing dot to prevent multiple search domains being queried.
+clusterDomain: "cluster.local."
+
 ## Components
 initSecrets:
   enabled: true

--- a/newsfragments/692.changed.md
+++ b/newsfragments/692.changed.md
@@ -1,0 +1,1 @@
+Support configuring a different cluster domain for internal Service references.

--- a/tests/manifests/test_haproxy.py
+++ b/tests/manifests/test_haproxy.py
@@ -38,7 +38,7 @@ async def test_haproxy_server_templates_reference_valid_services(templates):
 
         server_template = re.search(
             r"server-template [a-z-]+ \d+ _(?P<port>.*?)\._tcp\.(?P<service>.*?)\.(?P<namespace>.*?)"
-            r"\.svc\.cluster\.local ",
+            r"\.svc\.cluster\.local\. ",
             line,
         )
         assert server_template, (


### PR DESCRIPTION
Fixes #691 and also should reduce the DNS queries for these names 5-fold as the search domains are no longer considered