### PR TITLE
Set widgets.openIdOverrides for Hookshot in the test cluster

### DIFF
--- a/charts/matrix-stack/ci/test-cluster-mixin.yaml
+++ b/charts/matrix-stack/ci/test-cluster-mixin.yaml
@@ -17,6 +17,8 @@ hookshot:
         widgets:
           allowedIpRanges:
           - 10.0.0.0/8
+          openIdOverrides:
+            {{ $.Values.serverName | quote }}: "http://{{- $.Release.Name }}-synapse.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:8008"
   # Hookshot doesn't need extraEnv to disable TLS validation as `widgets.openIdOverrides` sets Synapse's endpoint to HTTP
   # Hookshot doesn't need hostAliases for Synapse and Well-Known as `widgets.openIdOverrides` skips this
 

--- a/newsfragments/1023.changed.md
+++ b/newsfragments/1023.changed.md
@@ -1,0 +1,1 @@
+Update the test cluster values so that Hookshot can make requests to cluster-internal IP addresses.


### PR DESCRIPTION
Touches up #1018 