### PR TITLE
Listen on IPv6 addresses for HAProxy traffic

### DIFF
--- a/charts/matrix-stack/configs/haproxy/haproxy.cfg.tpl
+++ b/charts/matrix-stack/configs/haproxy/haproxy.cfg.tpl
@@ -83,12 +83,14 @@ resolvers kubedns
 
 frontend prometheus
   bind *:8405
+  bind [::]:8405
   http-request use-service prometheus-exporter if { path /metrics }
   monitor-uri /haproxy_test
   no log
 
 frontend http-blackhole
   bind *:8009
+  bind [::]:8009
 
   # same as http log, with %Th (handshake time)
   log-format "%ci:%cp [%tr] %ft %b/%s %Th/%TR/%Tw/%Tc/%Tr/%Ta %ST %B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %hr %hs %{+Q}r"

--- a/charts/matrix-stack/configs/synapse/partial-haproxy.cfg.tpl
+++ b/charts/matrix-stack/configs/synapse/partial-haproxy.cfg.tpl
@@ -10,6 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 frontend startup
    bind *:8406
+   bind [::]:8406
    acl synapse_dead nbsrv(synapse-main) lt 1
 {{- range $workerType, $_ := (include "element-io.synapse.enabledWorkers" (dict "root" $root)) | fromJson }}
 {{- if not (include "element-io.synapse.process.canFallbackToMain" (dict "root" $root "context" $workerType)) }}
@@ -22,6 +23,7 @@ frontend startup
 
 frontend synapse-http-in
   bind *:8008
+  bind [::]:8008
 
   # if we hit the maxconn on a server, and the queue timeout expires, we want
   # to avoid returning 503, since that will cause cloudflare to mark us down.

--- a/charts/matrix-stack/configs/well-known/partial-haproxy.cfg.tpl
+++ b/charts/matrix-stack/configs/well-known/partial-haproxy.cfg.tpl
@@ -10,6 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 frontend well-known-in
   bind *:8010
+  bind [::]:8010
 
   # same as http log, with %Th (handshake time)
   log-format "%ci:%cp [%tr] %ft %b/%s %Th/%TR/%Tw/%Tc/%Tr/%Ta %ST %B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %hr %hs %{+Q}r"

--- a/newsfragments/905.changed.md
+++ b/newsfragments/905.changed.md
@@ -1,0 +1,1 @@
+Listen for HAProxy traffic over IPv6.


### PR DESCRIPTION
This PR modifies the HAProxy configuration file to direct HAProxy to create sockets in dual-stack mode so that traffic can be received via IPv4 or IPv6. Previously, sockets were created in IPv4 mode only. This was particularly problematic in IPv6-only environments where IPv4 is not routable.

Docs: https://www.haproxy.com/documentation/haproxy-configuration-tutorials/proxying-essentials/configuration-basics/frontends/#listen-on-multiple-ip-addresses-and-ports