### PR TITLE
Remove references to ECDSA secp256k1 & secp384r1 in the generation code

### DIFF
--- a/matrix-tools/internal/cmd/generate-secrets/args.go
+++ b/matrix-tools/internal/cmd/generate-secrets/args.go
@@ -41,8 +41,6 @@ func parseSecretType(value string) (secret.SecretType, error) {
 		return secret.RSA, nil
 	case "ecdsaprime256v1":
 		return secret.EcdsaPrime256v1, nil
-	case "ecdsasecp256k1":
-		return secret.EcdsaSecp256k1, nil
 	default:
 		return secret.UnknownSecretType, fmt.Errorf("unknown secret type: %s", value)
 	}
@@ -52,7 +50,7 @@ func ParseArgs(args []string) (*GenerateSecretsOptions, error) {
 	var options GenerateSecretsOptions
 
 	generateSecretsSet := flag.NewFlagSet("generate-secrets", flag.ExitOnError)
-	secrets := generateSecretsSet.String("secrets", "", "Comma-separated list of secrets to generate, in the format of `name:key:type`, where `type` is one of: rand32")
+	secrets := generateSecretsSet.String("secrets", "", "Comma-separated list of secrets to generate, in the format of `name:key:type`, where `type` is one of: rand32, signingkey, hex32, rsa, ecdsaprime256v1")
 	secretsLabels := generateSecretsSet.String("labels", "", "Comma-separated list of labels for generated secrets, in the format of `key=value`")
 
 	err := generateSecretsSet.Parse(args)

--- a/matrix-tools/internal/pkg/secret/secret.go
+++ b/matrix-tools/internal/pkg/secret/secret.go
@@ -27,8 +27,6 @@ const (
 	Hex32
 	RSA
 	EcdsaPrime256v1
-	EcdsaSecp256k1
-	EcdsaSecp384r1
 )
 
 func GenerateSecret(client kubernetes.Interface, secretLabels map[string]string, namespace string, name string, key string, secretType SecretType) error {

--- a/newsfragments/927.changed.md
+++ b/newsfragments/927.changed.md
@@ -1,0 +1,3 @@
+Removed some unused code from the `initSecrets` generation container.
+
+Also complete the docs on the secret types it supports.


### PR DESCRIPTION
Were partially added in https://github.com/element-hq/ess-helm/pull/132 but we only generated RSA and ECDSA Prime256v1.

We retain support for users configuring both types of key in MAS, but we're not going to generate them ourselves in the chart