### PR TITLE
hookshot: revert internal routing

### DIFF
--- a/charts/matrix-stack/ci/fragments/hookshot-pytest-extras.yaml
+++ b/charts/matrix-stack/ci/fragments/hookshot-pytest-extras.yaml
@@ -23,6 +23,8 @@ hookshot:
           enableHttpGet: false
           allowedIpRanges:
           - 10.0.0.0/8
+          openIdOverrides:
+            {{ $.Values.serverName | quote }}: "http://{{- $.Release.Name }}-synapse.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:8008"
     permissions.yaml:
       config: |
         # Permissions are ordered this way so that we can easily see that they aren't appended to the default

--- a/charts/matrix-stack/ci/pytest-hookshot-values.yaml
+++ b/charts/matrix-stack/ci/pytest-hookshot-values.yaml
@@ -44,6 +44,8 @@ hookshot:
           enableHttpGet: false
           allowedIpRanges:
           - 10.0.0.0/8
+          openIdOverrides:
+            {{ $.Values.serverName | quote }}: "http://{{- $.Release.Name }}-synapse.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:8008"
   enableEncryption: true
   enabled: true
   extraEnv:

--- a/charts/matrix-stack/ci/pytest-hookshot-with-mas-values.yaml
+++ b/charts/matrix-stack/ci/pytest-hookshot-with-mas-values.yaml
@@ -44,6 +44,8 @@ hookshot:
           enableHttpGet: false
           allowedIpRanges:
           - 10.0.0.0/8
+          openIdOverrides:
+            {{ $.Values.serverName | quote }}: "http://{{- $.Release.Name }}-synapse.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:8008"
   enabled: true
   extraEnv:
     - name: DEBUG_RENDERING

--- a/charts/matrix-stack/configs/hookshot/config-underride.yaml.tpl
+++ b/charts/matrix-stack/configs/hookshot/config-underride.yaml.tpl
@@ -12,11 +12,6 @@ widgets:
   roomSetupWidget:
     addOnInvite: true
 
-{{- if $root.Values.synapse.enabled }}
-  openIdOverrides:
-    {{ tpl $root.Values.serverName $root | quote }}: "http://{{ include "element-io.synapse.internal-hostport" (dict "root" $root "context" (dict "targetProcessType" "")) }}"
-{{- end }}
-
 permissions:
 # Allow all users to send commands to existing services
 - actor: {{ tpl $root.Values.serverName $root | quote }}

--- a/newsfragments/1010.changed.1.md
+++ b/newsfragments/1010.changed.1.md
@@ -1,1 +1,0 @@
-Route requests between Hookshot and Synapse internally to the cluster by default.

--- a/newsfragments/1018.changed.md
+++ b/newsfragments/1018.changed.md
@@ -1,0 +1,1 @@
+Update the test cluster values so that Hookshot can make requests to cluster-internal IP addresses.


### PR DESCRIPTION
- This is only used by Widgets
- This requires users to configure an allow ip list to work even if their cluster support harpinning to the front door
- In pytest, we will use the `openidOverride` feature to make it work without hostAliases. It can also be an example about how to make it work in practice.