### PR TITLE
Allow not to set nodePort on exposed services

### DIFF
--- a/charts/matrix-stack/source/common/exposedServicePort.json
+++ b/charts/matrix-stack/source/common/exposedServicePort.json
@@ -39,6 +39,9 @@
     },
     "port": {
       "type": "number"
+    },
+    "nodePort": {
+      "type": "string"
     }
   }
 }

--- a/charts/matrix-stack/source/common/exposedServicePortRange.json
+++ b/charts/matrix-stack/source/common/exposedServicePortRange.json
@@ -49,6 +49,9 @@
         },
         "endPort": {
           "type": "number"
+        },
+        "nodePort": {
+          "type": "string"
         }
       }
     }

--- a/charts/matrix-stack/source/common/exposedServicePortWithTLS.json
+++ b/charts/matrix-stack/source/common/exposedServicePortWithTLS.json
@@ -40,6 +40,9 @@
     "port": {
       "type": "number"
     },
+    "nodePort": {
+      "type": "string"
+    },
     "domain": {
       "type": "string"
     },

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -468,7 +468,7 @@ extraVolumeMounts: []
 extraInitContainers: []
 {% endmacro %}
 
-{% macro exposedServicePort(name, port, portType='NodePort', defaultEnabled=true, tlsSecret=false) %}
+{% macro exposedServicePort(name, port, portType='NodePort', defaultEnabled=true, tlsSecret=false, nodePortTemplate='') %}
 {{ name }}:
   enabled: {{ 'true' if defaultEnabled else 'false' }}
   # Annotations to be added to this service
@@ -478,6 +478,9 @@ extraInitContainers: []
   # Either a NodePort, HostPort or LoadBalancer
   # If the port is a HostPort, no Service will be created.
   portType: {{ portType }}
+  # Node Port template value. If empty, `nodePort` wont be set on the service port
+  # And kubernetes will automatically assign a port.
+  nodePort: "{{ nodePortTemplate }}"
   # Either Local or Cluster
   internalTrafficPolicy: Cluster
   externalTrafficPolicy: Cluster
@@ -490,7 +493,7 @@ extraInitContainers: []
 {% endif %}
 {%- endmacro %}
 
-{% macro exposedServicePortRange(name, startPort, endPort, portType='NodePort') %}
+{% macro exposedServicePortRange(name, startPort, endPort, portType='NodePort', nodePortTemplate='') %}
 {{ name }}:
   enabled: false
   # Annotations to be added to this service
@@ -505,4 +508,12 @@ extraInitContainers: []
     startPort: {{ startPort }}
     # The last port of the range
     endPort: {{ endPort }}
+    # Node Port template value.
+    # The template takes as argument :
+    # - "context" : This exposed service values context, in addition with a key "port"
+    #               containing current port number of the helm range
+    # - "root" : The $ helm root special context
+    # If empty, `nodePort` wont be set on the service port
+    # And kubernetes will automatically assign a port.
+    nodePort: "{{ nodePortTemplate }}"
 {%- endmacro %}

--- a/charts/matrix-stack/source/matrix-rtc.yaml.j2
+++ b/charts/matrix-stack/source/matrix-rtc.yaml.j2
@@ -71,11 +71,11 @@ sfu:
   # Whether to start the SFU in host network mode or not
   hostNetwork: false
   exposedServices:
