### PR TITLE
build services schema using a common service.json file.

### DIFF
--- a/charts/matrix-stack/source/common/ingress.json
+++ b/charts/matrix-stack/source/common/ingress.json
@@ -29,31 +29,7 @@
       ]
     },
     "service": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "ClusterIP",
-            "NodePort",
-            "LoadBalancer"
-          ]
-        },
-        "internalTrafficPolicy": {
-          "type": "string",
-          "enum": [
-            "Cluster",
-            "Local"
-          ]
-        },
-        "externalTrafficPolicy": {
-          "type": "string",
-          "enum": [
-            "Cluster",
-            "Local"
-          ]
-        }
-      }
+      "$ref": "file://common/service.json"
     }
   }
 }

--- a/charts/matrix-stack/source/common/ingress_without_host.json
+++ b/charts/matrix-stack/source/common/ingress_without_host.json
@@ -26,31 +26,7 @@
       ]
     },
     "service": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "ClusterIP",
-            "NodePort",
-            "LoadBalancer"
-          ]
-        },
-        "internalTrafficPolicy": {
-          "type": "string",
-          "enum": [
-            "Cluster",
-            "Local"
-          ]
-        },
-        "externalTrafficPolicy": {
-          "type": "string",
-          "enum": [
-            "Cluster",
-            "Local"
-          ]
-        }
-      }
+      "$ref": "file://common/service.json"
     }
   }
 }

--- a/charts/matrix-stack/source/common/service.json
+++ b/charts/matrix-stack/source/common/service.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "ClusterIP",
+        "NodePort",
+        "LoadBalancer"
+      ]
+    },
+    "internalTrafficPolicy": {
+      "type": "string",
+      "enum": [
+        "Cluster",
+        "Local"
+      ]
+    },
+    "externalTrafficPolicy": {
+      "type": "string",
+      "enum": [
+        "Cluster",
+        "Local"
+      ]
+    }
+  }
+}

--- a/newsfragments/1003.internal.md
+++ b/newsfragments/1003.internal.md
@@ -1,0 +1,1 @@
+Build services schema using a common service.json file.


### PR DESCRIPTION
This uses the same schema for both `ingress.json` and `ingress_without_host.json`.

The schema is kept distinct for `ingress_global.json` as it has `required` properties :  

```json
    "service": {
      "type": "object",
      "required": [
        "type",
        "internalTrafficPolicy"
      ],
```