### PR TITLE
Use unique file names for component configs

### DIFF
--- a/charts/matrix-stack/source/matrix-rtc.yaml.j2
+++ b/charts/matrix-stack/source/matrix-rtc.yaml.j2
@@ -54,7 +54,7 @@ sfu:
 
   ## Additional configuration to provide to all LiveKit processes.
   ## This should be provided as yaml-string and will be merged into the default configuration.
-  ## Each key under additional is an additional config to merge into LiveKit config.yaml
+  ## Each key under additional is an additional config to merge into LiveKit sfu-config.yaml
   ## Full details on available configuration options can be found at https://docs.livekit.io/home/self-hosting/deployment/#configuration
   {{- sub_schema_values.additionalConfig() | indent(2) }}
 

--- a/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
+++ b/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
@@ -16,7 +16,7 @@ replicas: 1
 {{ sub_schema_values.credential("Synapse - MAS Shared Secret", "synapseSharedSecret", initIfAbsent=True) }}
 
 ## Additional configuration to provide to Matrix Authentication Service.
-## Each key under additional is an additional config to merge into Matrix Authentication Service config.yaml
+## Each key under additional is an additional config to merge into Matrix Authentication Service mas-config.yaml
 ## Full details on available configuration options can be found at https://element-hq.github.io/matrix-authentication-service/reference/configuration.html
 {{- sub_schema_values.additionalConfig() }}
 privateKeys:

--- a/charts/matrix-stack/templates/matrix-authentication-service/_helpers.tpl
+++ b/charts/matrix-stack/templates/matrix-authentication-service/_helpers.tpl
@@ -94,7 +94,7 @@ app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .
 {{- $root := .root -}}
 env:
 - name: "MAS_CONFIG"
