### PR TITLE
Document why we don't use 'passfile' and have the Postgres password as a file

### DIFF
--- a/charts/matrix-stack/configs/matrix-authentication-service/config-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/matrix-authentication-service/config-overrides.yaml.tpl
@@ -37,6 +37,8 @@ http:
 
 
 database:
+{{- /* We don't attempt to use passfile and mount the Secret directly due to 
+https://github.com/kubernetes/kubernetes/issues/129043 / https://github.com/kubernetes/kubernetes/issues/81089 */}}
 {{- if .postgres }}
 {{- with .postgres }}
   uri: "postgresql://{{ .user }}:${POSTGRES_PASSWORD}@{{ tpl .host $root }}:{{ .port }}/{{ .database }}?{{ with .sslMode }}sslmode={{ . }}&{{ end }}application_name=matrix-authentication-service"

--- a/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
@@ -43,6 +43,8 @@ registration_shared_secret_path: /secrets/{{
 database:
   name: psycopg2
   args:
+{{- /* We don't attempt to use passfile and mount the Secret directly due to 
+https://github.com/kubernetes/kubernetes/issues/129043 / https://github.com/kubernetes/kubernetes/issues/81089 */}}
 {{- if .postgres }}
     user: {{ .postgres.user }}
     password: ${SYNAPSE_POSTGRES_PASSWORD}

--- a/newsfragments/881.internal.md
+++ b/newsfragments/881.internal.md
@@ -1,0 +1,1 @@
+Document why we don't use `passfile` for Synapse & MAS' Postgres configuration.


### PR DESCRIPTION
Because `Secrets` mounted by k8s are always owned by root and have group read permissions at a minimum. `libpq` complains if the `passfile` has a mode more permissive than `0600`