### PR TITLE
Merge maintenance/25.12 to main

### DIFF
--- a/.github/workflows/actions-linting.yml
+++ b/.github/workflows/actions-linting.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
     - main
+    - 'maintenance/*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
     - main
+    - 'maintenance/*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/changelog_check.yml
+++ b/.github/workflows/changelog_check.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
     - main
+    - 'maintenance/*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/licensing.yml
+++ b/.github/workflows/licensing.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
     - main
+    - 'maintenance/*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/matrix-tools.yml
+++ b/.github/workflows/matrix-tools.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
     - main
+    - 'maintenance/*'
     tags:
     - 'matrix-tools-*'
   workflow_dispatch:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
     - main
+    - 'maintenance/*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
     - main
+    - 'maintenance/*'
     tags:
     - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:

--- a/.github/workflows/scripts-linting.yml
+++ b/.github/workflows/scripts-linting.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
     - main
+    - 'maintenance/*'
   workflow_dispatch:
 
 permissions:

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -14,7 +14,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 ## The matrix-tools image, used in multiple components
 matrixTools:
-{{ image(registry="ghcr.io", repository="element-hq/ess-helm/matrix-tools", tag="0.5.7") | indent(2) }}
+{{ image(registry="ghcr.io", repository="element-hq/ess-helm/matrix-tools", tag="0.5.8") | indent(2) }}
 
 ## CertManager Issuer to configure by default automatically on all ingresses
 ## If configured, the chart will automatically generate the tlsSecret name for all ingresses

--- a/charts/matrix-stack/source/synapse.yaml.j2
+++ b/charts/matrix-stack/source/synapse.yaml.j2
@@ -85,7 +85,7 @@ logging:
   ## levelOverrides:
   ##   synapse.util.caches.lrucache: WARNING
   levelOverrides: {}
-{{- sub_schema_values.image(registry='ghcr.io', repository='element-hq/synapse', tag='v1.144.0') }}
+{{- sub_schema_values.image(registry='oci.element.io', repository='synapse', tag='v1.144.0-ess.2') }}
 {{- sub_schema_values.ingress() }}
 {{- sub_schema_values.labels() }}
 {{- sub_schema_values.workloadAnnotations() }}

--- a/charts/matrix-stack/templates/ess-library/_render_config.tpl
+++ b/charts/matrix-stack/templates/ess-library/_render_config.tpl
@@ -19,6 +19,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- end -}}
 {{- $outputFile := required "element-io.ess-library.render-config-container missing context.outputFile" .outputFile -}}
 {{- $underrides := .underrides | default list -}}
+{{- $underridesSecrets := .underridesSecrets | default list -}}
 {{- $overrides := required "element-io.ess-library.render-config-container missing context.overrides" .overrides -}}
 - name: {{ $containerName }}
   {{- include "element-io.ess-library.pods.image" (dict "root" $root "context" $root.Values.matrixTools.image) | nindent 2 }}
@@ -32,6 +33,9 @@ SPDX-License-Identifier: AGPL-3.0-only
   - /conf/{{ $outputFile }}
     {{- range $underrides }}
   - /config-templates/{{ . }}
+    {{- end }}
+    {{- range $underridesSecrets }}
+  - /secrets/{{ tpl .configSecret $root }}/{{ .configSecretKey }}
     {{- end }}
     {{- range $key := ($additionalProperty | keys | uniq | sortAlpha) -}}
     {{- $prop := index $additionalProperty $key }}

--- a/charts/matrix-stack/templates/init-secrets/_helpers.tpl
+++ b/charts/matrix-stack/templates/init-secrets/_helpers.tpl
@@ -49,7 +49,8 @@ app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" $
 {{- end }}
 {{- end }}
 {{- with $root.Values.synapse }}
-{{- if .enabled -}}
+{{- if .enabled }}
+- {{ (printf "%s-generated" $root.Release.Name) }}:SYNAPSE_EXTRA:extra
 {{- if not .macaroon }}
 - {{ (printf "%s-generated" $root.Release.Name) }}:SYNAPSE_MACAROON:rand32
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/_helpers.tpl
+++ b/charts/matrix-stack/templates/synapse/_helpers.tpl
@@ -241,12 +241,17 @@ ess-version.json: |
 {{- with required "element-io.synapse.render-config-container missing context" .context }}
 {{- $processType := required "element-io.synapse.render-config-container context required processType" .processType -}}
 {{- $isHook := required "element-io.synapse.render-config-container context required isHook" .isHook -}}
+{{- $underridesSecrets := list }}
+{{- if $root.Values.initSecrets.enabled }}
+{{- $underridesSecrets = append $underridesSecrets (dict "configSecret" (printf "%s-generated" $root.Release.Name) "configSecretKey" "SYNAPSE_EXTRA") }}
+{{- end}}
 {{- include "element-io.ess-library.render-config-container" (dict "root" $root "context"
             (dict "additionalPath" "synapse.additional"
                   "nameSuffix" "synapse"
                   "containerName" (.containerName | default "render-config")
                   "templatesVolume" (.templatesVolume | default "plain-config")
                   "underrides" (list "01-homeserver-underrides.yaml")
+                  "underridesSecrets" $underridesSecrets
                   "overrides" (list "04-homeserver-overrides.yaml"
                                     (eq $processType "check-config" | ternary "05-main.yaml" (printf "05-%s.yaml" $processType)))
                   "outputFile" "homeserver.yaml"

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -21,7 +21,7 @@ matrixTools:
 
     ## The tag of the container image to use.
     ## One of tag or digest must be provided.
-    tag: "0.5.7"
+    tag: "0.5.8"
 
     ## Container digest to use. Used to pull the image instead of the image tag if set
     ## The tag will still be set as the app.kubernetes.io/version label
@@ -4029,14 +4029,14 @@ synapse:
   image:
     ## The host and (optional) port of the container image registry for this component.
     ## If not specified Docker Hub is implied
-    registry: ghcr.io
+    registry: oci.element.io
 
     ## The path in the registry where the container image is located
-    repository: element-hq/synapse
+    repository: synapse
 
     ## The tag of the container image to use.
     ## One of tag or digest must be provided.
-    tag: "v1.144.0"
+    tag: "v1.144.0-ess.2"
 
     ## Container digest to use. Used to pull the image instead of the image tag if set
     ## The tag will still be set as the app.kubernetes.io/version label

--- a/newsfragments/945.internal.md
+++ b/newsfragments/945.internal.md
@@ -1,0 +1,1 @@
+CI: run most jobs on maintenance branches too.


### PR DESCRIPTION
Clears out the `maintenance/25.12` branch.

Adds a changelog for https://github.com/element-hq/ess-helm/commit/f0220482a58a003dc472e077a55d7655868c6303 as that's worth saying

Drops the changelog entry for https://github.com/element-hq/ess-helm/commit/f60c3ba910f8dbbebf7f9a22f76a00ba8a5fe0f1 as it has already been released

#944 can then be merged to `main` afterwards