### PR TITLE
Traefik seems to return 504 during the upgrade tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -108,7 +108,7 @@ jobs:
 
     - name: On upgrade, Synapse can restart, expect 429 to occur
       run: |
-        echo "PYTEST_EXPECTED_HTTP_STATUS_CODES=429,502" >> "$GITHUB_ENV"
+        echo "PYTEST_EXPECTED_HTTP_STATUS_CODES=429,502,504" >> "$GITHUB_ENV"
       if: ${{ matrix.test-from-ref != github.event.pull_request.head.sha }}
 
     - name: Test with pytest (upgrade or idempotent setup)

--- a/newsfragments/913.internal.md
+++ b/newsfragments/913.internal.md
@@ -1,0 +1,1 @@
+CI: adjust expected status codes to retry on the upgrade integration tests.


### PR DESCRIPTION
Attempt to fix e.g. https://github.com/element-hq/ess-helm/actions/runs/19888704898/job/57001932467

~~Unclear whether we'll also see 502's but lets be strict for now~~ 502s have been seen in the upgrade tests, keeping those as retryable