### PR TITLE
Improve the hook tests by asserting presence/absence of Hook annotations based on DeployableDetails

### DIFF
--- a/charts/matrix-stack/templates/matrix-authentication-service/configmap_hook.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/configmap_hook.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "element-io.matrix-authentication-service.labels" (dict "root" $ "context" $masContext) | nindent 4 }}
+    "k8s.element.io/hook-for": "synapse-check-config"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-1"

--- a/charts/matrix-stack/templates/matrix-authentication-service/secret_hook.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/secret_hook.yaml
@@ -20,6 +20,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "element-io.matrix-authentication-service.labels" (dict "root" $ "context" $masContext) | nindent 4 }}
+    "k8s.element.io/hook-for": "synapse-check-config"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-1"

--- a/newsfragments/884.internal.md
+++ b/newsfragments/884.internal.md
@@ -1,0 +1,1 @@
+CI: add tests covering the weights and phases of Helm hooks.

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -106,7 +106,8 @@ class DeployableDetails(abc.ABC):
     has_service_monitor: bool = field(default=None, hash=False)  # type: ignore[assignment]
     has_storage: bool = field(default=False, hash=False)
     makes_outbound_requests: bool = field(default=None, hash=False)  # type: ignore[assignment]
-    is_synapse_process: bool = field(default=False)
+    is_hook: bool = field(default=False, hash=False)
+    is_synapse_process: bool = field(default=False, hash=False)
 
     # Use this to skip mounts point we expect not to be referenced in commands, configs, etc
     # The format is expected to be `container_name: <list of mounts to ignore>`
@@ -429,6 +430,7 @@ all_components_details = [
         has_replicas=False,
         has_service_monitor=False,
         makes_outbound_requests=False,
+        is_hook=True,
         is_shared_component=True,
     ),
     ComponentDetails(
@@ -449,6 +451,7 @@ all_components_details = [
         has_replicas=False,
         has_service_monitor=False,
         makes_outbound_requests=False,
+        is_hook=True,
         is_shared_component=True,
     ),
     ComponentDetails(
@@ -593,6 +596,7 @@ all_components_details = [
                 has_automount_service_account_token=True,
                 has_replicas=False,
                 has_service_monitor=False,
+                is_hook=True,
                 makes_outbound_requests=False,
             ),
         ),
@@ -648,6 +652,7 @@ all_components_details = [
                 has_ingress=False,
                 has_service_monitor=False,
                 has_replicas=False,
+                is_hook=True,
                 makes_outbound_requests=False,
                 ignore_unreferenced_mounts={"synapse": ("/tmp",)},
                 content_volumes_mapping={

--- a/tests/manifests/test_helm_hooks.py
+++ b/tests/manifests/test_helm_hooks.py
@@ -16,12 +16,19 @@ async def test_hook_weight_is_specified_if_manifest_is_hook(templates):
     for template in templates:
         annotations = template["metadata"].get("annotations", {})
 
-        if "helm.sh/hook" in annotations:
+        deployable_details = template_to_deployable_details(template)
+        if deployable_details.is_hook or "k8s.element.io/hook-for" in template["metadata"]["labels"]:
+            assert "helm.sh/hook" in annotations, (
+                f"{template_id(template)} is a hook but it missing the Hook annotation"
+            )
             # If you want to use hook-weight of 0 (the default), it should be explicit
             assert "helm.sh/hook-weight" in annotations, (
                 f"{template_id(template)} is a hook ({annotations['helm.sh/hook']}) but doesn't set a hook weight"
             )
         else:
+            assert "helm.sh/hook" not in annotations, (
+                f"{template_id(template)} is not a hook but has the hook annotation"
+            )
             assert "helm.sh/hook-weight" not in annotations, (
                 f"{template_id(template)} is not a hook but has set a hook weight"
             )

--- a/tests/manifests/test_labels.py
+++ b/tests/manifests/test_labels.py
@@ -122,6 +122,7 @@ async def test_our_labels_are_named_consistently(templates):
     acceptable_matches = [
         "k8s.element.io/as-registration-[0-9]+-hash",
         "k8s.element.io/([a-z0-9-]+)-(config|secret)-hash",
+        "k8s.element.io/hook-for",
         "k8s.element.io/postgres-password-([a-z]+)-hash",
         "k8s.element.io/synapse-instance",
         "k8s.element.io/target-(instance|name)",


### PR DESCRIPTION
Improves #880 so that we can catch stray `helm.sh/hook` annotations on resources that shouldn't have it or missing annotations where they should be