-    {{- sub_schema_values.exposedServicePort('rtcTcp', 30881, 'NodePort') | indent(4) }}
-    {{- sub_schema_values.exposedServicePort('rtcMuxedUdp', 30882, 'NodePort') | indent(4) }}
-    {{- sub_schema_values.exposedServicePortRange('rtcUdp', 31000, 32000, 'NodePort') | indent(4) }}
-    {{- sub_schema_values.exposedServicePort('turnTLS', 31443, 'NodePort', defaultEnabled=False, tlsSecret=True) | indent(4) }}
-    {{- sub_schema_values.exposedServicePort('turn', 31478, 'NodePort', defaultEnabled=False) | indent(4) }}
+    {{- sub_schema_values.exposedServicePort('rtcTcp', 30881, 'NodePort', nodePortTemplate="{{ .context.port }}") | indent(4) }}
+    {{- sub_schema_values.exposedServicePort('rtcMuxedUdp', 30882, 'NodePort', nodePortTemplate="{{ .context.port }}") | indent(4) }}
+    {{- sub_schema_values.exposedServicePortRange('rtcUdp', 31000, 32000, 'NodePort', nodePortTemplate="{{ .context.port }}") | indent(4) }}
+    {{- sub_schema_values.exposedServicePort('turnTLS', 31443, 'NodePort', defaultEnabled=False, tlsSecret=True, nodePortTemplate="{{ .context.port }}") | indent(4) }}
+    {{- sub_schema_values.exposedServicePort('turn', 31478, 'NodePort', defaultEnabled=False, nodePortTemplate="{{ .context.port }}") | indent(4) }}
 
 
 {{- sub_schema_values.image(registry='docker.io', repository='livekit/livekit-server', tag='v1.9.1') | indent(2) }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_tcp_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_tcp_service.yaml
@@ -30,7 +30,9 @@ spec:
     protocol: "TCP"
     port: {{ .exposedServices.rtcTcp.port }}
     targetPort: {{ .exposedServices.rtcTcp.port }}
-    nodePort: {{ .exposedServices.rtcTcp.port }}
+    {{- with .exposedServices.rtcTcp.nodePort }}
+    nodePort: {{ tpl . (dict "context" $.Values.matrixRTC.sfu.exposedServices.rtcTcp "root" $) }}
+    {{- end }}
   selector:
     app.kubernetes.io/instance: "{{ $.Release.Name }}-matrix-rtc-sfu"
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_muxer_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_muxer_service.yaml
@@ -30,7 +30,9 @@ spec:
     protocol: "UDP"
     port: {{ .exposedServices.rtcMuxedUdp.port }}
     targetPort: {{ .exposedServices.rtcMuxedUdp.port }}
-    nodePort: {{ .exposedServices.rtcMuxedUdp.port }}
+    {{- with .exposedServices.rtcMuxedUdp.nodePort }}
+    nodePort: {{ tpl . (dict "context" $.Values.matrixRTC.sfu.exposedServices.rtcMuxedUdp "root" $) }}
+    {{- end }}
   selector:
     app.kubernetes.io/instance: "{{ $.Release.Name }}-matrix-rtc-sfu"
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_range_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_range_service.yaml
@@ -38,7 +38,9 @@ spec:
   - name: rtc-udp-{{ $port }}
     port: {{ $port }}
     targetPort: {{ $port }}
-    nodePort: {{ $port }}
+    {{- with $.Values.matrixRTC.sfu.exposedServices.rtcUdp.portRange.nodePort }}
+    nodePort: {{ tpl . (dict "context" (mustMergeOverwrite (dict "port" $port) ($.Values.matrixRTC.sfu.exposedServices.rtcUdp)) "root" $)  }}
+    {{- end }}
     protocol: UDP
 {{- end }}
   selector:

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_turn_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_turn_service.yaml
@@ -30,7 +30,9 @@ spec:
     protocol: "UDP"
     port: {{ .exposedServices.turn.port }}
     targetPort: {{ .exposedServices.turn.port }}
-    nodePort: {{ .exposedServices.turn.port }}
+    {{- with .exposedServices.turn.nodePort }}
+    nodePort: {{ tpl . (dict "context" $.Values.matrixRTC.sfu.exposedServices.turn "root" $) }}
+    {{- end }}
   selector:
     app.kubernetes.io/instance: "{{ $.Release.Name }}-matrix-rtc-sfu"
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_turn_tls_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_turn_tls_service.yaml
@@ -30,7 +30,9 @@ spec:
     protocol: "TCP"
     port: {{ .exposedServices.turnTLS.port }}
     targetPort: {{ .exposedServices.turnTLS.port }}
-    nodePort: {{ .exposedServices.turnTLS.port }}
+    {{- with .exposedServices.turnTLS.nodePort }}
+    nodePort: {{ tpl . (dict "context" $.Values.matrixRTC.sfu.exposedServices.turnTLS "root" $) }}
+    {{- end }}
   selector:
     app.kubernetes.io/instance: "{{ $.Release.Name }}-matrix-rtc-sfu"
 {{- end }}

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -2311,6 +2311,9 @@
                     },
                     "port": {
                       "type": "number"
+                    },
+                    "nodePort": {
+                      "type": "string"
                     }
                   },
                   "additionalProperties": false
