### PR TITLE
use apply instead of create and avoid silencing errors

### DIFF
--- a/newsfragments/729.internal.md
+++ b/newsfragments/729.internal.md
@@ -1,0 +1,1 @@
+CI: Make sure tests fixtures errors are not silenced.

--- a/tests/integration/fixtures/cluster.py
+++ b/tests/integration/fixtures/cluster.py
@@ -4,9 +4,7 @@
 
 import asyncio
 import os
-from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import Any
 
 import pyhelm3
 import pytest
@@ -175,14 +173,12 @@ async def prometheus_operator_crds(helm_client):
 
 
 @pytest.fixture(scope="session")
-async def ess_namespace(
-    cluster: PotentiallyExistingKindCluster, kube_client: AsyncClient, generated_data: ESSData
-) -> AsyncGenerator[Namespace, Any]:
+async def ess_namespace(cluster: PotentiallyExistingKindCluster, kube_client: AsyncClient, generated_data: ESSData):
     (major_version, minor_version) = cluster.version()
     try:
-        namespace = await kube_client.get(Namespace, name=generated_data.ess_namespace)
+        await kube_client.get(Namespace, name=generated_data.ess_namespace)
     except ApiError:
-        namespace = await kube_client.create(
+        await kube_client.create(
             Namespace(
                 metadata=ObjectMeta(
                     name=generated_data.ess_namespace,
@@ -202,7 +198,7 @@ async def ess_namespace(
             )
         )
 
-    yield namespace
+    yield
 
     if os.environ.get("PYTEST_KEEP_CLUSTER", "") != "1":
         await kube_client.delete(Namespace, name=generated_data.ess_namespace)

--- a/tests/integration/fixtures/helm.py
+++ b/tests/integration/fixtures/helm.py
@@ -26,7 +26,7 @@ async def helm_prerequisites(
     kube_client: AsyncClient,
     helm_client: pyhelm3.Client,
     delegated_ca: CertKey,
-    ess_namespace: Namespace,
+    ess_namespace,
     generated_data: ESSData,
 ):
     resources = []
@@ -135,7 +135,9 @@ retention:
             )
         )
 
-    return asyncio.gather(*setups, *[kube_client.create(resource) for resource in resources])
+    return await asyncio.gather(
+        *setups, *[kube_client.apply(resource, field_manager="pytest") for resource in resources]
+    )
 
 
 @pytest.fixture(autouse=True, scope="session")


### PR DESCRIPTION
While testing some complex setups, I discovered that how we do `helm_prerequisites` today might hide errors from the pytest results. Typically, it errors out on upgrade because we try to recreate resources already existing.