### PR TITLE
Configure MSC4143 support in Synapse when MatrixRTC is enabled

### DIFF
--- a/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
@@ -108,6 +108,8 @@ experimental_features:
 {{- if $root.Values.matrixRTC.enabled }}
   # MSC3266: Room summary API. Used for knocking over federation
   msc3266_enabled: true
+  # MSC4143: Matrix RTC Transport using Livekit Backend. This enables a client-server API for discovery of Matrix RTC backends
+  msc4143_enabled: true
   # MSC4222 needed for syncv2 state_after. This allow clients to
   # correctly track the state of the room.
   msc4222_enabled: true
@@ -120,6 +122,13 @@ password_config:
   localdb_enabled: false
   enabled: false
 {{- end }}
+{{- end }}
+{{- if $root.Values.matrixRTC.enabled }}
+
+matrix_rtc:
+  transports:
+  - type: livekit
+    livekit_service_url: {{ (printf "https://%s" $root.Values.matrixRTC.ingress.host) }}
 {{- end }}
 
 {{- if dig "appservice" "enabled" false .workers }}

--- a/newsfragments/855.changed.md
+++ b/newsfragments/855.changed.md
@@ -1,0 +1,3 @@
+Configure experimental MSC4143 advertisement in Synapse when MatrixRTC is enabled.
+
+This is in addition to the MSC4143 advertisement on the client well-known endpoint for now, but it is expected to replace it in time.


### PR DESCRIPTION
Makes use of https://github.com/element-hq/synapse/pull/18967 for future proofing Matrix RTC support