### PR TITLE
Ensure Postgres is fully setup before marking as available or live.

### DIFF
--- a/charts/matrix-stack/templates/postgres/_helpers.tpl
+++ b/charts/matrix-stack/templates/postgres/_helpers.tpl
@@ -133,7 +133,7 @@ env:
               )
             ) }}
 - name: "PGHOST"
-  value: "/var/run/postgresql"
+  value: "localhost"
 - name: "PGDATA"
   value: "/var/lib/postgres/data/pgdata"
 {{- end -}}
@@ -156,8 +156,6 @@ env:
                   )
                 )
               ) }}
-- name: "PGHOST"
-  value: "/var/run/postgresql"
 - name: "PGDATA"
   value: "/var/lib/postgres/data/pgdata"
 - name: "POSTGRES_INITDB_ARGS"

--- a/charts/matrix-stack/templates/postgres/statefulset.yaml
+++ b/charts/matrix-stack/templates/postgres/statefulset.yaml
@@ -53,13 +53,13 @@ spec:
               command: ["pg_ctl", "stop", "-D", "/var/lib/postgres/data", "-w", "-t", "55", "-m", "fast"]
         startupProbe: {{- include "element-io.ess-library.pods.probe" .startupProbe | nindent 10 }}
           exec:
-            command: ["psql", "-w", "-U", "postgres", "-d", "postgres", "-c", "SELECT 1"]
+            command: ["psql", "-w", "-U", "postgres", "-d", "postgres", "-h", "localhost", "-c", "SELECT 1"]
         readinessProbe: {{- include "element-io.ess-library.pods.probe" .readinessProbe | nindent 10 }}
           exec:
-            command: ["psql", "-w", "-U", "postgres", "-d", "postgres", "-c", "SELECT 1"]
+            command: ["pg_isready", "-U", "postgres", "-d", "postgres", "-h", "localhost"]
         livenessProbe: {{- include "element-io.ess-library.pods.probe" .livenessProbe | nindent 10 }}
           exec:
-            command: ["psql", "-w", "-U", "postgres", "-d", "postgres", "-c", "SELECT 1"]
+            command: ["psql", "-w", "-U", "postgres", "-d", "postgres", "-h", "localhost", "-c", "SELECT 1"]
         volumeMounts:
 {{- with (include "element-io.init-secrets.postgres-generated-secrets" (dict "root" $)) | fromYamlArray }}
   {{- range . -}}
@@ -116,13 +116,13 @@ spec:
               command: ["pg_ctl", "stop", "-D", "/var/lib/postgres/data", "-w", "-t", "55", "-m", "fast"]
         startupProbe: {{- include "element-io.ess-library.pods.probe" .startupProbe | nindent 10 }}
           exec:
-            command: ["psql", "-w", "-U", "postgres", "-d", "postgres", "-c", "SELECT 1"]
+            command: ["psql", "-w", "-U", "postgres", "-d", "postgres", "-h", "localhost", "-c", "SELECT 1"]
         readinessProbe: {{- include "element-io.ess-library.pods.probe" .readinessProbe | nindent 10 }}
           exec:
-            command: ["psql", "-w", "-U", "postgres", "-d", "postgres", "-c", "SELECT 1"]
+            command: ["pg_isready", "-U", "postgres", "-d", "postgres", "-h", "localhost"]
         livenessProbe: {{- include "element-io.ess-library.pods.probe" .livenessProbe | nindent 10 }}
           exec:
-            command: ["psql", "-w", "-U", "postgres", "-d", "postgres", "-c", "SELECT 1"]
+            command: ["psql", "-w", "-U", "postgres", "-d", "postgres", "-h", "localhost", "-c", "SELECT 1"]
         ports:
         - containerPort: 5432
           name: postgres
@@ -150,8 +150,6 @@ spec:
           subPath: configure-dbs.sh
         - name: database
           mountPath: /var/lib/postgres/data
-        - name: var-run
-          mountPath: /var/run/postgresql
 {{- with .postgresExporter }}
       - name: postgres-exporter
         {{- include "element-io.ess-library.pods.image" (dict "root" $ "context" .image) | nindent 8 }}

