### PR TITLE
Remove well-known-pytest-extras.yaml from pytest-matrix-rtc-synapse-wellknown-values.yaml

### DIFF
--- a/charts/matrix-stack/ci/fragments/well-known-pytest-base-extras.yaml
+++ b/charts/matrix-stack/ci/fragments/well-known-pytest-base-extras.yaml
@@ -1,0 +1,14 @@
+# Copyright 2025 New Vector Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+ingress:
+  controllerType: ingress-nginx
+
+wellKnownDelegation:
+  ingress:
+    tlsSecret: "{{ $.Release.Name }}-well-known-web-tls"
+
+haproxy:
+  podSecurityContext:
+    runAsGroup: 0

--- a/charts/matrix-stack/ci/fragments/well-known-pytest-self-extras.yaml
+++ b/charts/matrix-stack/ci/fragments/well-known-pytest-self-extras.yaml
@@ -8,15 +8,6 @@ global:
 # To check that templating works against the ingress
 serverName: "{{ $.Values.global.baseDomain }}"
 
-ingress:
-  controllerType: ingress-nginx
-
 wellKnownDelegation:
-  ingress:
-    tlsSecret: "{{ $.Release.Name }}-well-known-web-tls"
   baseDomainRedirect:
    url: "https://redirect.localhost/path"
-
-haproxy:
-  podSecurityContext:
-    runAsGroup: 0

--- a/charts/matrix-stack/ci/pytest-matrix-rtc-synapse-wellknown-values.yaml
+++ b/charts/matrix-stack/ci/pytest-matrix-rtc-synapse-wellknown-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# source_fragments: init-secrets-minimal.yaml init-secrets-pytest-extras.yaml matrix-rtc-minimal.yaml matrix-rtc-pytest-extras.yaml postgres-minimal.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml well-known-minimal.yaml well-known-pytest-extras.yaml
+# source_fragments: init-secrets-minimal.yaml init-secrets-pytest-extras.yaml matrix-rtc-minimal.yaml matrix-rtc-pytest-extras.yaml postgres-minimal.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml well-known-minimal.yaml well-known-pytest-base-extras.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:
@@ -11,8 +11,6 @@ elementAdmin:
   enabled: false
 elementWeb:
   enabled: false
-global:
-  baseDomain: ess.localhost
 haproxy:
   podSecurityContext:
     runAsGroup: 0
@@ -47,8 +45,7 @@ matrixRTC:
 postgres:
   podSecurityContext:
     runAsGroup: 0
-# To check that templating works against the ingress
-serverName: '{{ $.Values.global.baseDomain }}'
+serverName: ess.localhost
 synapse:
   checkConfigHook:
     annotations:
@@ -67,7 +64,5 @@ synapse:
     podSecurityContext:
       runAsGroup: 0
 wellKnownDelegation:
-  baseDomainRedirect:
-    url: https://redirect.localhost/path
   ingress:
     tlsSecret: '{{ $.Release.Name }}-well-known-web-tls'

--- a/charts/matrix-stack/ci/pytest-well-known-values.yaml
+++ b/charts/matrix-stack/ci/pytest-well-known-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# source_fragments: well-known-minimal.yaml well-known-pytest-extras.yaml
+# source_fragments: well-known-minimal.yaml well-known-pytest-base-extras.yaml well-known-pytest-self-extras.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # initSecrets, postgres don't have any required properties to be set and defaults to enabled

--- a/newsfragments/785.internal.md
+++ b/newsfragments/785.internal.md
@@ -1,0 +1,1 @@
+CI: simplify MatrixRTC PyTest with Synapse + Well-Knowns.

--- a/tests/integration/test_well_known_delegation.py
+++ b/tests/integration/test_well_known_delegation.py
@@ -83,7 +83,6 @@ async def test_delete_405(
         ".well-known/matrix/client",
         ".well-known/matrix/server",
         ".well-known/matrix/support",
-        ".well-known/element/element.json",
     ]:
         async with (
             aiohttp_client(ssl_context) as client,

--- a/tests/integration/test_well_known_delegation.py
+++ b/tests/integration/test_well_known_delegation.py
@@ -44,6 +44,10 @@ async def test_well_known_files_can_be_accessed(
 
 
 @pytest.mark.skipif(value_file_has("wellKnownDelegation.enabled", False), reason="WellKnownDelegation not deployed")
+@pytest.mark.skipif(
+    not value_file_has("wellKnownDelegation.baseDomainRedirect", {}),
+    reason="WellKnownDelegation base domain redirect is disabled",
+)
 @pytest.mark.asyncio_cooperative
 async def test_root_url_redirects(
     ingress_ready,


### PR DESCRIPTION
`<component>-pytest-extras.yaml` only gets added to its own set of PyTests, not other components. When we need to split this between multiple components we do `<component>-pytest-base-extras.yaml` (which can be shared) and `<component>-pytest-self-extras.yaml` (which is not shared).

`/.well-known/element/element.json` was removed in https://github.com/element-hq/ess-helm/pull/641 but was missed in the tests thanks to the redirect