### PR TITLE
Remove explicit configuration of HAProxy `maxconn` at the global and frontend level.

### DIFF
--- a/charts/matrix-stack/configs/haproxy/haproxy.cfg.tpl
+++ b/charts/matrix-stack/configs/haproxy/haproxy.cfg.tpl
@@ -9,7 +9,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- with required "haproxy/haproxy.cfg.tpl missing context" .context -}}
 
 global
-  maxconn 40000
   log stdout format raw local0 info
 
   # Allow for rewriting HTTP headers (e.g. Authorization) up to 4k
@@ -21,9 +20,6 @@ global
 
 defaults
   mode http
-  fullconn 20000
-
-  maxconn 20000
 
   log global
 

--- a/newsfragments/890.changed.md
+++ b/newsfragments/890.changed.md
@@ -1,0 +1,1 @@
+Remove explicit configuration of HAProxy `maxconn` at the global and backend level.


### PR DESCRIPTION
Fixes #886.

At the global level it is computed based on `ulimit -n` as per https://docs.haproxy.org/3.1/configuration.html#maxconn.

At the frontend level, it defaults to the global `maxconn` if omitted.

Removing `fullconn` from `defaults` removes it from each `backend`. This defaults to 10% of each the `maxconn` for each `frontend` that routes to the backend. Given each `server` has much lower `maxconn` it feels fine to remove this.

The previous values were a problem on at least microk8s which didn't raise the ulimits like most other clusters