### PR TITLE
Upgrade Synapse to v1.145.0

### DIFF
--- a/charts/matrix-stack/configs/synapse/path_map_file_get.tpl
+++ b/charts/matrix-stack/configs/synapse/path_map_file_get.tpl
@@ -1,6 +1,6 @@
 {{- /*
 Copyright 2025 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -9,6 +9,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # A map file that is used in haproxy config to map from matrix paths to the
 # named backend. The format is: path_regexp backend_name
+{{ if dig "client-reader" "enabled" false $root.Values.synapse.workers }}
+^/_synapse/admin/v2/users/[^/]+$ client-reader
+{{- end }}
 {{- /*
 The client-reader worker could also support the following GET requests
 when the related workers are not enabled. To keep things simple, we don't support

--- a/charts/matrix-stack/source/synapse.yaml.j2
+++ b/charts/matrix-stack/source/synapse.yaml.j2
@@ -85,7 +85,7 @@ logging:
   ## levelOverrides:
   ##   synapse.util.caches.lrucache: WARNING
   levelOverrides: {}
-{{- sub_schema_values.image(registry='oci.element.io', repository='synapse', tag='v1.144.0-ess.2') }}
+{{- sub_schema_values.image(registry='oci.element.io', repository='synapse', tag='v1.145.0-ess.1') }}
 {{- sub_schema_values.extraVolumes("Synapse", with_context=true) }}
 {{- sub_schema_values.extraVolumeMounts("Synapse", with_context=true) }}
 {{- sub_schema_values.ingress() }}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -4111,7 +4111,7 @@ synapse:
 
     ## The tag of the container image to use.
     ## One of tag or digest must be provided.
-    tag: "v1.144.0-ess.2"
+    tag: "v1.145.0-ess.1"
 
     ## Container digest to use. Used to pull the image instead of the image tag if set
     ## The tag will still be set as the app.kubernetes.io/version label

--- a/newsfragments/962.changed.md
+++ b/newsfragments/962.changed.md
@@ -1,0 +1,8 @@
+Upgrade Synapse to v1.145.0.
+
+Highlights:
+- Add memberships endpoint to the admin API. This is useful for forensics and T&S purpose
+- Add worker support to GET `/_synapse/admin/v2/users/<user_id>`
+
+Full Changelogs:
+- [v1.145.0](https://github.com/element-hq/synapse/releases/tag/v1.145.0)


### PR DESCRIPTION
Draft as RC and because is using ghcr.io, not oci.element.io.

Changelog written as per release