### PR TITLE
Don't get the k8s version from the wrong kube context

### DIFF
--- a/newsfragments/789.internal.md
+++ b/newsfragments/789.internal.md
@@ -1,0 +1,1 @@
+Ensure all `kubectl` commands in `scripts/setup_test_cluster.sh` specify the context.

--- a/scripts/setup_test_cluster.sh
+++ b/scripts/setup_test_cluster.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2024 New Vector Ltd
+# Copyright 2024-2025 New Vector Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -108,7 +108,7 @@ fi
 
 for namespace in $ess_namespaces; do
   echo "Constructing ESS dependencies in $namespace"
-  server_version=$(kubectl version | grep Server | sed 's/.*v/v/' | awk -F. '{print $1"."$2}')
+  server_version=$(kubectl --context $kind_context_name version | grep Server | sed 's/.*v/v/' | awk -F. '{print $1"."$2}')
   # We don't turn on enforce here as people may be experimenting but we do turn on warn so people see the warnings when helm install/upgrade
   cat <<EOF | kubectl --context $kind_context_name apply -f -
 apiVersion: v1


### PR DESCRIPTION
As users might have a different default context currently