### PR TITLE
Toggle SFU room creation restrictions to on

### DIFF
--- a/charts/matrix-stack/source/matrix-rtc.yaml.j2
+++ b/charts/matrix-stack/source/matrix-rtc.yaml.j2
@@ -10,8 +10,7 @@ enabled: true
 
 # Allows restricting room creation to local users only
 # Remote federated users can still join the room
-# Defaults to false for now until clients are upgraded to support the new mechanism
-restrictRoomCreationToLocalUsers: false
+restrictRoomCreationToLocalUsers: true
 
 # LiveKit Authentication Configuration
 # This section allows you to configure authentication for the LiveKit SFU.

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -416,8 +416,7 @@ matrixRTC:
 
   # Allows restricting room creation to local users only
   # Remote federated users can still join the room
-  # Defaults to false for now until clients are upgraded to support the new mechanism
-  restrictRoomCreationToLocalUsers: false
+  restrictRoomCreationToLocalUsers: true
 
   # LiveKit Authentication Configuration
   # This section allows you to configure authentication for the LiveKit SFU.

--- a/newsfragments/926.removed.md
+++ b/newsfragments/926.removed.md
@@ -1,0 +1,3 @@
+The MatrixRTC SFU now restricts creation of calls to users on the local homeserver.
+
+This can be changed back to allowing anyone to create calls on the SFU by by setting `matrixRTC.restrictRoomCreationToLocalUsers: false`.


### PR DESCRIPTION
Added in https://github.com/element-hq/ess-helm/pull/635 with `0.3.0` of the MatrixRTC authoriser service. Controls whether `LIVEKIT_FULL_ACCESS_HOMESERVERS` is set to `$.Values.serverName` (true) or `*` (false).

Unsure if this can be toggled yet, so draft and cc @fkwp for advice