### PR TITLE
Add support for configuring traffic policy of exposed services

### DIFF
--- a/charts/matrix-stack/source/common/exposedServicePort.json
+++ b/charts/matrix-stack/source/common/exposedServicePort.json
@@ -23,6 +23,20 @@
         "LoadBalancer"
       ]
     },
+    "internalTrafficPolicy": {
+      "type": "string",
+      "enum": [
+        "Cluster",
+        "Local"
+      ]
+    },
+    "externalTrafficPolicy": {
+      "type": "string",
+      "enum": [
+        "Cluster",
+        "Local"
+      ]
+    },
     "port": {
       "type": "number"
     }

--- a/charts/matrix-stack/source/common/exposedServicePortRange.json
+++ b/charts/matrix-stack/source/common/exposedServicePortRange.json
@@ -23,6 +23,20 @@
         "LoadBalancer"
       ]
     },
+    "internalTrafficPolicy": {
+      "type": "string",
+      "enum": [
+        "Cluster",
+        "Local"
+      ]
+    },
+    "externalTrafficPolicy": {
+      "type": "string",
+      "enum": [
+        "Cluster",
+        "Local"
+      ]
+    },
     "portRange": {
       "type": "object",
       "required": [

--- a/charts/matrix-stack/source/common/exposedServicePortWithTLS.json
+++ b/charts/matrix-stack/source/common/exposedServicePortWithTLS.json
@@ -23,6 +23,20 @@
         "LoadBalancer"
       ]
     },
+    "internalTrafficPolicy": {
+      "type": "string",
+      "enum": [
+        "Cluster",
+        "Local"
+      ]
+    },
+    "externalTrafficPolicy": {
+      "type": "string",
+      "enum": [
+        "Cluster",
+        "Local"
+      ]
+    },
     "port": {
       "type": "number"
     },

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -478,6 +478,9 @@ extraInitContainers: []
   # Either a NodePort, HostPort or LoadBalancer
   # If the port is a HostPort, no Service will be created.
   portType: {{ portType }}
+  # Either Local or Cluster
+  internalTrafficPolicy: Cluster
+  externalTrafficPolicy: Cluster
   port: {{ port }}
 {% if tlsSecret %}
   # The domain of the service

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_tcp_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_tcp_service.yaml
@@ -23,7 +23,8 @@ metadata:
 spec:
   type: {{ .exposedServices.rtcTcp.portType }}
   ipFamilyPolicy: PreferDualStack
-  externalTrafficPolicy: Local
+  internalTrafficPolicy: {{ .exposedServices.rtcTcp.internalTrafficPolicy }}
+  externalTrafficPolicy: {{ .exposedServices.rtcTcp.externalTrafficPolicy }}
   ports:
   - name: "rtc-tcp"
     protocol: "TCP"

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_muxer_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_muxer_service.yaml
@@ -23,7 +23,8 @@ metadata:
 spec:
   type: {{ .exposedServices.rtcMuxedUdp.portType }}
   ipFamilyPolicy: PreferDualStack
-  externalTrafficPolicy: Local
+  internalTrafficPolicy: {{ .exposedServices.rtcMuxedUdp.internalTrafficPolicy }}
+  externalTrafficPolicy: {{ .exposedServices.rtcMuxedUdp.externalTrafficPolicy }}
   ports:
   - name: "rtc-muxed-udp"
     protocol: "UDP"

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_range_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_range_service.yaml
@@ -29,7 +29,8 @@ metadata:
 spec:
   type: {{ $.Values.matrixRTC.sfu.exposedServices.rtcUdp.portType }}
   ipFamilyPolicy: PreferDualStack
-  externalTrafficPolicy: Local
+  internalTrafficPolicy: {{ $.Values.matrixRTC.sfu.exposedServices.rtcUdp.internalTrafficPolicy }}
+  externalTrafficPolicy: {{ $.Values.matrixRTC.sfu.exposedServices.rtcUdp.externalTrafficPolicy }}
   ports:
 {{- $segment_start := ((add $range_start (mul 250 $port_segment)) | int) }}
 {{- $segment_end := ((min (add $range_end 1) (add $segment_start 250)) | int) }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_turn_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_turn_service.yaml
@@ -23,7 +23,8 @@ metadata:
 spec:
   type: {{ .exposedServices.turn.portType }}
   ipFamilyPolicy: PreferDualStack
-  externalTrafficPolicy: Local
+  internalTrafficPolicy: {{ .exposedServices.turn.internalTrafficPolicy }}
+  externalTrafficPolicy: {{ .exposedServices.turn.externalTrafficPolicy }}
   ports:
   - name: "turn-udp"
     protocol: "UDP"

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_turn_tls_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_turn_tls_service.yaml
@@ -23,7 +23,8 @@ metadata:
 spec:
   type: {{ .exposedServices.turnTLS.portType }}
   ipFamilyPolicy: PreferDualStack
-  externalTrafficPolicy: Local
+  internalTrafficPolicy: {{ .exposedServices.turnTLS.internalTrafficPolicy }}
+  externalTrafficPolicy: {{ .exposedServices.turnTLS.externalTrafficPolicy }}
   ports:
   - name: "turn-tls-tcp"
     protocol: "TCP"

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -2295,6 +2295,20 @@
                         "LoadBalancer"
                       ]
                     },
