### PR TITLE
Validate matrix-tools containers use args only

### DIFF
--- a/newsfragments/820.internal.md
+++ b/newsfragments/820.internal.md
@@ -1,0 +1,1 @@
+CI: check that `matrix-tools` containers only ever set `args` and not `command`.

--- a/tests/manifests/test_pod_arguments.py
+++ b/tests/manifests/test_pod_arguments.py
@@ -1,0 +1,22 @@
+# Copyright 2025 New Vector Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import pytest
+
+from . import values_files_to_test
+from .utils import template_id
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_matrix_tools_containers_dont_set_command(templates):
+    for template in templates:
+        if template["kind"] not in ["Deployment", "StatefulSet", "Job"]:
+            continue
+        pod_spec = template["spec"]["template"]["spec"]
+        for container in pod_spec.get("initContainers", []) + pod_spec["containers"]:
+            if "/matrix-tools:" in container["image"] or "/matrix-tools@sha256:" in container["image"]:
+                assert "command" not in container, (
+                    f"{template_id(template)}/{container['name']} has a command of {container['command']}"
+                )


### PR DESCRIPTION
https://github.com/element-hq/ess-helm/pull/738 moved all `matrix-tools` usage over to `args` only. Let's add a test to keep it this way