### PR TITLE
dont delete curl pods on error

### DIFF
--- a/newsfragments/732.internal.md
+++ b/newsfragments/732.internal.md
@@ -1,0 +1,1 @@
+CI: Do not delete failed curl pods during metrics endpoints tests.


### PR DESCRIPTION
There are some flakes with the tests checking the metrics endpoint. Let's try to skip deleting curl pods when this happens to figure out what's going on.