### PR TITLE
Expose the ESS version and edition in an API

### DIFF
--- a/charts/matrix-stack/templates/synapse/_helpers.tpl
+++ b/charts/matrix-stack/templates/synapse/_helpers.tpl
@@ -229,6 +229,10 @@ path_map_file: |
 {{- (tpl ($root.Files.Get "configs/synapse/path_map_file.tpl") (dict "root" $root)) | nindent 2 }}
 path_map_file_get: |
 {{- (tpl ($root.Files.Get "configs/synapse/path_map_file_get.tpl") (dict "root" $root)) | nindent 2 -}}
+{{- /* We accept this means that the ConfigMap & all hash labels using this helper changes on every chart version upgrade and the HAProxy will restart as a result.
+When we have a process to watch for file changes and send a reload signal to HAProxy this can move out of this helper and into the `ConfigMap` proper. */}}
+ess-version.json: |-
+  {"version": "{{ $root.Chart.Version }}", "edition": "community"}
 {{- end -}}
 
 {{- define "element-io.synapse.render-config-container" -}}

--- a/newsfragments/715.added.md
+++ b/newsfragments/715.added.md
@@ -1,0 +1,1 @@
+Add `/_synapse/ess/version` to the Synapse ingress exposing the chart version and edition.


### PR DESCRIPTION
The admin API will want this.

This will cause the HAProxy `Pods` to restart on every chart version upgrade. The alternative is to accept that the version API could return incorrect results after upgrading or we need a sidecar process (that we don't have yet) to send the appropriate reload signal to HAProxy on the config changing