### PR TITLE
Expose services as dual-stack where possible

### DIFF
--- a/charts/matrix-stack/templates/element-admin/service.yaml
+++ b/charts/matrix-stack/templates/element-admin/service.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   type: {{ .ingress.service.type | default $.Values.ingress.service.type }}
+  ipFamilyPolicy: PreferDualStack
   ports:
   - port: 8080
     targetPort: http

--- a/charts/matrix-stack/templates/element-web/service.yaml
+++ b/charts/matrix-stack/templates/element-web/service.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   type: {{ .ingress.service.type | default $.Values.ingress.service.type }}
+  ipFamilyPolicy: PreferDualStack
   ports:
   - port: 80
     targetPort: element

--- a/charts/matrix-stack/templates/haproxy/service.yaml
+++ b/charts/matrix-stack/templates/haproxy/service.yaml
@@ -16,6 +16,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   type: ClusterIP
+  ipFamilyPolicy: PreferDualStack
   ports:
   - name: haproxy-metrics
     port: 8405

--- a/charts/matrix-stack/templates/matrix-authentication-service/service.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/service.yaml
@@ -16,6 +16,7 @@ metadata:
     {{- include "element-io.matrix-authentication-service.labels" (dict "root" $ "context" .) | nindent 4 }}
 spec:
   type: {{ .ingress.service.type | default $.Values.ingress.service.type }}
+  ipFamilyPolicy: PreferDualStack
   ports:
   - port: 8080
     protocol: TCP

--- a/charts/matrix-stack/templates/matrix-rtc/authorisation_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/authorisation_service.yaml
@@ -16,6 +16,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   type: ClusterIP
+  ipFamilyPolicy: PreferDualStack
   ports:
   - name: http
     port: 8080

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_tcp_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_tcp_service.yaml
@@ -18,6 +18,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   type: NodePort
+  ipFamilyPolicy: PreferDualStack
   externalTrafficPolicy: Local
   ports:
   - name: "rtc-tcp"

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_muxer_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_muxer_service.yaml
@@ -18,6 +18,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   type: NodePort
+  ipFamilyPolicy: PreferDualStack
   externalTrafficPolicy: Local
   ports:
   - name: "rtc-muxed-udp"

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_range_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_range_service.yaml
@@ -24,6 +24,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   type: NodePort
+  ipFamilyPolicy: PreferDualStack
   externalTrafficPolicy: Local
   ports:
 {{- $segment_start := ((add $range_start (mul 250 $port_segment)) | int) }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_service.yaml
@@ -18,6 +18,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   type: ClusterIP
+  ipFamilyPolicy: PreferDualStack
   ports:
   - name: http
     port: 7880

--- a/charts/matrix-stack/templates/postgres/service.yaml
+++ b/charts/matrix-stack/templates/postgres/service.yaml
@@ -22,6 +22,7 @@ spec:
   - port: 9187
     name: metrics
   type: ClusterIP
+  ipFamilyPolicy: PreferDualStack
   selector:
     app.kubernetes.io/instance: {{ $.Release.Name }}-postgres
 {{- end -}}

--- a/charts/matrix-stack/templates/synapse/redis_service.yaml
+++ b/charts/matrix-stack/templates/synapse/redis_service.yaml
@@ -17,6 +17,7 @@ metadata:
   name: {{ $.Release.Name }}-synapse-redis
   namespace: {{ $.Release.Namespace }}
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
   - port: 6379
     targetPort: redis

--- a/charts/matrix-stack/templates/synapse/synapse_http_service.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_http_service.yaml
@@ -16,6 +16,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   type: {{ .ingress.service.type | default $.Values.ingress.service.type }}
+  ipFamilyPolicy: PreferDualStack
   ports:
   - name: haproxy-synapse
     port: 8008

--- a/charts/matrix-stack/templates/synapse/synapse_service.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_service.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   clusterIP: None
+  ipFamilyPolicy: PreferDualStack
   ports:
 {{- if (include "element-io.synapse.process.hasHttp" (dict "root" $ "context" .)) }}
   - name: synapse-http

--- a/charts/matrix-stack/templates/well-known/service.yaml
+++ b/charts/matrix-stack/templates/well-known/service.yaml
@@ -16,6 +16,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   type: {{ .ingress.service.type | default $.Values.ingress.service.type }}
+  ipFamilyPolicy: PreferDualStack
   ports:
   - name: haproxy-wkd
     port: 8010

--- a/newsfragments/907.changed.md
+++ b/newsfragments/907.changed.md
@@ -1,0 +1,1 @@
+Change `ipFamilyPolicy` to `PreferDualStack` for all services to expose them over dual-stack where possible.

--- a/tests/manifests/test_services.py
+++ b/tests/manifests/test_services.py
@@ -57,3 +57,13 @@ async def test_references_to_services_are_anchored_by_the_cluster_domain(values,
                     f"{template_id(template)} has {line=} which has a reference to a Service that isn't "
                     "anchored with the configured cluster domain"
                 )
+
+
+@pytest.mark.parametrize("values_file", services_values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_services_are_dual_stack_where_possible(templates):
+    for template in templates:
+        if template["kind"] == "Service":
+            assert template["spec"]["ipFamilyPolicy"] == "PreferDualStack", (
+                f"{template_id(template)} does not set ipFamilyPolicy to PreferDualStack"
+            )


### PR DESCRIPTION
This PR directs Kubernetes to assign both IPv4 and IPv6 ClusterIPs to all services where possible. This change is applied to all services [following discussion](https://github.com/element-hq/ess-helm/pull/905#issuecomment-3601556460) with @benbz.

Closes #660 as redundant.