### PR TITLE
Matrix RTC: Add support for TURN UDP

### DIFF
--- a/charts/matrix-stack/ci/fragments/matrix-rtc-exposed-services.yaml
+++ b/charts/matrix-stack/ci/fragments/matrix-rtc-exposed-services.yaml
@@ -18,3 +18,6 @@ matrixRTC:
       turnTLS:
         enabled: true
         port: 31002
+      turn:
+        enabled: true
+        port: 31003

--- a/charts/matrix-stack/ci/matrix-rtc-exposed-services-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-exposed-services-values.yaml
@@ -29,6 +29,9 @@ matrixRTC:
         portRange:
           endPort: 30050
           startPort: 30000
+      turn:
+        enabled: true
+        port: 31003
       turnTLS:
         domain: turn.{{ $.Values.serverName }}
         enabled: true

--- a/charts/matrix-stack/configs/matrix-rtc/sfu/config-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/matrix-rtc/sfu/config-overrides.yaml.tpl
@@ -60,14 +60,21 @@ key_file: /secrets/{{ (printf "/secrets/%s"
 key_file: /conf/keys.yaml
 {{- end }}
 
-{{- with .exposedServices.turnTLS }}
-{{ if .enabled }}
+{{- if or .exposedServices.turnTLS.enabled .exposedServices.turn.enabled }}
 turn:
   enabled: true
+{{- with .exposedServices.turnTLS }}
+{{ if .enabled }}
   tls_port: {{ .port }}
   domain: {{ tpl .domain $root }}
   cert_file: /turn-tls/tls.crt
   key_file: /turn-tls/tls.key
+{{- end }}
+{{- end }}
+{{- with .exposedServices.turn }}
+{{ if .enabled }}
+  udp_port: {{ .port }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/matrix-stack/source/matrix-rtc.json
+++ b/charts/matrix-stack/source/matrix-rtc.json
@@ -189,6 +189,9 @@
             },
             "turnTLS": {
               "$ref": "file://common/exposedServicePortWithTLS.json"
+            },
+            "turn": {
+              "$ref": "file://common/exposedServicePort.json"
             }
           }
         },

--- a/charts/matrix-stack/source/matrix-rtc.yaml.j2
+++ b/charts/matrix-stack/source/matrix-rtc.yaml.j2
@@ -75,6 +75,7 @@ sfu:
     {{- sub_schema_values.exposedServicePort('rtcMuxedUdp', 30882, 'NodePort') | indent(4) }}
     {{- sub_schema_values.exposedServicePortRange('rtcUdp', 31000, 32000, 'NodePort') | indent(4) }}
     {{- sub_schema_values.exposedServicePort('turnTLS', 31443, 'NodePort', defaultEnabled=False, tlsSecret=True) | indent(4) }}
+    {{- sub_schema_values.exposedServicePort('turn', 31478, 'NodePort', defaultEnabled=False) | indent(4) }}
 
 
 {{- sub_schema_values.image(registry='docker.io', repository='livekit/livekit-server', tag='v1.9.1') | indent(2) }}

--- a/charts/matrix-stack/templates/matrix-rtc/_sfu_helpers.tpl
+++ b/charts/matrix-stack/templates/matrix-rtc/_sfu_helpers.tpl
@@ -9,31 +9,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- $root := .root -}}
 {{- with required "element-io.matrix-rtc.labels missing context" .context -}}
 {{ include "element-io.ess-library.labels.common" (dict "root" $root "context" (dict "labels" .labels "withChartVersion" .withChartVersion)) }}
+{{ $suffix := .suffix | default "" }}
 app.kubernetes.io/component: matrix-rtc-voip-server
