### PR TITLE
Give Traefik 30s to start and be available

### DIFF
--- a/newsfragments/942.internal.md
+++ b/newsfragments/942.internal.md
@@ -1,0 +1,1 @@
+CI: wait a bit longer for the `Ingress` controller to be available.

--- a/tests/integration/fixtures/helm.py
+++ b/tests/integration/fixtures/helm.py
@@ -219,7 +219,7 @@ def ingress_ready(cluster, kube_client: AsyncClient, matrix_stack, generated_dat
 
             if rule.host:
                 attempt = 0
-                while attempt < 20:
+                while attempt < 30:
                     try:
                         # Wait for the port and certificate to be available
                         _, writer = await asyncio.wait_for(
@@ -235,7 +235,7 @@ def ingress_ready(cluster, kube_client: AsyncClient, matrix_stack, generated_dat
                 else:
                     raise Exception(
                         f"Unable to connect to Ingress/{generated_data.release_name}-{ingress_suffix}"
-                        " externally after 20s"
+                        " externally after 30s"
                     )
 
     return _ingress_ready


### PR DESCRIPTION
Attempt to fix flakes like
```
                else:
>                   raise Exception(
                        f"Unable to connect to Ingress/{generated_data.release_name}-{ingress_suffix}"
                        " externally after 20s"
                    )
E                   Exception: Unable to connect to Ingress/pytest-193gu0ov-element-admin externally after 20s

tests/integration/fixtures/helm.py:236: Exception
=========================== short test summary info ============================
FAILED tests/integration/test_element_admin.py::test_element_admin_can_access_root - Exception: Unable to connect to Ingress/pytest-193gu0ov-element-admin externally after 20s
```

from https://github.com/element-hq/ess-helm/actions/runs/20261616202/job/58174800398#step:9:117