### PR TITLE
Remove legacy MSC2965 advertisment for Native-OIDC/MAS

### DIFF
--- a/charts/matrix-stack/templates/well-known/_helpers.tpl
+++ b/charts/matrix-stack/templates/well-known/_helpers.tpl
@@ -1,6 +1,6 @@
 {{- /*
 Copyright 2024-2025 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -49,14 +49,6 @@ k8s.element.io/target-instance: {{ $root.Release.Name }}-haproxy
 {{- with required "WellKnownDelegation requires synapse.ingress.host set" $root.Values.synapse.ingress.host -}}
 {{- $mHomeserver := dict "base_url" (printf "https://%s" .) -}}
 {{- $_ := set $config "m.homeserver" $mHomeserver -}}
-{{- end -}}
-{{- end -}}
-{{- if include "element-io.matrix-authentication-service.readyToHandleAuth" (dict "root" $root) }}
-{{- with required "WellKnownDelegation requires matrixAuthenticationService.ingress.host set" $root.Values.matrixAuthenticationService.ingress.host -}}
-{{- $msc2965 := dict "issuer" (printf "https://%s/" .)
-                     "account" (printf "https://%s/account" .)
--}}
-{{- $_ := set $config "org.matrix.msc2965.authentication" $msc2965 -}}
 {{- end -}}
 {{- end -}}
 {{- if $root.Values.matrixRTC.enabled -}}

--- a/newsfragments/898.changed.md
+++ b/newsfragments/898.changed.md
@@ -1,0 +1,7 @@
+Remove unstable MSC2965 details from Well Known Files.
+
+Native OIDC (Matrix Authentication Service) support is advertised through `/auth_metadata` availability.
+
+The classic Element applications need to be upgraded to the following versions:
+- Element Android: [v1.6.50](https://github.com/element-hq/element-android/releases/tag/v1.6.50)
+- Element iOS: [v1.11.34](https://github.com/element-hq/element-ios/releases/tag/v1.11.34)

--- a/tests/manifests/test_well_known_delegation.py
+++ b/tests/manifests/test_well_known_delegation.py
@@ -1,5 +1,5 @@
 # Copyright 2024-2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -11,12 +11,6 @@ import pytest
 from . import DeployableDetails, PropertyType
 from .utils import iterate_deployables_ingress_parts
 
-msc_2965_authentication = {
-    "org.matrix.msc2965.authentication": {
-        "issuer": "https://mas.ess.localhost/",
-        "account": "https://mas.ess.localhost/account",
-    }
-}
 synapse_federation = {"m.server": "synapse.ess.localhost:443"}
 synapse_base_url = {"m.homeserver": {"base_url": "https://synapse.ess.localhost"}}
 
@@ -75,50 +69,6 @@ async def test_only_additional_if_all_disabled_in_well_known(release_name, value
 async def test_synapse_injected_in_server_and_client_well_known(release_name, values, make_templates):
     await assert_well_known_files(
         release_name, values, make_templates, expected_client=synapse_base_url, expected_server=synapse_federation
-    )
-
-
-@pytest.mark.parametrize("values_file", ["well-known-mas-values.yaml"])
-@pytest.mark.asyncio_cooperative
-async def test_mas_injected_in_client_well_known(release_name, values, make_templates):
-    await assert_well_known_files(release_name, values, make_templates, expected_client=msc_2965_authentication)
-
-    await assert_well_known_files(
-        release_name,
-        values,
-        make_templates,
-        expected_client=msc_2965_authentication,
-        client_config={
-            "org.matrix.msc2965.authentication": {
-                "issuer": "should-not-override",
-                "account": "https://mas.ess.localhost/account",
-            }
-        },
-    )
-
-
-@pytest.mark.parametrize("values_file", ["well-known-synapse-mas-values.yaml"])
-@pytest.mark.asyncio_cooperative
-async def test_synapse_and_mas_injected_in_client_and_server_well_known(release_name, values, make_templates):
-    await assert_well_known_files(
-        release_name,
-        values,
-        make_templates,
-        expected_client=(msc_2965_authentication | synapse_base_url),
-        expected_server=synapse_federation,
-    )
-    await assert_well_known_files(
-        release_name,
-        values,
-        make_templates,
-        expected_client=(msc_2965_authentication | synapse_base_url),
-        expected_server=synapse_federation,
-        client_config={
-            "org.matrix.msc2965.authentication": {
-                "issuer": "should-not-override",
-                "account": "https://mas.ess.localhost/account",
-            }
-        },
     )
 
 


### PR DESCRIPTION
Draft as legacy Element Android and legacy Element iOS appear to still rely on this and don't check for `/auth_metadata` as [spec'ed](https://spec.matrix.org/latest/client-server-api/#authentication-api-discovery)