+                    "internalTrafficPolicy": {
+                      "type": "string",
+                      "enum": [
+                        "Cluster",
+                        "Local"
+                      ]
+                    },
+                    "externalTrafficPolicy": {
+                      "type": "string",
+                      "enum": [
+                        "Cluster",
+                        "Local"
+                      ]
+                    },
                     "port": {
                       "type": "number"
                     }
@@ -2326,6 +2340,20 @@
                         "LoadBalancer"
                       ]
                     },
+                    "internalTrafficPolicy": {
+                      "type": "string",
+                      "enum": [
+                        "Cluster",
+                        "Local"
+                      ]
+                    },
+                    "externalTrafficPolicy": {
+                      "type": "string",
+                      "enum": [
+                        "Cluster",
+                        "Local"
+                      ]
+                    },
                     "port": {
                       "type": "number"
                     }
@@ -2355,6 +2383,20 @@
                         "NodePort",
                         "HostPort",
                         "LoadBalancer"
+                      ]
+                    },
+                    "internalTrafficPolicy": {
+                      "type": "string",
+                      "enum": [
+                        "Cluster",
+                        "Local"
+                      ]
+                    },
+                    "externalTrafficPolicy": {
+                      "type": "string",
+                      "enum": [
+                        "Cluster",
+                        "Local"
                       ]
                     },
                     "portRange": {
@@ -2401,6 +2443,20 @@
                         "LoadBalancer"
                       ]
                     },
+                    "internalTrafficPolicy": {
+                      "type": "string",
+                      "enum": [
+                        "Cluster",
+                        "Local"
+                      ]
+                    },
+                    "externalTrafficPolicy": {
+                      "type": "string",
+                      "enum": [
+                        "Cluster",
+                        "Local"
+                      ]
+                    },
                     "port": {
                       "type": "number"
                     },
@@ -2436,6 +2492,20 @@
                         "NodePort",
                         "HostPort",
                         "LoadBalancer"
+                      ]
+                    },
+                    "internalTrafficPolicy": {
+                      "type": "string",
+                      "enum": [
+                        "Cluster",
+                        "Local"
+                      ]
+                    },
+                    "externalTrafficPolicy": {
+                      "type": "string",
+                      "enum": [
+                        "Cluster",
+                        "Local"
                       ]
                     },
                     "port": {

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -776,6 +776,9 @@ matrixRTC:
         # Either a NodePort, HostPort or LoadBalancer
         # If the port is a HostPort, no Service will be created.
         portType: NodePort
+        # Either Local or Cluster
+        internalTrafficPolicy: Cluster
+        externalTrafficPolicy: Cluster
         port: 30881
 
       rtcMuxedUdp:
@@ -787,6 +790,9 @@ matrixRTC:
         # Either a NodePort, HostPort or LoadBalancer
         # If the port is a HostPort, no Service will be created.
         portType: NodePort
+        # Either Local or Cluster
+        internalTrafficPolicy: Cluster
+        externalTrafficPolicy: Cluster
         port: 30882
 
       rtcUdp:
@@ -812,6 +818,9 @@ matrixRTC:
         # Either a NodePort, HostPort or LoadBalancer
         # If the port is a HostPort, no Service will be created.
         portType: NodePort
+        # Either Local or Cluster
+        internalTrafficPolicy: Cluster
+        externalTrafficPolicy: Cluster
         port: 31443
 
         # The domain of the service
@@ -828,6 +837,9 @@ matrixRTC:
         # Either a NodePort, HostPort or LoadBalancer
         # If the port is a HostPort, no Service will be created.
         portType: NodePort
+        # Either Local or Cluster
+        internalTrafficPolicy: Cluster
+        externalTrafficPolicy: Cluster
         port: 31478
 
     # Details of the image to be used

--- a/newsfragments/1001.added.1.md
+++ b/newsfragments/1001.added.1.md
@@ -1,0 +1,1 @@
+Add support for configuring `externalTrafficPolicy` to `exposedServices`.

--- a/newsfragments/1001.added.md
+++ b/newsfragments/1001.added.md
@@ -1,0 +1,1 @@
+Add support for configuring `internalTrafficPolicy` to `exposedServices`.

--- a/newsfragments/1001.changed.md
+++ b/newsfragments/1001.changed.md
@@ -1,0 +1,1 @@
+Change default `externalTrafficPolicy` for the SFU exposed services from `Local` to Kubernetes defaults `Cluster`.


### PR DESCRIPTION
- This changes the default of the SFU exposed services to `Cluster` to stay consistent with kubernetes defaults