-app.kubernetes.io/name: matrix-rtc-sfu
-app.kubernetes.io/instance: {{ $root.Release.Name }}-matrix-rtc-sfu
-app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .image.tag }}
-{{- end }}
-{{- end }}
-
-{{- define "element-io.matrix-rtc-sfu-rtc.labels" -}}
-{{- $root := .root -}}
-{{- with required "element-io.matrix-rtc.labels missing context" .context -}}
-{{ include "element-io.ess-library.labels.common" (dict "root" $root "context" (dict "labels" .labels)) }}
-app.kubernetes.io/component: matrix-rtc-voip-server
-app.kubernetes.io/name: matrix-rtc-sfu-rtc
-app.kubernetes.io/instance: {{ $root.Release.Name }}-matrix-rtc-sfu-rtc
-app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .image.tag }}
-{{- end }}
-{{- end }}
-
-{{- define "element-io.matrix-rtc-sfu-turn-tls.labels" -}}
-{{- $root := .root -}}
-{{- with required "element-io.matrix-rtc.labels missing context" .context -}}
-{{ include "element-io.ess-library.labels.common" (dict "root" $root "context" (dict "labels" .labels)) }}
-app.kubernetes.io/component: matrix-rtc-voip-server
-app.kubernetes.io/name: matrix-rtc-sfu-turn-tls
-app.kubernetes.io/instance: {{ $root.Release.Name }}-matrix-rtc-sfu-turn-tls
+app.kubernetes.io/name: matrix-rtc-sfu{{ $suffix }}
+app.kubernetes.io/instance: {{ $root.Release.Name }}-matrix-rtc-sfu{{ $suffix }}
 app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .image.tag }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
@@ -101,6 +101,16 @@ spec:
           protocol: TCP
   {{- end }}
   {{- end }}
+  {{- with .turn }}
+  {{- if .enabled }}
+        - containerPort: {{ .port }}
+    {{- if eq .portType "HostPort" }}
+          hostPort: {{ .port }}
+    {{- end }}
+          name: turn-udp
+          protocol: UDP
+  {{- end }}
+  {{- end }}
   {{- with .rtcTcp }}
   {{- if .enabled }}
         - containerPort: {{ .port }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_tcp_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_tcp_service.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{- include "element-io.matrix-rtc-sfu-rtc.labels" (dict "root" $ "context" .) | nindent 4 }}
