### PR TITLE
ci: cache asdf tool setup

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -103,7 +103,9 @@ jobs:
 
     - name: Reshim installed ASDF tools
       shell: bash
-      run: asdf reshim
+      run: |
+        ls -lRt ${{ env.ASDF_DIR }}
+        asdf reshim
 
     - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
 


### PR DESCRIPTION
There are some failure when k3d pull are throttled in CI. Let's try to cache those.