### PR TITLE
make sure no secret is generated when unneeded

### DIFF
--- a/newsfragments/896.internal.md
+++ b/newsfragments/896.internal.md
@@ -1,0 +1,1 @@
+CI: Make sure `init-secrets` job is not created when no secrets needs to be generated.

--- a/tests/manifests/test_secrets.py
+++ b/tests/manifests/test_secrets.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from . import values_files_to_test
+from . import secret_values_files_to_test, values_files_to_test
 from .utils import template_id
 
 
@@ -18,3 +18,12 @@ async def test_all_secrets_have_type(templates):
             assert template["type"] in ["Opaque"], (
                 f"{template_id(template)} has an unexpected Secret type {template['type']}"
             )
+
+
+@pytest.mark.parametrize("values_file", secret_values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_no_secret_generated_when_unneeded(release_name, values, make_templates):
+    values["initSecrets"] = {"enabled": True}
+    for template in await make_templates(values):
+        if template["kind"] == "Job":
+            assert template["metadata"]["name"] != f"{release_name}-init-secrets"


### PR DESCRIPTION
A simple test to make sure the chart does not create the init-secrets job when it is not required.