### PR TITLE
Add support for `internalTrafficPolicy` configuration for ingress services

### DIFF
--- a/charts/matrix-stack/source/common/ingress.json
+++ b/charts/matrix-stack/source/common/ingress.json
@@ -38,6 +38,13 @@
             "NodePort",
             "LoadBalancer"
           ]
+        },
+        "internalTrafficPolicy": {
+          "type": "string",
+          "enum": [
+            "Cluster",
+            "Local"
+          ]
         }
       }
     }

--- a/charts/matrix-stack/source/common/ingress_global.json
+++ b/charts/matrix-stack/source/common/ingress_global.json
@@ -25,7 +25,8 @@
     "service": {
       "type": "object",
       "required": [
-        "type"
+        "type",
+        "internalTrafficPolicy"
       ],
       "properties": {
         "type": {
@@ -34,6 +35,13 @@
             "ClusterIP",
             "NodePort",
             "LoadBalancer"
+          ]
+        },
+        "internalTrafficPolicy": {
+          "type": "string",
+          "enum": [
+            "Cluster",
+            "Local"
           ]
         }
       }

--- a/charts/matrix-stack/source/common/ingress_without_host.json
+++ b/charts/matrix-stack/source/common/ingress_without_host.json
@@ -35,6 +35,13 @@
             "NodePort",
             "LoadBalancer"
           ]
+        },
+        "internalTrafficPolicy": {
+          "type": "string",
+          "enum": [
+            "Cluster",
+            "Local"
+          ]
         }
       }
     }

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -183,6 +183,7 @@ networking:
 {%- if global %}
   service:
     type: ClusterIP
+    internalTrafficPolicy: Cluster
 {%- else %}
   service: {}
 {%- endif %}

--- a/charts/matrix-stack/source/synapse/ingress_with_additional_paths.json
+++ b/charts/matrix-stack/source/synapse/ingress_with_additional_paths.json
@@ -38,6 +38,13 @@
             "NodePort",
             "LoadBalancer"
           ]
+        },
+        "internalTrafficPolicy": {
+          "type": "string",
+          "enum": [
+            "Cluster",
+            "Local"
+          ]
         }
       }
     },

