### PR TITLE
hookshot: add support for github private key configuration

### DIFF
--- a/charts/matrix-stack/ci/fragments/hookshot-secrets-externally.yaml
+++ b/charts/matrix-stack/ci/fragments/hookshot-secrets-externally.yaml
@@ -4,6 +4,10 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 hookshot:
+  github:
+    privateKey:
+      secret: "{{ $.Release.Name }}-hookshot-external-private-key"
+      secretKey: githubPrivateKey
 
   passkey:
     secret: "{{ $.Release.Name }}-hookshot-external-passkey"

--- a/charts/matrix-stack/ci/fragments/hookshot-secrets-in-helm.yaml
+++ b/charts/matrix-stack/ci/fragments/hookshot-secrets-in-helm.yaml
@@ -4,6 +4,12 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 hookshot:
+  github:
+    privateKey:
+      value: |
+        -----BEGIN PRIVATE KEY-----
+        MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg
+        -----END PRIVATE KEY-----
 
   passkey:
     value: |

--- a/charts/matrix-stack/ci/hookshot-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/hookshot-secrets-externally-values.yaml
@@ -21,6 +21,10 @@ hookshot:
     secret: '{{ $.Release.Name }}-hookshot-external-registration'
     secretKey: registration.yaml
   enabled: true
+  github:
+    privateKey:
+      secret: '{{ $.Release.Name }}-hookshot-external-private-key'
+      secretKey: githubPrivateKey
   ingress:
     host: hookshot.ess.localhost
   passkey:

--- a/charts/matrix-stack/ci/hookshot-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/hookshot-secrets-in-helm-values.yaml
@@ -30,6 +30,12 @@ hookshot:
       url: "http://hookshot:9993"
       sender_localpart: "hookshot"
   enabled: true
+  github:
+    privateKey:
+      value: |
+        -----BEGIN PRIVATE KEY-----
+        MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg
+        -----END PRIVATE KEY-----
   ingress:
     host: hookshot.ess.localhost
   passkey:

--- a/charts/matrix-stack/configs/hookshot/config.yaml.tpl
+++ b/charts/matrix-stack/configs/hookshot/config.yaml.tpl
@@ -65,6 +65,21 @@ generic:
   urlPrefix: https://{{ (tpl $root.Values.synapse.ingress.host $root) }}/_matrix/hookshot/webhook
 {{ end }}
 
+{{ with .github }}
+github:
+  auth:
+    privateKeyFile: /secrets/{{
+                include "element-io.ess-library.provided-secret-path" (
+                      dict "root" $root
+                      "context" (dict
+                        "secretPath" "hookshot.github.privateKey"
+                        "defaultSecretName" (include "element-io.hookshot.secret-name" (dict "root" $root "context" $context))
+                        "defaultSecretKey" "GITHUB_PRIVATE_KEY"
+                      )
+                    ) }}
+{{ end }}
+
+
 widgets:
 {{- if .ingress.host }}
   publicUrl: https://{{ tpl .ingress.host $root }}/widgetapi/v1/static

--- a/charts/matrix-stack/source/hookshot.json
+++ b/charts/matrix-stack/source/hookshot.json
@@ -13,6 +13,14 @@
     "passkey": {
       "$ref": "file://common/credential.json"
     },
+    "github": {
+      "type": "object",
+      "properties": {
+        "privateKey": {
+          "$ref": "file://common/credential.json"
+        }
+      }
+    },
     "logging": {
       "type": "object",
       "properties": {

--- a/charts/matrix-stack/source/hookshot.yaml.j2
+++ b/charts/matrix-stack/source/hookshot.yaml.j2
@@ -12,6 +12,9 @@ enabled: false
 user:
   localpart: hookshot
 
+github: {}
+{{- sub_schema_values.credential("Github App Private key.", "privateKey", initIfAbsent=False, commented=True) | indent(2) }}
+
 logging:
   # The maximum level of Hookshot log output before any overrides
   # Must be one of [critical, error, warning, info, debug]

--- a/charts/matrix-stack/templates/hookshot/_helpers.tpl
+++ b/charts/matrix-stack/templates/hookshot/_helpers.tpl
@@ -65,6 +65,13 @@ app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .
       {{- $configSecrets = append $configSecrets (tpl .secret $root) }}
     {{- end -}}
   {{- end -}}
+  {{- with (.github).privateKey -}}
+    {{- if .value }}
+      {{- $configSecrets = append $configSecrets (printf "%s-hookshot" $root.Release.Name) }}
+    {{- else -}}
+      {{- $configSecrets = append $configSecrets (tpl .secret $root) }}
+    {{- end -}}
+  {{- end -}}
   {{- with .additional -}}
     {{- range $key := (. | keys | uniq | sortAlpha) -}}
       {{- $prop := index $root.Values.hookshot.additional $key }}
@@ -108,6 +115,9 @@ RSA_PASSKEY: {{ . | b64enc }}
   {{- end }}
   {{- with .appserviceRegistration.value }}
 REGISTRATION: {{ . | b64enc }}
+  {{- end }}
+  {{- with ((.github).privateKey).value }}
+GITHUB_PRIVATE_KEY: {{ . | b64enc }}
   {{- end }}
   {{- with .additional }}
     {{- range $key := (. | keys | uniq | sortAlpha) }}

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -4873,6 +4873,27 @@
           },
           "additionalProperties": false
         },
+        "github": {
+          "type": "object",
+          "properties": {
+            "privateKey": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "string"
+                },
+                "secret": {
+                  "type": "string"
+                },
+                "secretKey": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
         "logging": {
           "type": "object",
           "properties": {

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -1809,6 +1809,18 @@ hookshot:
   user:
     localpart: hookshot
 
+  github: {}
+    ## Github App Private key..
+    ## It can either be provided inline in the Helm chart e.g.:
+    ## privateKey:
+    ##   value: SecretValue
+    ##
+    ## Or it can be provided via an existing Secret e.g.:
+    ## privateKey:
+    ##   secret: existing-secret
+    ##   secretKey: key-in-secret
+    # privateKey: {}
+
   logging:
     # The maximum level of Hookshot log output before any overrides
     # Must be one of [critical, error, warning, info, debug]

--- a/newsfragments/991.changed.md
+++ b/newsfragments/991.changed.md
@@ -1,0 +1,1 @@
+Hookshot: Add support for `github.privateKey` configuration to configure github app private key pem file.


### PR DESCRIPTION
Github configuration requires a dedicated private key pem file. We need to inject it through the chart values.