-  value: "/conf/config.yaml"
+  value: "/conf/mas-config.yaml"
 {{- end -}}
 
 {{- /* The filesystem structure is `/secrets`/<< secret name>>/<< secret key >>.
@@ -171,7 +171,7 @@ SYNAPSE_SHARED_SECRET: {{ . | b64enc }}
 {{- define "element-io.matrix-authentication-service.configmap-data" }}
 {{- $root := .root -}}
 {{- with required "element-io.matrix-authentication-service.configmap-data" .context -}}
-config.yaml: |
+mas-config.yaml: |
   {{- include "element-io.matrix-authentication-service.config" (dict "root" $root "context" .) | nindent 2 }}
 {{- end -}}
 {{- end -}}
@@ -242,7 +242,7 @@ config.yaml: |
               "containerName" (.containerName | default "render-config")
               "templatesVolume" (.templatesVolume | default "plain-config")
               "overrides" (list "config.yaml")
-              "outputFile" "config.yaml"
+              "outputFile" "mas-config.yaml"
               "resources" .resources
               "containersSecurityContext" .containersSecurityContext
               "extraEnv" .extraEnv

--- a/charts/matrix-stack/templates/matrix-authentication-service/_helpers.tpl
+++ b/charts/matrix-stack/templates/matrix-authentication-service/_helpers.tpl
@@ -241,7 +241,7 @@ mas-config.yaml: |
               "nameSuffix" "matrix-authentication-service"
               "containerName" (.containerName | default "render-config")
               "templatesVolume" (.templatesVolume | default "plain-config")
-              "overrides" (list "config.yaml")
+              "overrides" (list "mas-config.yaml")
               "outputFile" "mas-config.yaml"
               "resources" .resources
               "containersSecurityContext" .containersSecurityContext

--- a/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
@@ -95,7 +95,7 @@ spec:
         volumeMounts:
         {{- include "element-io.ess-library.render-config-volume-mounts" (dict "root" $ "context"
             (dict "nameSuffix" "matrix-authentication-service"
-                  "outputFile" "config.yaml"
+                  "outputFile" "mas-config.yaml"
                   "isHook" false)) | nindent 8 }}
       containers:
       - name: matrix-authentication-service
@@ -151,7 +151,7 @@ We don't want background jobs to get failed use up their retries because MAS has
         volumeMounts:
         {{- include "element-io.ess-library.render-config-volume-mounts" (dict "root" $ "context"
             (dict "nameSuffix" "matrix-authentication-service"
-                  "outputFile" "config.yaml"
+                  "outputFile" "mas-config.yaml"
                   "isHook" false)) | nindent 8 }}
       volumes:
       {{- include "element-io.ess-library.render-config-volumes" (dict "root" $ "context"

--- a/charts/matrix-stack/templates/matrix-authentication-service/syn2mas_job.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/syn2mas_job.yaml
@@ -162,7 +162,7 @@ spec:
           {{- toYaml . | nindent 10 }}
 {{- end }}
       - name: syn2mas-check
-        args: ["syn2mas", "check", "--config", "/conf/config.yaml", "--synapse-config", "/conf/homeserver.yaml"]
+        args: ["syn2mas", "check", "--config", "/conf/mas-config.yaml", "--synapse-config", "/conf/homeserver.yaml"]
 {{- with .image -}}
 {{- if .digest }}
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
@@ -194,7 +194,7 @@ spec:
       containers:
       - name: syn2mas-migrate
 {{- if .dryRun }}
-        args: ["syn2mas", "migrate", "--config", "/conf/config.yaml", "--synapse-config", "/conf/homeserver.yaml", "--dry-run"]
+        args: ["syn2mas", "migrate", "--config", "/conf/mas-config.yaml", "--synapse-config", "/conf/homeserver.yaml", "--dry-run"]
     {{- with .image -}}
     {{- if .digest }}
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
@@ -205,7 +205,7 @@ spec:
     {{- end }}
     {{- end }}
 {{- else }}
-        command: ["/matrix-tools", "syn2mas", "--config", "/conf/config.yaml", "--synapse-config", "/conf/homeserver.yaml"]
+        command: ["/matrix-tools", "syn2mas", "--config", "/conf/mas-config.yaml", "--synapse-config", "/conf/homeserver.yaml"]
     {{- with $.Values.matrixTools.image -}}
     {{- if .digest }}
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
@@ -55,7 +55,7 @@ spec:
               "underrides" (list "config-underrides.yaml")
               "overrides" (list "config-overrides.yaml")
               "containerName" "render-config-sfu"
-              "outputFile" "config.yaml"
+              "outputFile" "sfu-config.yaml"
               "resources" .resources
               "containersSecurityContext" .containersSecurityContext
               "extraEnv" .extraEnv)) | nindent 6 }}
@@ -64,7 +64,7 @@ spec:
       - name: sfu
         args:
         - --config
-        - /conf/config.yaml
+        - /conf/sfu-config.yaml
 {{- with .image -}}
 {{- if .digest }}
         image: "{{ .registry }}/{{ .repository }}@{{ .digest }}"
@@ -145,7 +145,7 @@ spec:
         volumeMounts:
         {{- include "element-io.ess-library.render-config-volume-mounts" (dict "root" $ "context"
               (dict "nameSuffix" "matrix-rtc-sfu"
-                    "outputFile" "config.yaml")) | nindent 8 }}
+                    "outputFile" "sfu-config.yaml")) | nindent 8 }}
 {{- if not (.livekitAuth).keysYaml }}
         - mountPath: /conf/keys.yaml
           name: rendered-config

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -655,7 +655,7 @@ matrixRTC:
 
     ## Additional configuration to provide to all LiveKit processes.
     ## This should be provided as yaml-string and will be merged into the default configuration.
-    ## Each key under additional is an additional config to merge into LiveKit config.yaml
+    ## Each key under additional is an additional config to merge into LiveKit sfu-config.yaml
     ## Full details on available configuration options can be found at https://docs.livekit.io/home/self-hosting/deployment/#configuration
     ## This can be provided in-line in the Helm Chart and/or via an existing Secret
     ## e.g.

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -1442,7 +1442,7 @@ matrixAuthenticationService:
   synapseSharedSecret: {}
 
   ## Additional configuration to provide to Matrix Authentication Service.
-  ## Each key under additional is an additional config to merge into Matrix Authentication Service config.yaml
+  ## Each key under additional is an additional config to merge into Matrix Authentication Service mas-config.yaml
   ## Full details on available configuration options can be found at https://element-hq.github.io/matrix-authentication-service/reference/configuration.html
   ## This can be provided in-line in the Helm Chart and/or via an existing Secret
   ## e.g.

--- a/newsfragments/723.changed.md
+++ b/newsfragments/723.changed.md
@@ -1,0 +1,1 @@
+Use unique names for component configuration files, to prevent them from clashing against identically-named files in pods that deploy those components.

--- a/tests/manifests/test_matrix_authentication_service.py
+++ b/tests/manifests/test_matrix_authentication_service.py
@@ -11,7 +11,7 @@ async def test_matrix_authentication_service_env_overrides(values, make_template
     for template in await make_templates(values):
         if "matrix-authentication-service" in template["metadata"]["name"] and template["kind"] == "Deployment":
             env = {e["name"]: e["value"] for e in template["spec"]["template"]["spec"]["containers"][0]["env"]}
-            assert env["MAS_CONFIG"] == "/conf/config.yaml"
+            assert env["MAS_CONFIG"] == "/conf/mas-config.yaml"
             break
     else:
         raise RuntimeError("Could not find Matrix Authentication Service deployment")
@@ -24,7 +24,7 @@ async def test_matrix_authentication_service_env_overrides(values, make_template
     for template in await make_templates(values):
         if "matrix-authentication-service" in template["metadata"]["name"] and template["kind"] == "Deployment":
             env = {e["name"]: e["value"] for e in template["spec"]["template"]["spec"]["containers"][0]["env"]}
-            assert env["MAS_CONFIG"] == "/conf/config.yaml"
+            assert env["MAS_CONFIG"] == "/conf/mas-config.yaml"
             assert env["OTHER_KEY"] == "should-exists"
             break
     else:

--- a/tests/manifests/test_matrix_rtc.py
+++ b/tests/manifests/test_matrix_rtc.py
@@ -22,7 +22,7 @@ async def test_log_level_overrides(values, make_templates):
             assert tcp_port == 30881
             break
     else:
-        raise RuntimeError("Could not find config.yaml")
+        raise RuntimeError("Could not find config-overrides.yaml")
 
 
 @pytest.mark.parametrize("values_file", ["matrix-rtc-minimal-values.yaml"])
@@ -40,7 +40,7 @@ async def test_external_ip_underrides(values, make_templates):
             assert use_external_ip
             break
     else:
-        raise RuntimeError("Could not find config.yaml")
+        raise RuntimeError("Could not find config-underrides.yaml")
 
 
 async def get_sfu_udp_port_range_services(start_port, end_point, values, make_templates):


### PR DESCRIPTION
Do this to prevent clashing against multiple files in the same pod all named `config.yaml`.