--- a/charts/matrix-stack/templates/element-admin/service.yaml
+++ b/charts/matrix-stack/templates/element-admin/service.yaml
@@ -1,6 +1,6 @@
 {{- /*
 Copyright 2025 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -15,6 +15,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   type: {{ .ingress.service.type | default $.Values.ingress.service.type }}
+  internalTrafficPolicy: {{ .ingress.service.internalTrafficPolicy | default $.Values.ingress.service.internalTrafficPolicy }}
   ipFamilyPolicy: PreferDualStack
   ports:
   - port: 8080

--- a/charts/matrix-stack/templates/element-web/service.yaml
+++ b/charts/matrix-stack/templates/element-web/service.yaml
@@ -1,6 +1,6 @@
 {{- /*
 Copyright 2024 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -15,6 +15,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   type: {{ .ingress.service.type | default $.Values.ingress.service.type }}
+  internalTrafficPolicy: {{ .ingress.service.internalTrafficPolicy | default $.Values.ingress.service.internalTrafficPolicy }}
   ipFamilyPolicy: PreferDualStack
   ports:
   - port: 80

--- a/charts/matrix-stack/templates/hookshot/hookshot_service.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_service.yaml
@@ -21,6 +21,7 @@ spec:
   clusterIP: None
   {{- end }}
 {{- end }}
+  internalTrafficPolicy: {{ .ingress.service.internalTrafficPolicy | default $.Values.ingress.service.internalTrafficPolicy }}
   ipFamilyPolicy: PreferDualStack
   publishNotReadyAddresses: true
   ports:

--- a/charts/matrix-stack/templates/matrix-authentication-service/service.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/service.yaml
@@ -1,6 +1,6 @@
 {{- /*
 Copyright 2025 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -16,6 +16,7 @@ metadata:
     {{- include "element-io.matrix-authentication-service.labels" (dict "root" $ "context" .) | nindent 4 }}
 spec:
   type: {{ .ingress.service.type | default $.Values.ingress.service.type }}
+  internalTrafficPolicy: {{ .ingress.service.internalTrafficPolicy | default $.Values.ingress.service.internalTrafficPolicy }}
   ipFamilyPolicy: PreferDualStack
   ports:
   - port: 8080

--- a/charts/matrix-stack/templates/matrix-rtc/authorisation_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/authorisation_service.yaml
@@ -16,6 +16,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   type: {{ .ingress.service.type | default $.Values.ingress.service.type }}
+  internalTrafficPolicy: {{ .ingress.service.internalTrafficPolicy | default $.Values.ingress.service.internalTrafficPolicy }}
   ipFamilyPolicy: PreferDualStack
   ports:
   - name: http

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_service.yaml
@@ -18,6 +18,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   type: {{ $.Values.matrixRTC.ingress.service.type | default $.Values.ingress.service.type }}
+  internalTrafficPolicy: {{ $.Values.matrixRTC.ingress.service.internalTrafficPolicy | default $.Values.ingress.service.internalTrafficPolicy }}
   ipFamilyPolicy: PreferDualStack
   ports:
   - name: http

--- a/charts/matrix-stack/templates/synapse/synapse_http_service.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_http_service.yaml
@@ -1,6 +1,6 @@
 {{- /*
 Copyright 2024 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -16,6 +16,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   type: {{ .ingress.service.type | default $.Values.ingress.service.type }}
+  internalTrafficPolicy: {{ .ingress.service.internalTrafficPolicy | default $.Values.ingress.service.internalTrafficPolicy }}
   ipFamilyPolicy: PreferDualStack
   ports:
   - name: haproxy-synapse

--- a/charts/matrix-stack/templates/well-known/service.yaml
+++ b/charts/matrix-stack/templates/well-known/service.yaml
@@ -1,6 +1,6 @@
 {{- /*
 Copyright 2024 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -16,6 +16,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   type: {{ .ingress.service.type | default $.Values.ingress.service.type }}
+  internalTrafficPolicy: {{ .ingress.service.internalTrafficPolicy | default $.Values.ingress.service.internalTrafficPolicy }}
   ipFamilyPolicy: PreferDualStack
   ports:
   - name: haproxy-wkd

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -186,7 +186,8 @@
         "service": {
           "type": "object",
           "required": [
-            "type"
+            "type",
+            "internalTrafficPolicy"
           ],
           "properties": {
             "type": {
@@ -195,6 +196,13 @@
                 "ClusterIP",
                 "NodePort",
                 "LoadBalancer"
+              ]
+            },
+            "internalTrafficPolicy": {
+              "type": "string",
+              "enum": [
+                "Cluster",
+                "Local"
               ]
             }
           },
@@ -1495,6 +1503,13 @@
                     "ClusterIP",
                     "NodePort",
                     "LoadBalancer"
+                  ]
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
                   ]
                 }
               },
@@ -2986,6 +3001,13 @@
                     "NodePort",
                     "LoadBalancer"
                   ]
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
                 }
               },
               "additionalProperties": false
@@ -3734,6 +3756,13 @@
                     "ClusterIP",
                     "NodePort",
                     "LoadBalancer"
+                  ]
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
                   ]
                 }
               },
@@ -4986,6 +5015,13 @@
                     "ClusterIP",
                     "NodePort",
                     "LoadBalancer"
+                  ]
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
                   ]
                 }
               },
@@ -6396,6 +6432,13 @@
                     "ClusterIP",
                     "NodePort",
                     "LoadBalancer"
+                  ]
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
                   ]
                 }
               },
@@ -9075,6 +9118,13 @@
                     "ClusterIP",
                     "NodePort",
                     "LoadBalancer"
+                  ]
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
                   ]
                 }
               },
@@ -14834,6 +14884,13 @@
                     "ClusterIP",
                     "NodePort",
                     "LoadBalancer"
+                  ]
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
                   ]
                 }
               },

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -68,6 +68,7 @@ ingress:
   ## How the Services behind all Ingresses is constructed by default
   service:
     type: ClusterIP
+    internalTrafficPolicy: Cluster
   ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
   ## This can be set to `ingress-nginx`.
   # controllerType:

--- a/newsfragments/999.added.md
+++ b/newsfragments/999.added.md
@@ -1,0 +1,1 @@
+Add support for configuring `internalTrafficPolicy` for services behind ingresses.


### PR DESCRIPTION
- Ingresses services now support setting `internalTrafficPolicy`
- It defaults to `Cluster` using the root value `$.Values.services.internalTrafficPolicy`
- It can be adjusted per-service like service types

Resolves https://github.com/element-hq/ess-helm/issues/922