+    {{- include "element-io.matrix-rtc-sfu.labels" (dict "root" $ "context" (mustMergeOverwrite (dict "suffix" "-rtc") .)) | nindent 4 }}
   {{- with .exposedServices.rtcTcp.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_muxer_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_muxer_service.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{- include "element-io.matrix-rtc-sfu-rtc.labels" (dict "root" $ "context" .) | nindent 4 }}
+    {{- include "element-io.matrix-rtc-sfu.labels" (dict "root" $ "context" (mustMergeOverwrite (dict "suffix" "-rtc") .)) | nindent 4 }}
   {{- with .exposedServices.rtcMuxedUdp.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_range_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_range_service.yaml
@@ -19,7 +19,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{- include "element-io.matrix-rtc-sfu-rtc.labels" (dict "root" $ "context" $.Values.matrixRTC.sfu) | nindent 4 }}
+    {{- include "element-io.matrix-rtc-sfu.labels" (dict "root" $ "context" (mustMergeOverwrite (dict "suffix" "-rtc") $.Values.matrixRTC.sfu)) | nindent 4 }}
   {{- with $.Values.matrixRTC.sfu.exposedServices.rtcUdp.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_turn_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_turn_service.yaml
@@ -1,0 +1,38 @@
+{{- /*
+Copyright 2024 New Vector Ltd
+Copyright 2026 Element Creations Ltd
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/ -}}
+
+{{- with $.Values.matrixRTC -}}
+{{- if .enabled -}}
+{{- with .sfu -}}
+{{- if and .enabled .exposedServices.turn.enabled (ne .exposedServices.turn.portType "HostPort") -}}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "element-io.matrix-rtc-sfu.labels" (dict "root" $ "context" (mustMergeOverwrite (dict "suffix" "-turn") .)) | nindent 4 }}
+  {{- with .exposedServices.turn.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ $.Release.Name }}-matrix-rtc-sfu-turn
+  namespace: {{ $.Release.Namespace }}
+spec:
+  type: {{ .exposedServices.turn.portType }}
+  ipFamilyPolicy: PreferDualStack
+  externalTrafficPolicy: Local
+  ports:
+  - name: "turn-udp"
+    protocol: "UDP"
+    port: {{ .exposedServices.turn.port }}
+    targetPort: {{ .exposedServices.turn.port }}
+    nodePort: {{ .exposedServices.turn.port }}
+  selector:
+    app.kubernetes.io/instance: "{{ $.Release.Name }}-matrix-rtc-sfu"
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_turn_tls_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_turn_tls_service.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{- include "element-io.matrix-rtc-sfu-turn-tls.labels" (dict "root" $ "context" .) | nindent 4 }}
+    {{- include "element-io.matrix-rtc-sfu.labels" (dict "root" $ "context" (mustMergeOverwrite (dict "suffix" "-turn-tls") .)) | nindent 4 }}
   {{- with .exposedServices.turnTLS.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -2362,6 +2362,37 @@
                     }
                   },
                   "additionalProperties": false
+                },
+                "turn": {
+                  "type": "object",
+                  "required": [
+                    "enabled",
+                    "portType",
+                    "port"
+                  ],
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "annotations": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "portType": {
+                      "type": "string",
+                      "enum": [
+                        "NodePort",
+                        "HostPort",
+                        "LoadBalancer"
+                      ]
+                    },
+                    "port": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
                 }
               },
               "additionalProperties": false

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -816,6 +816,17 @@ matrixRTC:
         # The TLS secret used to expose this service
         tlsSecret: ""
 
+      turn:
+        enabled: false
+        # Annotations to be added to this service
+        # This is unused if the portType is `HostPort` as the pod port
+        # is exposed directly on the node running it, so no service is created.
+        annotations: {}
+        # Either a NodePort, HostPort or LoadBalancer
+        # If the port is a HostPort, no Service will be created.
+        portType: NodePort
+        port: 31478
+
     # Details of the image to be used
     image:
       ## The host and (optional) port of the container image registry for this component.

--- a/newsfragments/982.added.md
+++ b/newsfragments/982.added.md
@@ -1,0 +1,1 @@
+Matrix RTC: Add support for configuring UDP Turn.

--- a/tests/integration/fixtures/files/clusters/k3d.yml
+++ b/tests/integration/fixtures/files/clusters/k3d.yml
@@ -24,6 +24,9 @@ ports:
   # Matrix RTC SFU Turn TLS
 - port: 127.0.0.1:31443:31443
   nodeFilters: [loadbalancer]
+  # Matrix RTC SFU Turn
+- port: 127.0.0.1:31478:31478
+  nodeFilters: [loadbalancer]
 options:
   k3d:
     wait: true

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -366,7 +366,6 @@ def make_synapse_worker_sub_component(worker_name: str, worker_type: str) -> Sub
     values_file_path_overrides: dict[PropertyType, ValuesFilePath] = {
         PropertyType.AdditionalConfig: ValuesFilePath.read_elsewhere("synapse", "additional"),
         PropertyType.Env: ValuesFilePath.read_elsewhere("synapse", "extraEnv"),
-        PropertyType.ExposedServices: ValuesFilePath.not_supported(),
         PropertyType.HostAliases: ValuesFilePath.read_elsewhere("synapse", "hostAliases"),
         PropertyType.Image: ValuesFilePath.read_elsewhere("synapse", "image"),
         PropertyType.InitContainers: ValuesFilePath.read_elsewhere("synapse", "extraInitContainers"),


### PR DESCRIPTION
- This adds support for Turn UDP on the Matrix RTC SFU
- It refactors the SFU Exposed Services labels helpers a bit to reduce code duplication