### PR TITLE
use oci repository to install cert-manager and prometheus-operator-crds

### DIFF
--- a/newsfragments/1020.internal.md
+++ b/newsfragments/1020.internal.md
@@ -1,0 +1,1 @@
+CI: Use OCI repository to install `cert-manager` and `prometheus-operator-crds`.

--- a/tests/integration/fixtures/cluster.py
+++ b/tests/integration/fixtures/cluster.py
@@ -153,10 +153,7 @@ async def cert_manager(helm_client, kube_client):
     if os.environ.get("SKIP_CERT_MANAGER", "false") != "false":
         return
 
-    chart = await helm_client.get_chart(
-        "cert-manager",
-        repo="https://charts.jetstack.io",
-    )
+    chart = await helm_client.get_chart("oci://quay.io/jetstack/charts/cert-manager")
     await helm_client.install_or_upgrade_release(
         "cert-manager",
         chart,
@@ -231,9 +228,7 @@ async def cert_manager(helm_client, kube_client):
 @pytest.fixture(scope="session")
 async def prometheus_operator_crds(helm_client):
     if os.environ.get("SKIP_SERVICE_MONITORS_CRDS", "false") == "false":
-        chart = await helm_client.get_chart(
-            "prometheus-operator-crds", repo="https://prometheus-community.github.io/helm-charts"
-        )
+        chart = await helm_client.get_chart("oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds")
 
         # Install or upgrade a release
         await helm_client.install_or_upgrade_release(


### PR DESCRIPTION
The HTTP repositories are being throttled and are causing some CI Jobs failures. Let's use OCI which can even profit from docker caching instead.