### PR TITLE
Correct major version number on cspell-action

### DIFF
--- a/.github/workflows/scripts-linting.yml
+++ b/.github/workflows/scripts-linting.yml
@@ -1,5 +1,5 @@
 # Copyright 2024-2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -63,4 +63,4 @@ jobs:
     - name: Checkout
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
 
-    - uses: streetsidesoftware/cspell-action@24fa8d3096a314ce263f39578744e9d9f8d80acf  # v7
+    - uses: streetsidesoftware/cspell-action@24fa8d3096a314ce263f39578744e9d9f8d80acf  # v8


### PR DESCRIPTION
https://github.com/streetsidesoftware/cspell-action/commit/24fa8d3096a314ce263f39578744e9d9f8d80acf is v8.1.2.

I don't think this needs a changelog fragment