### PR TITLE
Update Chart metadata

### DIFF
--- a/charts/matrix-stack/Chart.yaml
+++ b/charts/matrix-stack/Chart.yaml
@@ -4,7 +4,28 @@
 
 apiVersion: v2
 name: matrix-stack
-description: A Helm meta-chart for deploying a Matrix Stack from Element
-type: application
 version: 25.10.3-dev
+kubeVersion: '>= 1.22.0'
+description: A Helm chart for deploying a Matrix Stack from Element
+type: application
+keywords:
+  - ESS
+  - Element
+  - Matrix
+  - Synapse
+  - ElementWeb
+  - MAS
+  - MatrixAuthenticationService
+  - ElementAdmin
+  - MatrixRTC
+home: https://element.io/server-suite
+sources:
+  - https://github.com/element-hq/ess-helm
+  - https://github.com/element-hq/synapse
+  - https://github.com/element-hq/element-web
+  - https://github.com/element-hq/matrix-authentication-service
+  - https://github.com/element-hq/element-admin
+  - https://github.com/element-hq/lk-jwt-service
 dependencies: []
+maintainers:
+  - name: Element - Server Products Team

--- a/newsfragments/818.changed.md
+++ b/newsfragments/818.changed.md
@@ -1,0 +1,1 @@
+Update Chart metadata to enhance tooling like `renovate` and `artifacthub.io`.


### PR DESCRIPTION
Set more metadata in `Chart.yaml` as per https://github.com/helm/helm/issues/11062 to hopefully get renovate changelogs working and enhance things in artifacthub.io.

The `kubeVersion` is a bit of a guess, based on the fact that we rely on the new-style `Ingress` spec. Arguably we only support k8s versions that are upstream supported but lets be expansive for now