@@ -2356,6 +2359,9 @@
                     },
                     "port": {
                       "type": "number"
+                    },
+                    "nodePort": {
+                      "type": "string"
                     }
                   },
                   "additionalProperties": false
@@ -2411,6 +2417,9 @@
                         },
                         "endPort": {
                           "type": "number"
+                        },
+                        "nodePort": {
+                          "type": "string"
                         }
                       },
                       "additionalProperties": false
@@ -2459,6 +2468,9 @@
                     },
                     "port": {
                       "type": "number"
+                    },
+                    "nodePort": {
+                      "type": "string"
                     },
                     "domain": {
                       "type": "string"
@@ -2510,6 +2522,9 @@
                     },
                     "port": {
                       "type": "number"
+                    },
+                    "nodePort": {
+                      "type": "string"
                     }
                   },
                   "additionalProperties": false

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -776,6 +776,9 @@ matrixRTC:
         # Either a NodePort, HostPort or LoadBalancer
         # If the port is a HostPort, no Service will be created.
         portType: NodePort
+        # Node Port template value. If empty, `nodePort` wont be set on the service port
+        # And kubernetes will automatically assign a port.
+        nodePort: "{{ .context.port }}"
         # Either Local or Cluster
         internalTrafficPolicy: Cluster
         externalTrafficPolicy: Cluster
@@ -790,6 +793,9 @@ matrixRTC:
         # Either a NodePort, HostPort or LoadBalancer
         # If the port is a HostPort, no Service will be created.
         portType: NodePort
+        # Node Port template value. If empty, `nodePort` wont be set on the service port
+        # And kubernetes will automatically assign a port.
+        nodePort: "{{ .context.port }}"
         # Either Local or Cluster
         internalTrafficPolicy: Cluster
         externalTrafficPolicy: Cluster
@@ -809,6 +815,14 @@ matrixRTC:
           startPort: 31000
           # The last port of the range
           endPort: 32000
+          # Node Port template value.
+          # The template takes as argument :
+          # - "context" : This exposed service values context, in addition with a key "port"
+          #               containing current port number of the helm range
+          # - "root" : The $ helm root special context
+          # If empty, `nodePort` wont be set on the service port
+          # And kubernetes will automatically assign a port.
+          nodePort: "{{ .context.port }}"
       turnTLS:
         enabled: false
         # Annotations to be added to this service
@@ -818,6 +832,9 @@ matrixRTC:
         # Either a NodePort, HostPort or LoadBalancer
         # If the port is a HostPort, no Service will be created.
         portType: NodePort
+        # Node Port template value. If empty, `nodePort` wont be set on the service port
+        # And kubernetes will automatically assign a port.
+        nodePort: "{{ .context.port }}"
         # Either Local or Cluster
         internalTrafficPolicy: Cluster
         externalTrafficPolicy: Cluster
@@ -837,6 +854,9 @@ matrixRTC:
         # Either a NodePort, HostPort or LoadBalancer
         # If the port is a HostPort, no Service will be created.
         portType: NodePort
+        # Node Port template value. If empty, `nodePort` wont be set on the service port
+        # And kubernetes will automatically assign a port.
+        nodePort: "{{ .context.port }}"
         # Either Local or Cluster
         internalTrafficPolicy: Cluster
         externalTrafficPolicy: Cluster

--- a/newsfragments/1002.added.md
+++ b/newsfragments/1002.added.md
@@ -1,0 +1,9 @@
+Add support to customize `nodePort` of exposed services.
+
+`nodePort` property of `exposedServices.*` is now a string template taking two parameters:
+- `context`: The exposed service values context `*.exposedServices.<svc>`
+- `root` : The helm $ root values context
+
+On Matrix RTC values, the `nodePort` template defaults to `{{ .context.port }}` so that the `nodePort`
+is the same as `port`. Setting the template to an empty string will skip setting `nodePort`
+on the service.


### PR DESCRIPTION
Add support to customize `nodePort` of exposed services.

`nodePort` property of `exposedServices.*` is now a string template taking two parameters

- `context`: The exposed service values context `*.exposedServices.<svc>` with `port` property injected in case of port ranges
- `root` : The helm $ root values context

On Matrix RTC values, the `nodePort` template defaults to `{{ .context.port }}` so that the `nodePort`
is the same as `port`. Setting the template to an empty string will skip setting `nodePort`
on the service.
