### PR TITLE
Set timeouts on curl requests in CI

### DIFF
--- a/newsfragments/935.internal.md
+++ b/newsfragments/935.internal.md
@@ -1,0 +1,1 @@
+CI: set timeouts for curl so it doesn't attempt to connect for longer than `Pod` startup time.

--- a/tests/integration/test_networking.py
+++ b/tests/integration/test_networking.py
@@ -261,6 +261,10 @@ async def has_actual_metrics_on_endpoint(
                     "curl",
                     [
                         "-s",
+                        "--connect-timeout",
+                        "2",
+                        "--max-time",
+                        "5",
                         f"http://{service.metadata.name}.{generated_data.ess_namespace}.svc.cluster.local:{port_spec.port}/metrics",
                     ],
                     restart_policy="OnFailure",


### PR DESCRIPTION
We've seen failures like

`FAILED tests/integration/test_networking.py::test_service_monitors_point_to_metrics - RuntimeError: Pod curl-1765790722455 did not start in time (failed after 60.58133029937744 seconds), pod status: PodStatus(conditions=[PodCondition(status='True', type='PodReadyToStartContainers', lastProbeTime=None, lastTransitionTime=datetime.datetime(2025, 12, 15, 9, 25, 23, tzinfo=datetime.timezone.utc), message=None, observedGeneration=1, reason=None), PodCondition(status='True', type='Initialized', lastProbeTime=None, lastTransitionTime=datetime.datetime(2025, 12, 15, 9, 25, 22, tzinfo=datetime.timezone.utc), message=None, observedGeneration=1, reason=None), PodCondition(status='True', type='Ready', lastProbeTime=None, lastTransitionTime=datetime.datetime(2025, 12, 15, 9, 25, 23, tzinfo=datetime.timezone.utc), message=None, observedGeneration=1, reason=None), PodCondition(status='True', type='ContainersReady', lastProbeTime=None, lastTransitionTime=datetime.datetime(2025, 12, 15, 9, 25, 23, tzinfo=datetime.timezone.utc), message=None, observedGeneration=1, reason=None), PodCondition(status='True', type='PodScheduled', lastProbeTime=None, lastTransitionTime=datetime.datetime(2025, 12, 15, 9, 25, 22, tzinfo=datetime.timezone.utc), message=None, observedGeneration=1, reason=None)], containerStatuses=[ContainerStatus(image='docker.io/curlimages/curl:latest', imageID='docker.io/curlimages/curl@sha256:935d9100e9ba842cdb060de42472c7ca90cfe9a7c96e4dacb55e79e560b3ff40', name='cmd', ready=True, restartCount=0, allocatedResources=None, allocatedResourcesStatus=None, containerID='containerd://750ed6fc78f1365bf738240b3ccc66974fc0a215d6bcaefcce07c7c173884160', lastState=ContainerState(running=None, terminated=None, waiting=None), resources=ResourceRequirements(claims=None, limits=None, requests=None), started=True, state=ContainerState(running=ContainerStateRunning(startedAt=datetime.datetime(2025, 12, 15, 9, 25, 23, tzinfo=datetime.timezone.utc)), terminated=None, waiting=None), stopSignal=None, user=ContainerUser(linux=LinuxContainerUser(gid=3000, uid=3000, supplementalGroups=[3000])), volumeMounts=[VolumeMountStatus(mountPath='/var/run/secrets/kubernetes.io/serviceaccount', name='kube-api-access-82mvn', readOnly=True, recursiveReadOnly='Disabled')])], ephemeralContainerStatuses=None, extendedResourceClaimStatus=None, hostIP='172.18.0.2', hostIPs=[HostIP(ip='172.18.0.2')], initContainerStatuses=None, message=None, nominatedNodeName=None, observedGeneration=1, phase='Running', podIP='10.42.0.13', podIPs=[PodIP(ip='10.42.0.13')], qosClass='BestEffort', reason=None, resize=None, resourceClaimStatuses=None, startTime=datetime.datetime(2025, 12, 15, 9, 25, 22, tzinfo=datetime.timezone.utc))`

There's no error logs and so the test's [60s timeout is hit](https://github.com/element-hq/ess-helm/blob/25.12.1/tests/integration/lib/helpers.py#L167). The only thing we've got is `exitCode: 7` in the `Pod` YAML, which suggests a [connection error](https://curl.se/libcurl/c/libcurl-errors.html). The default connect timeout is [5 minutes](https://github.com/curl/curl/blob/curl-8_17_0/lib/connect.h#L43), so by dropping this we can see about letting k8s retry the `Pod`