--- a/newsfragments/897.fixed.md
+++ b/newsfragments/897.fixed.md
@@ -1,0 +1,1 @@
+Ensure Postgres is fully setup before marking as available or live.

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -491,7 +491,12 @@ all_components_details = [
         content_volumes_mapping={
             "/var/lib/postgres/data": ("pgdata",),
         },
-        ignore_unreferenced_mounts={"postgres": ("/tmp",)},
+        ignore_unreferenced_mounts={
+            "postgres": (
+                "/tmp",
+                "/var/run/postgresql",
+            )
+        },
     ),
     ComponentDetails(
         name="matrix-rtc",


### PR DESCRIPTION
When the Postgres container initialises itself it does so without binding any TCP ports, only allowing connections on the Unix socket. Only after it restarts after running the entrypoint scripts/SQL does it bind TCP ports. Make the liveness/readiness/startup probes only use the TCP port so that we don't mark Postgres as being ready and available too early.

```
...
2025-11-25 16:56:15.588 UTC [32] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2025-11-25 16:56:15.597 UTC [35] LOG:  database system was shut down at 2025-11-25 16:56:15 UTC
2025-11-25 16:56:15.606 UTC [32] LOG:  database system is ready to accept connections
 done
server started

/usr/local/bin/docker-entrypoint.sh: sourcing /docker-entrypoint-initdb.d/init-ess-dbs.sh
Password:
Password:
CREATE ROLE
Password:
Password:
Password:
CREATE ROLE
Password:

2025-11-25 16:56:15.934 UTC [32] LOG:  received fast shutdown request
waiting for server to shut down....2025-11-25 16:56:15.938 UTC [32] LOG:  aborting any active transactions
2025-11-25 16:56:15.946 UTC [32] LOG:  background worker "logical replication launcher" (PID 38) exited with exit code 1
2025-11-25 16:56:15.954 UTC [33] LOG:  shutting down
2025-11-25 16:56:15.958 UTC [33] LOG:  checkpoint starting: shutdown immediate
2025-11-25 16:56:16.042 UTC [33] LOG:  checkpoint complete: wrote 1853 buffers (1.4%); 0 WAL file(s) added, 0 removed, 0 recycled; write=0.071 s, sync=0.008 s, total=0.088 s; sync files=604, longest=0.003 s, average=0.001 s; distance=8515 kB, estimate=8515 kB; lsn=0/1D3DDC0, redo lsn=0/1D3DDC0
2025-11-25 16:56:16.070 UTC [32] LOG:  database system is shut down
 done
server stopped

PostgreSQL init process complete; ready for start up.

2025-11-25 16:56:16.189 UTC [1] LOG:  starting PostgreSQL 17.7 on x86_64-pc-linux-musl, compiled by gcc (Alpine 14.2.0) 14.2.0, 64-bit
2025-11-25 16:56:16.189 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2025-11-25 16:56:16.189 UTC [1] LOG:  listening on IPv6 address "::", port 5432
2025-11-25 16:56:16.194 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2025-11-25 16:56:16.202 UTC [87] LOG:  database system was shut down at 2025-11-25 16:56:16 UTC
2025-11-25 16:56:16.257 UTC [1] LOG:  database system is ready to accept connections
/usr/local/bin/docker-entrypoint.sh: sourcing /docker-entrypoint-initdb.d/init-ess-dbs.sh
Password:
Password:
CREATE ROLE
Password:
Password:
Password:
CREATE ROLE
Password:

2025-11-25 16:56:15.934 UTC [32] LOG:  received fast shutdown request
...
2025-11-25 16:56:30.082 UTC [129] ERROR:  deadlock detected
2025-11-25 16:56:30.082 UTC [129] DETAIL:  Process 129 waits for ShareLock on virtual transaction 22/5; blocked by process 130.
	Process 130 waits for ExclusiveLock on advisory lock [16385,438033630,3765090638,1]; blocked by process 129.
	Process 129: -- no-transaction
	-- Copyright 2025 New Vector Ltd.
	--
	-- SPDX-License-Identifier: AGPL-3.0-only
	-- Please see LICENSE in the repository root for full details.

	CREATE INDEX CONCURRENTLY
	  compat_access_tokens_session_fk
	  ON compat_access_tokens (compat_session_id);

	Process 130: SELECT pg_advisory_lock($1)
...
```