### PR TITLE
Hookshot: Enhance appservice connection

### DIFF
--- a/charts/matrix-stack/configs/hookshot/registration.yaml.tpl
+++ b/charts/matrix-stack/configs/hookshot/registration.yaml.tpl
@@ -10,7 +10,7 @@ namespaces: {}
 id: hookshot
 as_token: "${AS_TOKEN}"
 hs_token: "${HS_TOKEN}"
-url: "http://{{ $root.Release.Name }}-hookshot:9993"
+url: "http://{{ $root.Release.Name }}-hookshot.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}:9993"
 sender_localpart: {{ $root.Values.hookshot.user.localpart }}
 
 org.matrix.msc3202: true

--- a/charts/matrix-stack/templates/hookshot/hookshot_service.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_service.yaml
@@ -22,6 +22,7 @@ spec:
   {{- end }}
 {{- end }}
   ipFamilyPolicy: PreferDualStack
+  publishNotReadyAddresses: true
   ports:
   - port: 9993
     name: appservice

--- a/newsfragments/996.changed.1.md
+++ b/newsfragments/996.changed.1.md
@@ -1,0 +1,1 @@
+Hookshot: Use appservice fully qualified domain name in the registration file.

--- a/newsfragments/996.changed.md
+++ b/newsfragments/996.changed.md
@@ -1,0 +1,1 @@
+Hookshot: Publish service unready address.


### PR DESCRIPTION
- Use the full FQDN of the appservice in the registration file
- Publish Hookshot not ready service addresses