### PR TITLE
Revert "Enable MSC4140 when RTC is enabled"

### DIFF
--- a/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
@@ -110,8 +110,6 @@ experimental_features:
   # MSC4222 needed for syncv2 state_after. This allow clients to
   # correctly track the state of the room.
   msc4222_enabled: true
-  # MSC4140 (delayed events) needs to be enabled for call membership to work.
-  msc4140_enabled: true
 {{- end }}
 
 {{- if (include "element-io.matrix-authentication-service.readyToHandleAuth" (dict "root" $root)) }}

--- a/newsfragments/803.fixed.md
+++ b/newsfragments/803.fixed.md
@@ -1,1 +1,0 @@
-Fixed delayed events not being enabled on Synapse when Matrix RTC is enabled.


### PR DESCRIPTION
Reverts element-hq/ess-helm#803

As it turns out msc4140_enabled does not exist. For reasons that escape me, we enable *this* feature with `max_event_delay_duration`. Everything is fine and I have egg on my face :)