### PR TITLE
Add Gateway/HTTPRoute alternative ingress

### DIFF
--- a/charts/matrix-stack/configs/element-web/config.json.tpl
+++ b/charts/matrix-stack/configs/element-web/config.json.tpl
@@ -16,7 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- $_ := set $mHomeserver "server_name" (tpl $root.Values.serverName $root) }}
 {{- end }}
 {{- if $root.Values.synapse.enabled }}
-{{- $_ := set $mHomeserver "base_url" (printf "https://%s" (tpl $root.Values.synapse.ingress.host $root)) -}}
+{{- $_ := set $mHomeserver "base_url" (printf "https://%s" (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" $root.Values.synapse)))) -}}
 {{- end }}
 {{- if $root.Values.matrixRTC.enabled }}
 {{- $_ := set $config "features" (dict "feature_video_rooms" true  "feature_new_room_decoration_ui" true "feature_element_call_video_rooms" true) -}}

--- a/charts/matrix-stack/configs/hookshot/config-override.yaml.tpl
+++ b/charts/matrix-stack/configs/hookshot/config-override.yaml.tpl
@@ -51,7 +51,7 @@ listeners:
     bindAddress: {{ ( has $root.Values.networking.ipFamily (list "ipv6" "dual-stack")) | ternary "::" "0.0.0.0" | quote }}
     resources:
       - webhooks
-{{- if and $root.Values.synapse.enabled (not .ingress.host) }}
+{{- if and $root.Values.synapse.enabled (not (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)))) }}
     prefix: "/_matrix/hookshot"
 {{- end }}
   - port: 7777
@@ -64,22 +64,22 @@ listeners:
     bindAddress: {{ ( has $root.Values.networking.ipFamily (list "ipv6" "dual-stack")) | ternary "::" "0.0.0.0" | quote }}
     resources:
       - widgets
-{{- if and $root.Values.synapse.enabled (not .ingress.host) }}
+{{- if and $root.Values.synapse.enabled (not (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)))) }}
     prefix: "/_matrix/hookshot"
 {{- end }}
 
 generic:
-{{ if .ingress.host }}
-  urlPrefix: https://{{ (tpl .ingress.host $root) }}/webhook
+{{ if include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)) }}
+  urlPrefix: https://{{ include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)) }}/webhook
 {{ else if $root.Values.synapse.enabled }}
-  urlPrefix: https://{{ (tpl $root.Values.synapse.ingress.host $root) }}/_matrix/hookshot/webhook
+  urlPrefix: https://{{ include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" $root.Values.synapse)) }}/_matrix/hookshot/webhook
 {{ end }}
 
 widgets:
-{{- if .ingress.host }}
-  publicUrl: https://{{ tpl .ingress.host $root }}/widgetapi/v1/static
+{{- if include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)) }}
+  publicUrl: https://{{ include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)) }}/widgetapi/v1/static
 {{ else if $root.Values.synapse.enabled }}
-  publicUrl: https://{{ tpl $root.Values.synapse.ingress.host $root }}/_matrix/hookshot/widgetapi/v1/static
+  publicUrl: https://{{ include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" $root.Values.synapse)) }}/_matrix/hookshot/widgetapi/v1/static
 {{ end }}
 
 {{- end -}}

--- a/charts/matrix-stack/configs/matrix-authentication-service/config-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/matrix-authentication-service/config-overrides.yaml.tpl
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- with required "matrix-authentication-service/config.yaml.tpl missing context" .context }}
 {{- $context := . -}}
 http:
-  public_base: "https://{{ tpl .ingress.host $root }}"
+  public_base: "https://{{ include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)) }}"
   listeners:
   - name: web
     binds:

--- a/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 {{- $root := .root -}}
 {{- if $root.Values.elementWeb.enabled }}
-web_client_location: https://{{ $root.Values.elementWeb.ingress.host }}/
+web_client_location: https://{{ include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" $root.Values.elementWeb)) }}/
 {{- end }}
 
 report_stats: false

--- a/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- $root := .root -}}
 {{- with required "synapse/synapse-04-homeserver-overrides.yaml.tpl missing context" .context }}
 {{- $isHook := required "element-io.synapse.config.shared-overrides requires context.isHook" .isHook -}}
-public_baseurl: https://{{ tpl .ingress.host $root }}/
+public_baseurl: https://{{ include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)) }}/
 server_name: {{ tpl $root.Values.serverName $root }}
 signing_key_path: /secrets/{{
   include "element-io.ess-library.init-secret-path" (
@@ -131,7 +131,7 @@ password_config:
 matrix_rtc:
   transports:
   - type: livekit
-    livekit_service_url: {{ (printf "https://%s" $root.Values.matrixRTC.ingress.host) }}
+    livekit_service_url: {{ (printf "https://%s" (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" $root.Values.matrixRTC)))) }}
 {{- end }}
 
 {{- if dig "appservice" "enabled" false .workers }}

--- a/charts/matrix-stack/configs/well-known/partial-haproxy.cfg.tpl
+++ b/charts/matrix-stack/configs/well-known/partial-haproxy.cfg.tpl
@@ -35,8 +35,8 @@ frontend well-known-in
   http-request redirect  code 301  location {{ .baseDomainRedirect.url }} unless well-known
 {{- else if $root.Values.elementWeb.enabled }}
 {{- with $root.Values.elementWeb }}
-{{- $elementWebHttps := include "element-io.ess-library.ingress.tlsHostsSecret" (dict "root" $root "context" (dict "hosts" (list .ingress.host) "tlsSecret" .ingress.tlsSecret "ingressName" "element-web")) }}
-  http-request redirect  code 301  location http{{ if $elementWebHttps }}s{{ end }}://{{ tpl .ingress.host $root }} unless well-known
+{{- $elementWebHttps := include "element-io.ess-library.ingress.tlsHostsSecret" (dict "root" $root "context" (dict "hosts" (list (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)))) "tlsSecret" .ingress.tlsSecret "ingressName" "element-web")) }}
+  http-request redirect  code 301  location http{{ if $elementWebHttps }}s{{ end }}://{{ include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)) }} unless well-known
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/source/common/ingress.json
+++ b/charts/matrix-stack/source/common/ingress.json
@@ -1,6 +1,52 @@
 {
   "type": "object",
   "properties": {
+    "enabled": {
+      "type": "boolean"
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "HTTPRoute",
+        "Ingress"
+      ]
+    },
+    "HTTPRoute": {
+      "type": "object",
+      "properties": {
+        "existingGateways": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": { "type": "string" },
+              "namespace": { "type": "string" },
+              "group": { "type": "string" },
+              "kind": { "type": "string" },
+              "sectionName": { "type": "string" },
+              "port": { "type": "integer" }
+            }
+          }
+        }
+      }
+    },
+    "Ingress": {
+      "type": "object",
+      "properties": {
+        "className": {
+          "type": "string"
+        },
+        "controllerType": {
+          "type": "string",
+          "enum": [
+            "ingress-nginx"
+          ]
+        }
+      }
+    },
     "annotations": {
       "type": "object",
       "additionalProperties": {
@@ -13,20 +59,11 @@
     "host": {
       "type": "string"
     },
-    "className": {
-      "type": "string"
-    },
     "tlsEnabled": {
       "type": "boolean"
     },
     "tlsSecret": {
       "type": "string"
-    },
-    "controllerType": {
-      "type": "string",
-      "enum": [
-        "ingress-nginx"
-      ]
     },
     "service": {
       "$ref": "file://common/service.json"

--- a/charts/matrix-stack/source/common/ingress.json
+++ b/charts/matrix-stack/source/common/ingress.json
@@ -1,52 +1,6 @@
 {
   "type": "object",
   "properties": {
-    "enabled": {
-      "type": "boolean"
-    },
-    "type": {
-      "type": "string",
-      "enum": [
-        "HTTPRoute",
-        "Ingress"
-      ]
-    },
-    "HTTPRoute": {
-      "type": "object",
-      "properties": {
-        "existingGateways": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name"
-            ],
-            "properties": {
-              "name": { "type": "string" },
-              "namespace": { "type": "string" },
-              "group": { "type": "string" },
-              "kind": { "type": "string" },
-              "sectionName": { "type": "string" },
-              "port": { "type": "integer" }
-            }
-          }
-        }
-      }
-    },
-    "Ingress": {
-      "type": "object",
-      "properties": {
-        "className": {
-          "type": "string"
-        },
-        "controllerType": {
-          "type": "string",
-          "enum": [
-            "ingress-nginx"
-          ]
-        }
-      }
-    },
     "annotations": {
       "type": "object",
       "additionalProperties": {
@@ -59,11 +13,20 @@
     "host": {
       "type": "string"
     },
+    "className": {
+      "type": "string"
+    },
     "tlsEnabled": {
       "type": "boolean"
     },
     "tlsSecret": {
       "type": "string"
+    },
+    "controllerType": {
+      "type": "string",
+      "enum": [
+        "ingress-nginx"
+      ]
     },
     "service": {
       "$ref": "file://common/service.json"

--- a/charts/matrix-stack/source/common/ingress_global.json
+++ b/charts/matrix-stack/source/common/ingress_global.json
@@ -54,24 +54,6 @@
         }
       }
     },
-    "gateway": {
-      "type": "object",
-      "properties": {
-        "create": {
-          "type": "boolean",
-          "default": false
-        },
-        "className": {
-          "type": "string"
-        },
-        "annotations": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "annotations": {
       "type": "object",
       "additionalProperties": {

--- a/charts/matrix-stack/source/common/ingress_global.json
+++ b/charts/matrix-stack/source/common/ingress_global.json
@@ -1,26 +1,88 @@
 {
   "type": "object",
+  "required": [
+    "enabled",
+    "type"
+  ],
   "properties": {
+    "enabled": {
+      "type": "boolean",
+      "default": true
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "HTTPRoute",
+        "Ingress"
+      ],
+      "default": "Ingress"
+    },
+    "HTTPRoute": {
+      "type": "object",
+      "properties": {
+        "existingGateways": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": { "type": "string" },
+              "namespace": { "type": "string" },
+              "group": { "type": "string" },
+              "kind": { "type": "string" },
+              "sectionName": { "type": "string" },
+              "port": { "type": "integer" }
+            }
+          },
+          "minItems": 1
+        }
+      }
+    },
+    "Ingress": {
+      "type": "object",
+      "properties": {
+        "className": {
+          "type": "string"
+        },
+        "controllerType": {
+          "type": "string",
+          "enum": [
+            "ingress-nginx"
+          ]
+        }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "default": false
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "annotations": {
       "type": "object",
       "additionalProperties": {
         "type": "string"
       }
     },
-    "className": {
-      "type": "string"
-    },
     "tlsEnabled": {
       "type": "boolean"
     },
     "tlsSecret": {
       "type": "string"
-    },
-    "controllerType": {
-      "type": "string",
-      "enum": [
-        "ingress-nginx"
-      ]
     },
     "service": {
       "type": "object",

--- a/charts/matrix-stack/source/common/ingress_without_host.json
+++ b/charts/matrix-stack/source/common/ingress_without_host.json
@@ -1,52 +1,6 @@
 {
   "type": "object",
   "properties": {
-    "enabled": {
-      "type": "boolean"
-    },
-    "type": {
-      "type": "string",
-      "enum": [
-        "HTTPRoute",
-        "Ingress"
-      ]
-    },
-    "HTTPRoute": {
-      "type": "object",
-      "properties": {
-        "existingGateways": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name"
-            ],
-            "properties": {
-              "name": { "type": "string" },
-              "namespace": { "type": "string" },
-              "group": { "type": "string" },
-              "kind": { "type": "string" },
-              "sectionName": { "type": "string" },
-              "port": { "type": "integer" }
-            }
-          }
-        }
-      }
-    },
-    "Ingress": {
-      "type": "object",
-      "properties": {
-        "className": {
-          "type": "string"
-        },
-        "controllerType": {
-          "type": "string",
-          "enum": [
-            "ingress-nginx"
-          ]
-        }
-      }
-    },
     "annotations": {
       "type": "object",
       "additionalProperties": {
@@ -56,11 +10,20 @@
         ]
       }
     },
+    "className": {
+      "type": "string"
+    },
     "tlsEnabled": {
       "type": "boolean"
     },
     "tlsSecret": {
       "type": "string"
+    },
+    "controllerType": {
+      "type": "string",
+      "enum": [
+        "ingress-nginx"
+      ]
     },
     "service": {
       "$ref": "file://common/service.json"

--- a/charts/matrix-stack/source/common/ingress_without_host.json
+++ b/charts/matrix-stack/source/common/ingress_without_host.json
@@ -1,6 +1,52 @@
 {
   "type": "object",
   "properties": {
+    "enabled": {
+      "type": "boolean"
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "HTTPRoute",
+        "Ingress"
+      ]
+    },
+    "HTTPRoute": {
+      "type": "object",
+      "properties": {
+        "existingGateways": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": { "type": "string" },
+              "namespace": { "type": "string" },
+              "group": { "type": "string" },
+              "kind": { "type": "string" },
+              "sectionName": { "type": "string" },
+              "port": { "type": "integer" }
+            }
+          }
+        }
+      }
+    },
+    "Ingress": {
+      "type": "object",
+      "properties": {
+        "className": {
+          "type": "string"
+        },
+        "controllerType": {
+          "type": "string",
+          "enum": [
+            "ingress-nginx"
+          ]
+        }
+      }
+    },
     "annotations": {
       "type": "object",
       "additionalProperties": {
@@ -10,20 +56,11 @@
         ]
       }
     },
-    "className": {
-      "type": "string"
-    },
     "tlsEnabled": {
       "type": "boolean"
     },
     "tlsSecret": {
       "type": "string"
-    },
-    "controllerType": {
-      "type": "string",
-      "enum": [
-        "ingress-nginx"
-      ]
     },
     "service": {
       "$ref": "file://common/service.json"

--- a/charts/matrix-stack/source/common/routes.json
+++ b/charts/matrix-stack/source/common/routes.json
@@ -1,0 +1,41 @@
+{
+  "type": "object",
+  "properties": {
+    "existingGateways": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": { "type": "string" },
+          "namespace": { "type": "string" },
+          "group": { "type": "string" },
+          "kind": { "type": "string" },
+          "sectionName": { "type": "string" },
+          "port": { "type": "integer" }
+        }
+      },
+      "minItems": 1
+    },
+    "host": {
+      "type": "string"
+    },
+    "annotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "tlsEnabled": {
+      "type": "boolean"
+    },
+    "tlsSecret": {
+      "type": "string"
+    },
+    "service": {
+      "$ref": "file://common/service.json"
+    }
+  }
+}

--- a/charts/matrix-stack/source/common/routes.json
+++ b/charts/matrix-stack/source/common/routes.json
@@ -9,12 +9,24 @@
           "name"
         ],
         "properties": {
-          "name": { "type": "string" },
-          "namespace": { "type": "string" },
-          "group": { "type": "string" },
-          "kind": { "type": "string" },
-          "sectionName": { "type": "string" },
-          "port": { "type": "integer" }
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "group": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "sectionName": {
+            "type": "string"
+          },
+          "port": {
+            "type": "integer"
+          }
         }
       },
       "minItems": 1

--- a/charts/matrix-stack/source/common/routes.json
+++ b/charts/matrix-stack/source/common/routes.json
@@ -34,6 +34,9 @@
     "tlsSecret": {
       "type": "string"
     },
+    "disableHTTPRedirect": {
+      "type": "boolean"
+    },
     "service": {
       "$ref": "file://common/service.json"
     }

--- a/charts/matrix-stack/source/common/routes_global.json
+++ b/charts/matrix-stack/source/common/routes_global.json
@@ -1,26 +1,35 @@
 {
   "type": "object",
   "properties": {
+    "existingGateways": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": { "type": "string" },
+          "namespace": { "type": "string" },
+          "group": { "type": "string" },
+          "kind": { "type": "string" },
+          "sectionName": { "type": "string" },
+          "port": { "type": "integer" }
+        }
+      },
+      "minItems": 1
+    },
     "annotations": {
       "type": "object",
       "additionalProperties": {
         "type": "string"
       }
     },
-    "className": {
-      "type": "string"
-    },
     "tlsEnabled": {
       "type": "boolean"
     },
     "tlsSecret": {
       "type": "string"
-    },
-    "controllerType": {
-      "type": "string",
-      "enum": [
-        "ingress-nginx"
-      ]
     },
     "service": {
       "type": "object",

--- a/charts/matrix-stack/source/common/routes_global.json
+++ b/charts/matrix-stack/source/common/routes_global.json
@@ -31,6 +31,9 @@
     "tlsSecret": {
       "type": "string"
     },
+    "disableHTTPRedirect": {
+      "type": "boolean"
+    },
     "service": {
       "type": "object",
       "required": [

--- a/charts/matrix-stack/source/common/routes_global.json
+++ b/charts/matrix-stack/source/common/routes_global.json
@@ -9,12 +9,24 @@
           "name"
         ],
         "properties": {
-          "name": { "type": "string" },
-          "namespace": { "type": "string" },
-          "group": { "type": "string" },
-          "kind": { "type": "string" },
-          "sectionName": { "type": "string" },
-          "port": { "type": "integer" }
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "group": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "sectionName": {
+            "type": "string"
+          },
+          "port": {
+            "type": "integer"
+          }
         }
       },
       "minItems": 1

--- a/charts/matrix-stack/source/common/routes_without_host.json
+++ b/charts/matrix-stack/source/common/routes_without_host.json
@@ -1,0 +1,38 @@
+{
+  "type": "object",
+  "properties": {
+    "existingGateways": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": { "type": "string" },
+          "namespace": { "type": "string" },
+          "group": { "type": "string" },
+          "kind": { "type": "string" },
+          "sectionName": { "type": "string" },
+          "port": { "type": "integer" }
+        }
+      },
+      "minItems": 1
+    },
+    "annotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "tlsEnabled": {
+      "type": "boolean"
+    },
+    "tlsSecret": {
+      "type": "string"
+    },
+    "service": {
+      "$ref": "file://common/service.json"
+    }
+  }
+}

--- a/charts/matrix-stack/source/common/routes_without_host.json
+++ b/charts/matrix-stack/source/common/routes_without_host.json
@@ -31,6 +31,9 @@
     "tlsSecret": {
       "type": "string"
     },
+    "disableHTTPRedirect": {
+      "type": "boolean"
+    },
     "service": {
       "$ref": "file://common/service.json"
     }

--- a/charts/matrix-stack/source/common/routes_without_host.json
+++ b/charts/matrix-stack/source/common/routes_without_host.json
@@ -9,12 +9,24 @@
           "name"
         ],
         "properties": {
-          "name": { "type": "string" },
-          "namespace": { "type": "string" },
-          "group": { "type": "string" },
-          "kind": { "type": "string" },
-          "sectionName": { "type": "string" },
-          "port": { "type": "integer" }
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "group": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "sectionName": {
+            "type": "string"
+          },
+          "port": {
+            "type": "integer"
+          }
         }
       },
       "minItems": 1

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -170,7 +170,7 @@ networking:
   ## Should we generate {{ 'any' if global else 'this' }} Ingress {{ 'resources' if global else 'resource' }}
   enabled: true
   ## What type of ingress resource should be used (Ingress, HTTPRoute)
-  type: Ingress
+  {{ '# ' if not global }}type: Ingress
 
   ## Annotations to be added to {{ 'all Ingresses. Will be merged with component specific Ingress annotations' if global else 'this Ingress' }}
   annotations: {}

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -167,11 +167,13 @@ networking:
   ## What hostname should be used for this Ingress
   # host:
 {% endif %}
+  ## Should we generate {{ 'any' if global else 'this' }} Ingress {{ 'resources' if global else 'resource' }}
+  enabled: true
+  ## What type of ingress resource should be used (Ingress, HTTPRoute)
+  type: Ingress
+
   ## Annotations to be added to {{ 'all Ingresses. Will be merged with component specific Ingress annotations' if global else 'this Ingress' }}
   annotations: {}
-
-  ## What Ingress Class Name that should be used for {{ 'all Ingresses by default' if global else 'this Ingress' }}
-  # className:
 
   ## Disable TLS configuration by setting it to false
   tlsEnabled: true
@@ -199,9 +201,35 @@ networking:
   #   externalIPs: []
   service: {}
 {%- endif %}
-  ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-  ## This can be set to `ingress-nginx`.
-  # controllerType:
+
+  ## Ingress specific configuration
+  Ingress: {}
+    ## What Ingress Class Name that should be used for {{ 'all Ingresses by default' if global else 'this Ingress' }}
+    # className:
+
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
+
+  ## HTTPRoute specific configuration
+  HTTPRoute: {}
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
+  
+  {%- if global %}
+
+  ## Configuration for the generated Gateway
+  gateway:
+    ## Should we generate a Gateway resource for the HTTPRoutes
+    create: false
+
+    ## Gateway controller class name to use
+    # className: ""
+
+    ## Additional annotations for the Gateway
+    annotations: {}
+  {%- endif %}
 {%- endmacro %}
 
 {% macro labels(global=false, key='labels') %}

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -28,6 +28,7 @@ certManager: {}
 # serverName: ess.localhost
 {{ labels(global=true) }}
 {{ ingress(global=true) }}
+{{ routes(global=true, withHost=false) }}
 
 ## Common image properties that are applied as defaults to all components.
 image:
@@ -182,11 +183,6 @@ inboundTrafficHandler: ingress
   ## What hostname should be used for this Ingress
   # host:
 {% endif %}
-  ## Should we generate {{ 'any' if global else 'this' }} Ingress {{ 'resources' if global else 'resource' }}
-  enabled: true
-  ## What type of ingress resource should be used (Ingress, HTTPRoute)
-  {{ '# ' if not global }}type: Ingress
-
   ## Annotations to be added to {{ 'all Ingresses. Will be merged with component specific Ingress annotations' if global else 'this Ingress' }}
   annotations: {}
 
@@ -217,21 +213,61 @@ inboundTrafficHandler: ingress
   service: {}
 {%- endif %}
 
-  ## Ingress specific configuration
-  Ingress: {}
-    ## What Ingress Class Name that should be used for {{ 'all Ingresses by default' if global else 'this Ingress' }}
-    # className:
+  ## What Ingress Class Name that should be used for {{ 'all Ingresses by default' if global else 'this Ingress' }}
+  # className:
 
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+  ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+  ## This can be set to `ingress-nginx`.
+  # controllerType:
 
-  ## HTTPRoute specific configuration
-  HTTPRoute: {}
-    ## List of existing Gateway parent refs to connect the routes to.
-    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-    # existingGateways: {}
   
+{%- endmacro %}
+
+{% macro routes(global=false, withHost=true, key='routes') %}
+{%- if  global %}
+## How all routes should be constructed by default, unless overridden
+{%- else %}
+## How this component's routes should be constructed
+{%- endif %}
+{{ key }}:
+{%- if withHost %}
+  ## What hostname should be used for this component
+  # host:
+{% endif %}
+  ## Annotations to be added to {{ 'all routes. Will be merged with component specific route annotations' if global else 'this route' }}
+  annotations: {}
+
+  ## Disable TLS configuration by setting it to false
+  tlsEnabled: true
+
+  ## The name of the Secret containing the TLS certificate and the key that should be used for {{ 'all routes by default' if global else 'this route' }}
+  # tlsSecret:
+
+  ## How the {{ 'Services' if global else 'Service' }} behind {{ 'all routes' if global else 'this route' }} is constructed{{ ' by default' if global else '' }}
+{%- if global %}
+  service:
+    type: ClusterIP
+    ## Annotations to be added to {{ 'all routes services. Will be merged with component specific route services annotations' if global else 'this route' }}
+    annotations: {}
+    # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    externalTrafficPolicy: Cluster
+    internalTrafficPolicy: Cluster
+{%- else %}
+  # service:
+  #   type: ClusterIP
+  #   annotations: {}
+  #   # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+  #   externalTrafficPolicy: Cluster
+  #   internalTrafficPolicy: Cluster
+  #   # External IPs addresses of this service.
+  #   externalIPs: []
+  service: {}
+{%- endif %}
+
+  ## List of existing Gateway parent refs to connect the routes to.
+  ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+  # existingGateways: {}
+
 {%- endmacro %}
 
 {% macro labels(global=false, key='labels') %}

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -54,6 +54,21 @@ clusterDomain: "cluster.local."
 networking:
   ## Whether components should attempt to bind IPv4 (ipv4) /IPv6 (ipv6) / both (dual-stack)
   ipFamily: dual-stack
+
+## Gateway configuration options
+gateway:
+  ## Create a default gateway for all routes
+  create: false
+  
+  ## Set the gateway class to use. If not set it will use the cluster default
+  # className: ""
+
+  ## Additional annotations to add to the gateway resource
+  annotations: {}
+
+## Set the default inbound traffic handler type. Options are ingress | routes | none
+inboundTrafficHandler: ingress
+
 {%- endmacro %}
 
 {% macro containersSecurityContext(key='containersSecurityContext') %}
@@ -217,19 +232,6 @@ networking:
     ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
     # existingGateways: {}
   
-  {%- if global %}
-
-  ## Configuration for the generated Gateway
-  gateway:
-    ## Should we generate a Gateway resource for the HTTPRoutes
-    create: false
-
-    ## Gateway controller class name to use
-    # className: ""
-
-    ## Additional annotations for the Gateway
-    annotations: {}
-  {%- endif %}
 {%- endmacro %}
 
 {% macro labels(global=false, key='labels') %}

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -256,6 +256,9 @@ inboundTrafficHandler: ingress
   ## The name of the Secret containing the TLS certificate and the key that should be used for {{ 'all routes by default' if global else 'this route' }}
   # tlsSecret:
 
+  ## Disable automatic HTTP redirect route generation by setting true
+  disableHTTPRedirect: false
+
   ## How the {{ 'Services' if global else 'Service' }} behind {{ 'all routes' if global else 'this route' }} is constructed{{ ' by default' if global else '' }}
 {%- if global %}
   service:

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -66,7 +66,7 @@ gateway:
   ## Create a default gateway for all routes
   create: false
   
-  ## Set the gateway class to use. If not set it will use the cluster default
+  ## Set the gateway class to use, required when create=true.
   # className: ""
 
   ## Additional annotations to add to the gateway resource

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -28,6 +28,7 @@ certManager: {}
 # serverName: ess.localhost
 {{ labels(global=true) }}
 {{ ingress(global=true) }}
+{{ routes(global=true, withHost=false) }}
 
 ## Common image properties that are applied as defaults to all components.
 image:
@@ -192,11 +193,6 @@ inboundTrafficHandler: ingress
   ## What hostname should be used for this Ingress
   # host:
 {% endif %}
-  ## Should we generate {{ 'any' if global else 'this' }} Ingress {{ 'resources' if global else 'resource' }}
-  enabled: true
-  ## What type of ingress resource should be used (Ingress, HTTPRoute)
-  {{ '# ' if not global }}type: Ingress
-
   ## Annotations to be added to {{ 'all Ingresses. Will be merged with component specific Ingress annotations' if global else 'this Ingress' }}
   annotations: {}
 
@@ -227,21 +223,61 @@ inboundTrafficHandler: ingress
   service: {}
 {%- endif %}
 
-  ## Ingress specific configuration
-  Ingress: {}
-    ## What Ingress Class Name that should be used for {{ 'all Ingresses by default' if global else 'this Ingress' }}
-    # className:
+  ## What Ingress Class Name that should be used for {{ 'all Ingresses by default' if global else 'this Ingress' }}
+  # className:
 
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+  ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+  ## This can be set to `ingress-nginx`.
+  # controllerType:
 
-  ## HTTPRoute specific configuration
-  HTTPRoute: {}
-    ## List of existing Gateway parent refs to connect the routes to.
-    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-    # existingGateways: {}
   
+{%- endmacro %}
+
+{% macro routes(global=false, withHost=true, key='routes') %}
+{%- if  global %}
+## How all routes should be constructed by default, unless overridden
+{%- else %}
+## How this component's routes should be constructed
+{%- endif %}
+{{ key }}:
+{%- if withHost %}
+  ## What hostname should be used for this component
+  # host:
+{% endif %}
+  ## Annotations to be added to {{ 'all routes. Will be merged with component specific route annotations' if global else 'this route' }}
+  annotations: {}
+
+  ## Disable TLS configuration by setting it to false
+  tlsEnabled: true
+
+  ## The name of the Secret containing the TLS certificate and the key that should be used for {{ 'all routes by default' if global else 'this route' }}
+  # tlsSecret:
+
+  ## How the {{ 'Services' if global else 'Service' }} behind {{ 'all routes' if global else 'this route' }} is constructed{{ ' by default' if global else '' }}
+{%- if global %}
+  service:
+    type: ClusterIP
+    ## Annotations to be added to {{ 'all routes services. Will be merged with component specific route services annotations' if global else 'this route' }}
+    annotations: {}
+    # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    externalTrafficPolicy: Cluster
+    internalTrafficPolicy: Cluster
+{%- else %}
+  # service:
+  #   type: ClusterIP
+  #   annotations: {}
+  #   # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+  #   externalTrafficPolicy: Cluster
+  #   internalTrafficPolicy: Cluster
+  #   # External IPs addresses of this service.
+  #   externalIPs: []
+  service: {}
+{%- endif %}
+
+  ## List of existing Gateway parent refs to connect the routes to.
+  ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+  # existingGateways: {}
+
 {%- endmacro %}
 
 {% macro labels(global=false, key='labels') %}

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -177,11 +177,13 @@ networking:
   ## What hostname should be used for this Ingress
   # host:
 {% endif %}
+  ## Should we generate {{ 'any' if global else 'this' }} Ingress {{ 'resources' if global else 'resource' }}
+  enabled: true
+  ## What type of ingress resource should be used (Ingress, HTTPRoute)
+  type: Ingress
+
   ## Annotations to be added to {{ 'all Ingresses. Will be merged with component specific Ingress annotations' if global else 'this Ingress' }}
   annotations: {}
-
-  ## What Ingress Class Name that should be used for {{ 'all Ingresses by default' if global else 'this Ingress' }}
-  # className:
 
   ## Disable TLS configuration by setting it to false
   tlsEnabled: true
@@ -209,9 +211,35 @@ networking:
   #   externalIPs: []
   service: {}
 {%- endif %}
-  ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-  ## This can be set to `ingress-nginx`.
-  # controllerType:
+
+  ## Ingress specific configuration
+  Ingress: {}
+    ## What Ingress Class Name that should be used for {{ 'all Ingresses by default' if global else 'this Ingress' }}
+    # className:
+
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
+
+  ## HTTPRoute specific configuration
+  HTTPRoute: {}
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
+  
+  {%- if global %}
+
+  ## Configuration for the generated Gateway
+  gateway:
+    ## Should we generate a Gateway resource for the HTTPRoutes
+    create: false
+
+    ## Gateway controller class name to use
+    # className: ""
+
+    ## Additional annotations for the Gateway
+    annotations: {}
+  {%- endif %}
 {%- endmacro %}
 
 {% macro labels(global=false, key='labels') %}

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -72,6 +72,9 @@ gateway:
   ## Additional annotations to add to the gateway resource
   annotations: {}
 
+  ## Override which services the generated gateway creates listeners for
+  # listenFor: []
+
 ## Set the default inbound traffic handler type. Options are ingress | routes | none
 inboundTrafficHandler: ingress
 

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -59,6 +59,21 @@ clusterDomain: "cluster.local."
 networking:
   ## Whether components should attempt to bind IPv4 (ipv4) /IPv6 (ipv6) / both (dual-stack)
   ipFamily: dual-stack
+
+## Gateway configuration options
+gateway:
+  ## Create a default gateway for all routes
+  create: false
+  
+  ## Set the gateway class to use. If not set it will use the cluster default
+  # className: ""
+
+  ## Additional annotations to add to the gateway resource
+  annotations: {}
+
+## Set the default inbound traffic handler type. Options are ingress | routes | none
+inboundTrafficHandler: ingress
+
 {%- endmacro %}
 
 {% macro containersSecurityContext(key='containersSecurityContext') %}
@@ -227,19 +242,6 @@ networking:
     ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
     # existingGateways: {}
   
-  {%- if global %}
-
-  ## Configuration for the generated Gateway
-  gateway:
-    ## Should we generate a Gateway resource for the HTTPRoutes
-    create: false
-
-    ## Gateway controller class name to use
-    # className: ""
-
-    ## Additional annotations for the Gateway
-    annotations: {}
-  {%- endif %}
 {%- endmacro %}
 
 {% macro labels(global=false, key='labels') %}

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -65,7 +65,7 @@ networking:
 gateway:
   ## Create a default gateway for all routes
   create: false
-  
+
   ## Set the gateway class to use, required when create=true.
   # className: ""
 

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -180,7 +180,7 @@ networking:
   ## Should we generate {{ 'any' if global else 'this' }} Ingress {{ 'resources' if global else 'resource' }}
   enabled: true
   ## What type of ingress resource should be used (Ingress, HTTPRoute)
-  type: Ingress
+  {{ '# ' if not global }}type: Ingress
 
   ## Annotations to be added to {{ 'all Ingresses. Will be merged with component specific Ingress annotations' if global else 'this Ingress' }}
   annotations: {}

--- a/charts/matrix-stack/source/element-admin.json
+++ b/charts/matrix-stack/source/element-admin.json
@@ -10,11 +10,22 @@
       "minimum": 1,
       "type": "integer"
     },
+    "inboundTrafficHandler": {
+      "type": "string",
+      "enum": [
+        "ingress",
+        "routes",
+        "none"
+      ]
+    },
     "image": {
       "$ref": "file://common/image.json"
     },
     "ingress": {
       "$ref": "file://common/ingress.json"
+    },
+    "routes": {
+      "$ref": "file://common/routes.json"
     },
     "labels": {
       "$ref": "file://common/labels.json"

--- a/charts/matrix-stack/source/element-admin.json
+++ b/charts/matrix-stack/source/element-admin.json
@@ -10,11 +10,22 @@
       "minimum": 0,
       "type": "integer"
     },
+    "inboundTrafficHandler": {
+      "type": "string",
+      "enum": [
+        "ingress",
+        "routes",
+        "none"
+      ]
+    },
     "image": {
       "$ref": "file://common/image.json"
     },
     "ingress": {
       "$ref": "file://common/ingress.json"
+    },
+    "routes": {
+      "$ref": "file://common/routes.json"
     },
     "labels": {
       "$ref": "file://common/labels.json"

--- a/charts/matrix-stack/source/element-admin.yaml.j2
+++ b/charts/matrix-stack/source/element-admin.yaml.j2
@@ -14,6 +14,7 @@ enabled: true
 replicas: 1
 {{- sub_schema_values.image(registry='oci.element.io', repository='element-admin', tag='0.1.10') -}}
 {{- sub_schema_values.ingress() -}}
+{{- sub_schema_values.routes() -}}
 {{- sub_schema_values.labels() -}}
 {{- sub_schema_values.workloadAnnotations() -}}
 {{- sub_schema_values.extraEnv() -}}

--- a/charts/matrix-stack/source/element-admin.yaml.j2
+++ b/charts/matrix-stack/source/element-admin.yaml.j2
@@ -14,6 +14,7 @@ enabled: true
 replicas: 1
 {{- sub_schema_values.image(registry='oci.element.io', repository='element-admin', tag='0.1.12') -}}
 {{- sub_schema_values.ingress() -}}
+{{- sub_schema_values.routes() -}}
 {{- sub_schema_values.labels() -}}
 {{- sub_schema_values.workloadAnnotations() -}}
 {{- sub_schema_values.extraEnv() -}}

--- a/charts/matrix-stack/source/element-web.json
+++ b/charts/matrix-stack/source/element-web.json
@@ -16,6 +16,14 @@
       "minimum": 1,
       "type": "integer"
     },
+    "inboundTrafficHandler": {
+      "type": "string",
+      "enum": [
+        "ingress",
+        "routes",
+        "none"
+      ]
+    },
     "extraVolumes": {
       "$ref": "file://common/extraVolumes.json"
     },
@@ -30,6 +38,9 @@
     },
     "ingress": {
       "$ref": "file://common/ingress.json"
+    },
+    "routes": {
+      "$ref": "file://common/routes.json"
     },
     "labels": {
       "$ref": "file://common/labels.json"

--- a/charts/matrix-stack/source/element-web.json
+++ b/charts/matrix-stack/source/element-web.json
@@ -16,6 +16,14 @@
       "minimum": 0,
       "type": "integer"
     },
+    "inboundTrafficHandler": {
+      "type": "string",
+      "enum": [
+        "ingress",
+        "routes",
+        "none"
+      ]
+    },
     "extraVolumes": {
       "$ref": "file://common/extraVolumes.json"
     },
@@ -30,6 +38,9 @@
     },
     "ingress": {
       "$ref": "file://common/ingress.json"
+    },
+    "routes": {
+      "$ref": "file://common/routes.json"
     },
     "labels": {
       "$ref": "file://common/labels.json"

--- a/charts/matrix-stack/source/element-web.yaml.j2
+++ b/charts/matrix-stack/source/element-web.yaml.j2
@@ -22,6 +22,7 @@ additional: {}
 replicas: 1
 {{- sub_schema_values.image(registry='oci.element.io', repository='element-web', tag='v1.12.12') -}}
 {{- sub_schema_values.ingress() -}}
+{{- sub_schema_values.routes() -}}
 {{- sub_schema_values.labels() -}}
 {{- sub_schema_values.workloadAnnotations() -}}
 {{- sub_schema_values.extraEnv() -}}

--- a/charts/matrix-stack/source/element-web.yaml.j2
+++ b/charts/matrix-stack/source/element-web.yaml.j2
@@ -22,6 +22,7 @@ additional: {}
 replicas: 1
 {{- sub_schema_values.image(registry='oci.element.io', repository='element-web', tag='v1.12.26') -}}
 {{- sub_schema_values.ingress() -}}
+{{- sub_schema_values.routes() -}}
 {{- sub_schema_values.labels() -}}
 {{- sub_schema_values.workloadAnnotations() -}}
 {{- sub_schema_values.extraEnv() -}}

--- a/charts/matrix-stack/source/hookshot.json
+++ b/charts/matrix-stack/source/hookshot.json
@@ -45,11 +45,22 @@
         }
       }
     },
+    "inboundTrafficHandler": {
+      "type": "string",
+      "enum": [
+        "ingress",
+        "routes",
+        "none"
+      ]
+    },
     "additional": {
       "$ref": "file://common/additional.json"
     },
     "ingress": {
       "$ref": "file://common/ingress.json"
+    },
+    "routes": {
+      "$ref": "file://common/routes.json"
     },
     "image": {
       "$ref": "file://common/image.json"

--- a/charts/matrix-stack/source/hookshot.json
+++ b/charts/matrix-stack/source/hookshot.json
@@ -50,11 +50,22 @@
         }
       }
     },
+    "inboundTrafficHandler": {
+      "type": "string",
+      "enum": [
+        "ingress",
+        "routes",
+        "none"
+      ]
+    },
     "additional": {
       "$ref": "file://common/additional.json"
     },
     "ingress": {
       "$ref": "file://common/ingress.json"
+    },
+    "routes": {
+      "$ref": "file://common/routes.json"
     },
     "image": {
       "$ref": "file://common/image.json"

--- a/charts/matrix-stack/source/hookshot.yaml.j2
+++ b/charts/matrix-stack/source/hookshot.yaml.j2
@@ -24,6 +24,7 @@ logging:
 {{ sub_schema_values.credential("Hookshot passkey used to encrypt stored tokens.", "passkey", initIfAbsent=True) }}
 {{ sub_schema_values.redis() }}
 {{ sub_schema_values.ingress() }}
+{{ sub_schema_values.routes() }}
 
 ## Additional configuration to provide to Hookshot.
 ## You can, if you whish, override it in the additional config.

--- a/charts/matrix-stack/source/hookshot.yaml.j2
+++ b/charts/matrix-stack/source/hookshot.yaml.j2
@@ -27,6 +27,7 @@ replicas: 1
 {{ sub_schema_values.credential("Hookshot passkey used to encrypt stored tokens", "passkey", initIfAbsent=True) }}
 {{ sub_schema_values.redis() }}
 {{ sub_schema_values.ingress() }}
+{{ sub_schema_values.routes() }}
 
 ## Additional configuration to provide to Hookshot.
 ## You can, if you whish, override it in the additional config.

--- a/charts/matrix-stack/source/matrix-rtc.json
+++ b/charts/matrix-stack/source/matrix-rtc.json
@@ -47,6 +47,14 @@
         }
       }
     },
+    "inboundTrafficHandler": {
+      "type": "string",
+      "enum": [
+        "ingress",
+        "routes",
+        "none"
+      ]
+    },
     "replicas": {
       "type": "integer"
     },
@@ -67,6 +75,9 @@
     },
     "ingress": {
       "$ref": "file://common/ingress.json"
+    },
+    "routes": {
+      "$ref": "file://common/routes.json"
     },
     "labels": {
       "$ref": "file://common/labels.json"

--- a/charts/matrix-stack/source/matrix-rtc.json
+++ b/charts/matrix-stack/source/matrix-rtc.json
@@ -23,6 +23,14 @@
         }
       }
     },
+    "inboundTrafficHandler": {
+      "type": "string",
+      "enum": [
+        "ingress",
+        "routes",
+        "none"
+      ]
+    },
     "replicas": {
       "minimum": 0,
       "type": "integer"
@@ -44,6 +52,9 @@
     },
     "ingress": {
       "$ref": "file://common/ingress.json"
+    },
+    "routes": {
+      "$ref": "file://common/routes.json"
     },
     "labels": {
       "$ref": "file://common/labels.json"

--- a/charts/matrix-stack/source/matrix-rtc.yaml.j2
+++ b/charts/matrix-stack/source/matrix-rtc.yaml.j2
@@ -24,6 +24,7 @@ restrictRoomCreationToLocalUsers: true
 
 replicas: 1
 {{- sub_schema_values.ingress() }}
+{{- sub_schema_values.routes() }}
 {{- sub_schema_values.image(registry='ghcr.io', repository='element-hq/lk-jwt-service', tag='0.4.1') }}
 {{- sub_schema_values.labels() }}
 {{- sub_schema_values.workloadAnnotations() }}

--- a/charts/matrix-stack/source/matrix-rtc.yaml.j2
+++ b/charts/matrix-stack/source/matrix-rtc.yaml.j2
@@ -21,6 +21,7 @@ livekitAuth:
 
 replicas: 1
 {{- sub_schema_values.ingress() }}
+{{- sub_schema_values.routes() }}
 {{- sub_schema_values.image(registry='oci.element.io', repository='lk-jwt-service', tag='0.6.0') }}
 {{- sub_schema_values.labels() }}
 {{- sub_schema_values.workloadAnnotations() }}

--- a/charts/matrix-stack/source/matrixAuthenticationService.json
+++ b/charts/matrix-stack/source/matrixAuthenticationService.json
@@ -96,8 +96,19 @@
         }
       }
     },
+    "inboundTrafficHandler": {
+      "type": "string",
+      "enum": [
+        "ingress",
+        "routes",
+        "none"
+      ]
+    },
     "ingress": {
       "$ref": "file://common/ingress.json"
+    },
+    "routes": {
+      "$ref": "file://common/routes.json"
     },
     "image": {
       "$ref": "file://common/image.json"

--- a/charts/matrix-stack/source/matrixAuthenticationService.json
+++ b/charts/matrix-stack/source/matrixAuthenticationService.json
@@ -109,8 +109,19 @@
         }
       }
     },
+    "inboundTrafficHandler": {
+      "type": "string",
+      "enum": [
+        "ingress",
+        "routes",
+        "none"
+      ]
+    },
     "ingress": {
       "$ref": "file://common/ingress.json"
+    },
+    "routes": {
+      "$ref": "file://common/routes.json"
     },
     "image": {
       "$ref": "file://common/image.json"

--- a/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
+++ b/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
@@ -27,6 +27,7 @@ privateKeys:
 {{ sub_schema_values.credential("ECDSA Secp384r1 Private Key", "ecdsaSecp384r1") | indent(2) }}
 
 {{ sub_schema_values.ingress() }}
+{{ sub_schema_values.routes() }}
 {{ sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='350Mi') }}
 {{ sub_schema_values.labels() }}
 {{ sub_schema_values.serviceAccount() }}

--- a/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
+++ b/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
@@ -27,6 +27,7 @@ privateKeys: {}
 {{ sub_schema_values.credential("ECDSA Secp384r1 Private Key", "ecdsaSecp384r1") | indent(2) }}
 
 {{ sub_schema_values.ingress() }}
+{{ sub_schema_values.routes() }}
 {{ sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='350Mi') }}
 {{ sub_schema_values.labels() }}
 {{ sub_schema_values.serviceAccount() }}

--- a/charts/matrix-stack/source/synapse.json
+++ b/charts/matrix-stack/source/synapse.json
@@ -133,8 +133,19 @@
         "type": "string"
       }
     },
+    "inboundTrafficHandler": {
+      "type": "string",
+      "enum": [
+        "ingress",
+        "routes",
+        "none"
+      ]
+    },
     "ingress": {
       "$ref": "file://synapse/ingress_with_additional_paths.json"
+    },
+    "routes": {
+      "$ref": "file://synapse/routes_with_additional_paths.json"
     },
     "image": {
       "$ref": "file://common/image.json"

--- a/charts/matrix-stack/source/synapse.json
+++ b/charts/matrix-stack/source/synapse.json
@@ -141,8 +141,19 @@
       "maximum": 1,
       "type": "integer"
     },
+    "inboundTrafficHandler": {
+      "type": "string",
+      "enum": [
+        "ingress",
+        "routes",
+        "none"
+      ]
+    },
     "ingress": {
       "$ref": "file://synapse/ingress_with_additional_paths.json"
+    },
+    "routes": {
+      "$ref": "file://synapse/routes_with_additional_paths.json"
     },
     "image": {
       "$ref": "file://common/image.json"

--- a/charts/matrix-stack/source/synapse.yaml.j2
+++ b/charts/matrix-stack/source/synapse.yaml.j2
@@ -91,6 +91,7 @@ logging:
 {{- sub_schema_values.extraVolumeMounts("Synapse", with_context=true) }}
 {{- sub_schema_values.extraInitContainers("Synapse") }}
 {{- sub_schema_values.ingress() }}
+{{- sub_schema_values.routes() }}
 {{- sub_schema_values.labels() }}
 {{- sub_schema_values.workloadAnnotations() }}
 {{- sub_schema_values.containersSecurityContext() }}

--- a/charts/matrix-stack/source/synapse.yaml.j2
+++ b/charts/matrix-stack/source/synapse.yaml.j2
@@ -95,6 +95,7 @@ replicas: 1
 {{- sub_schema_values.extraVolumeMounts("Synapse", with_context=true) }}
 {{- sub_schema_values.extraInitContainers("Synapse") }}
 {{- sub_schema_values.ingress() }}
+{{- sub_schema_values.routes() }}
 {{- sub_schema_values.labels() }}
 {{- sub_schema_values.workloadAnnotations() }}
 {{- sub_schema_values.containersSecurityContext() }}

--- a/charts/matrix-stack/source/synapse/ingress_with_additional_paths.json
+++ b/charts/matrix-stack/source/synapse/ingress_with_additional_paths.json
@@ -1,6 +1,52 @@
 {
   "type": "object",
   "properties": {
+    "enabled": {
+      "type": "boolean"
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "HTTPRoute",
+        "Ingress"
+      ]
+    },
+    "HTTPRoute": {
+      "type": "object",
+      "properties": {
+        "existingGateways": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": { "type": "string" },
+              "namespace": { "type": "string" },
+              "group": { "type": "string" },
+              "kind": { "type": "string" },
+              "sectionName": { "type": "string" },
+              "port": { "type": "integer" }
+            }
+          }
+        }
+      }
+    },
+    "Ingress": {
+      "type": "object",
+      "properties": {
+        "className": {
+          "type": "string"
+        },
+        "controllerType": {
+          "type": "string",
+          "enum": [
+            "ingress-nginx"
+          ]
+        }
+      }
+    },
     "annotations": {
       "type": "object",
       "additionalProperties": {
@@ -13,20 +59,11 @@
     "host": {
       "type": "string"
     },
-    "className": {
-      "type": "string"
-    },
     "tlsEnabled": {
       "type": "boolean"
     },
     "tlsSecret": {
       "type": "string"
-    },
-    "controllerType": {
-      "type": "string",
-      "enum": [
-        "ingress-nginx"
-      ]
     },
     "service": {
       "$ref": "file://common/service.json"

--- a/charts/matrix-stack/source/synapse/routes_with_additional_paths.json
+++ b/charts/matrix-stack/source/synapse/routes_with_additional_paths.json
@@ -1,6 +1,23 @@
 {
   "type": "object",
   "properties": {
+    "existingGateways": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": { "type": "string" },
+          "namespace": { "type": "string" },
+          "group": { "type": "string" },
+          "kind": { "type": "string" },
+          "sectionName": { "type": "string" },
+          "port": { "type": "integer" }
+        }
+      }
+    },
     "annotations": {
       "type": "object",
       "additionalProperties": {
@@ -13,20 +30,11 @@
     "host": {
       "type": "string"
     },
-    "className": {
-      "type": "string"
-    },
     "tlsEnabled": {
       "type": "boolean"
     },
     "tlsSecret": {
       "type": "string"
-    },
-    "controllerType": {
-      "type": "string",
-      "enum": [
-        "ingress-nginx"
-      ]
     },
     "service": {
       "$ref": "file://common/service.json"

--- a/charts/matrix-stack/source/synapse/routes_with_additional_paths.json
+++ b/charts/matrix-stack/source/synapse/routes_with_additional_paths.json
@@ -9,12 +9,24 @@
           "name"
         ],
         "properties": {
-          "name": { "type": "string" },
-          "namespace": { "type": "string" },
-          "group": { "type": "string" },
-          "kind": { "type": "string" },
-          "sectionName": { "type": "string" },
-          "port": { "type": "integer" }
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "group": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "sectionName": {
+            "type": "string"
+          },
+          "port": {
+            "type": "integer"
+          }
         }
       }
     },

--- a/charts/matrix-stack/source/synapse/routes_with_additional_paths.json
+++ b/charts/matrix-stack/source/synapse/routes_with_additional_paths.json
@@ -39,6 +39,9 @@
     "service": {
       "$ref": "file://common/service.json"
     },
+    "disableHTTPRedirect": {
+      "type": "boolean"
+    },
     "additionalPaths": {
       "type": "array",
       "items": {

--- a/charts/matrix-stack/source/values.schema.json
+++ b/charts/matrix-stack/source/values.schema.json
@@ -101,6 +101,31 @@
         }
       }
     },
+    "gateway": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "inboundTrafficHandler": {
+      "type": "string",
+      "enum": [
+        "ingress",
+        "routes",
+        "none"
+      ]
+    },
     "deploymentMarkers": {
       "$ref": "file://deployment-markers.json"
     },

--- a/charts/matrix-stack/source/values.schema.json
+++ b/charts/matrix-stack/source/values.schema.json
@@ -79,6 +79,9 @@
     "ingress": {
       "$ref": "file://common/ingress_global.json"
     },
+    "routes": {
+      "$ref": "file://common/routes_global.json"
+    },
     "tolerations": {
       "$ref": "file://common/tolerations.json"
     },

--- a/charts/matrix-stack/source/values.schema.json
+++ b/charts/matrix-stack/source/values.schema.json
@@ -133,6 +133,12 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "listenFor": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/charts/matrix-stack/source/values.schema.json
+++ b/charts/matrix-stack/source/values.schema.json
@@ -116,6 +116,31 @@
         }
       }
     },
+    "gateway": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "inboundTrafficHandler": {
+      "type": "string",
+      "enum": [
+        "ingress",
+        "routes",
+        "none"
+      ]
+    },
     "deploymentMarkers": {
       "$ref": "file://deployment-markers.json"
     },

--- a/charts/matrix-stack/source/values.schema.json
+++ b/charts/matrix-stack/source/values.schema.json
@@ -82,6 +82,9 @@
     "storage": {
       "$ref": "file://common/storage_global.json"
     },
+    "routes": {
+      "$ref": "file://common/routes_global.json"
+    },
     "tolerations": {
       "$ref": "file://common/tolerations.json"
     },

--- a/charts/matrix-stack/source/wellKnownDelegation.json
+++ b/charts/matrix-stack/source/wellKnownDelegation.json
@@ -6,8 +6,19 @@
     "enabled": {
       "type": "boolean"
     },
+    "inboundTrafficHandler": {
+      "type": "string",
+      "enum": [
+        "ingress",
+        "routes",
+        "none"
+      ]
+    },
     "ingress": {
       "$ref": "file://common/ingress_without_host.json"
+    },
+    "routes": {
+      "$ref": "file://common/routes_without_host.json"
     },
     "labels": {
       "$ref": "file://common/labels.json"

--- a/charts/matrix-stack/source/wellKnownDelegation.yaml.j2
+++ b/charts/matrix-stack/source/wellKnownDelegation.yaml.j2
@@ -10,6 +10,7 @@ enabled: true
 
 {{ sub_schema_values.labels() }}
 {{ sub_schema_values.ingress() }}
+{{ sub_schema_values.routes(withHost=false) }}
 
 ## If ElementWeb is deployed, the base domain will redirect to it's ingress host by default
 ## If ElementWeb is not deployed or this is disabled, no base domain URL redirect will be set.

--- a/charts/matrix-stack/templates/NOTES.txt
+++ b/charts/matrix-stack/templates/NOTES.txt
@@ -28,7 +28,7 @@ kubectl exec -n {{ $.Release.Namespace }} -it deployment/{{ $.Release.Name }}-ma
 ---
 
 {{- if $.Values.elementAdmin.enabled }}
-- Element Admin is available at: https://{{ tpl $.Values.elementAdmin.ingress.host $ }}
+- Element Admin is available at: {{ printf "https://%s" (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $ "context" (dict "component" $.Values.elementAdmin))) }}
 {{- if and $.Values.serverName (not $.Values.matrixAuthenticationService.enabled) }}
 WARNING: You have enabled the element-admin component, but have disabled the matrix-authentication-service.
          You will not be able to login to the element admin console to manage your users.
@@ -36,11 +36,11 @@ WARNING: You have enabled the element-admin component, but have disabled the mat
          in https://github.com/element-hq/ess-helm/blob/main/docs/syn2mas.md.
 {{- end }}
 {{- end }}
-{{- if and $.Values.elementWeb.enabled $.Values.elementWeb.ingress.host }}
-- Element Web is available at: https://{{ tpl $.Values.elementWeb.ingress.host $ }}
+{{- if and $.Values.elementWeb.enabled (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $ "context" (dict "component" $.Values.elementWeb))) }}
+- Element Web is available at: {{ printf "https://%s" (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $ "context" (dict "component" $.Values.elementWeb))) }}
 {{- end }}
-{{- if and $.Values.matrixAuthenticationService.enabled $.Values.matrixAuthenticationService.ingress.host }}
-- Users can manage their accounts at: https://{{ tpl $.Values.matrixAuthenticationService.ingress.host $ }}
+{{- if and $.Values.matrixAuthenticationService.enabled (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $ "context" (dict "component" $.Values.matrixAuthenticationService))) }}
+- Users can manage their accounts at: {{ printf "https://%s" (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $ "context" (dict "component" $.Values.matrixAuthenticationService))) }}
 {{- end }}
 
 {{- include "element-io.deprecations" (dict "root" $) }}

--- a/charts/matrix-stack/templates/element-admin/_helpers.tpl
+++ b/charts/matrix-stack/templates/element-admin/_helpers.tpl
@@ -9,8 +9,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- $root := .root -}}
 {{- with required "element-io.element-admin.validations missing context" .context -}}
 {{ $messages := list }}
-{{- if not .ingress.host -}}
-{{ $messages = append $messages "elementAdmin.ingress.host is required when elementAdmin.enabled=true" }}
+{{- $trafficHandler := include "element-io.ess-library.inboundTrafficHandler.name" (dict "root" $root "context" (dict "component" .)) -}}
+{{- if and $trafficHandler (not (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)))) -}}
+{{ $messages = append $messages (printf "elementAdmin.%s.host is required when elementAdmin.enabled=true and inboundTrafficHandler is %s" $trafficHandler $trafficHandler) }}
 {{- end }}
 {{ $messages | toJson }}
 {{- end }}

--- a/charts/matrix-stack/templates/element-admin/httproute.yaml
+++ b/charts/matrix-stack/templates/element-admin/httproute.yaml
@@ -1,4 +1,7 @@
 {{- /*
+Copyright 2026 New Vector Ltd
+Copyright 2026 Element Creations Ltd
+
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with .Values.elementAdmin -}}

--- a/charts/matrix-stack/templates/element-admin/httproute.yaml
+++ b/charts/matrix-stack/templates/element-admin/httproute.yaml
@@ -1,0 +1,41 @@
+{{- /*
+SPDX-License-Identifier: AGPL-3.0-only
+*/ -}}
+{{- with .Values.elementAdmin -}}
+{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "HTTPRoute"))) "true" -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress)) | nindent 2 }}
+  labels:
+    {{- include "element-io.element-admin.labels" (dict "root" $ "context" .) | nindent 4 }}
+  name: {{ $.Release.Name }}-element-admin
+  namespace: {{ $.Release.Namespace }}
+spec:
+  parentRefs:
+    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "serviceName" "element-admin" "HTTPRoute" .ingress.HTTPRoute)) | nindent 4 }}
+  hostnames:
+    - {{ (tpl .ingress.host $) | quote }}
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      backendRefs:
+        - name: {{ $.Release.Name }}-element-admin
+          port: 8080
+          group: ""
+          kind: Service
+    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .ingress)) "true" }}
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      filters:
+      - requestRedirect:
+          scheme: https
+          statusCode: 301
+        type: RequestRedirect
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/matrix-stack/templates/element-admin/httproute.yaml
+++ b/charts/matrix-stack/templates/element-admin/httproute.yaml
@@ -9,16 +9,16 @@ SPDX-License-Identifier: AGPL-3.0-only
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress)) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .routes)) | nindent 2 }}
   labels:
     {{- include "element-io.element-admin.labels" (dict "root" $ "context" .) | nindent 4 }}
   name: {{ $.Release.Name }}-element-admin
   namespace: {{ $.Release.Namespace }}
 spec:
   parentRefs:
-    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "serviceName" "element-admin" "HTTPRoute" .ingress.HTTPRoute)) | nindent 4 }}
+    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "component" . "serviceName" "element-admin")) | nindent 4 }}
   hostnames:
-    - {{ (tpl .ingress.host $) | quote }}
+    - {{ (tpl .routes.host $) | quote }}
   rules:
     - matches:
       - path:
@@ -29,7 +29,7 @@ spec:
           port: 8080
           group: ""
           kind: Service
-    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .ingress)) "true" }}
+    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
     - matches:
       - path:
           type: PathPrefix

--- a/charts/matrix-stack/templates/element-admin/httproute.yaml
+++ b/charts/matrix-stack/templates/element-admin/httproute.yaml
@@ -30,7 +30,7 @@ spec:
           group: ""
           kind: Service
 {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
-{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "element-admin" "host" (tpl .routes.host $))) }}
+{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "element-admin" "host" (tpl .routes.host $) "labels" (include "element-io.element-admin.labels" (dict "root" $ "context" .)))) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/element-admin/httproute.yaml
+++ b/charts/matrix-stack/templates/element-admin/httproute.yaml
@@ -1,5 +1,4 @@
 {{- /*
-Copyright 2026 New Vector Ltd
 Copyright 2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/charts/matrix-stack/templates/element-admin/httproute.yaml
+++ b/charts/matrix-stack/templates/element-admin/httproute.yaml
@@ -5,7 +5,7 @@ Copyright 2026 Element Creations Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with .Values.elementAdmin -}}
-{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "HTTPRoute"))) "true" -}}
+{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "routes"))) "true" -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/matrix-stack/templates/element-admin/httproute.yaml
+++ b/charts/matrix-stack/templates/element-admin/httproute.yaml
@@ -29,7 +29,7 @@ spec:
           port: 8080
           group: ""
           kind: Service
-{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
+{{- if eq (include "element-io.ess-library.routes.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
 {{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "element-admin" "host" (tpl .routes.host $) "labels" (include "element-io.element-admin.labels" (dict "root" $ "context" .)))) }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/element-admin/httproute.yaml
+++ b/charts/matrix-stack/templates/element-admin/httproute.yaml
@@ -29,16 +29,8 @@ spec:
           port: 8080
           group: ""
           kind: Service
-    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
-    - matches:
-      - path:
-          type: PathPrefix
-          value: /
-      filters:
-      - requestRedirect:
-          scheme: https
-          statusCode: 301
-        type: RequestRedirect
-    {{- end }}
+{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
+{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "element-admin" "host" (tpl .routes.host $))) }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/element-admin/ingress.yaml
+++ b/charts/matrix-stack/templates/element-admin/ingress.yaml
@@ -5,7 +5,7 @@ Copyright 2025 Element Creations Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with .Values.elementAdmin -}}
-{{- if .enabled -}}
+{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "Ingress"))) "true" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -16,7 +16,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
 {{- include "element-io.ess-library.ingress.tls" (dict "root" $ "context" (dict "ingress" .ingress "ingressName" "element-admin")) | nindent 2 }}
-{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.className) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.Ingress.className) | nindent 2 }}
   rules:
   - host: {{ (tpl .ingress.host $) | quote }}
     http:

--- a/charts/matrix-stack/templates/element-admin/ingress.yaml
+++ b/charts/matrix-stack/templates/element-admin/ingress.yaml
@@ -5,7 +5,7 @@ Copyright 2025 Element Creations Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with .Values.elementAdmin -}}
-{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "Ingress"))) "true" -}}
+{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "ingress"))) "true" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -16,7 +16,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
 {{- include "element-io.ess-library.ingress.tls" (dict "root" $ "context" (dict "ingress" .ingress "ingressName" "element-admin")) | nindent 2 }}
-{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.Ingress.className) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.className) | nindent 2 }}
   rules:
   - host: {{ (tpl .ingress.host $) | quote }}
     http:

--- a/charts/matrix-stack/templates/element-web/_helpers.tpl
+++ b/charts/matrix-stack/templates/element-web/_helpers.tpl
@@ -9,8 +9,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- $root := .root -}}
 {{- with required "element-io.element-web.validations missing context" .context -}}
 {{ $messages := list }}
-{{- if not .ingress.host -}}
-{{ $messages = append $messages "elementWeb.ingress.host is required when elementWeb.enabled=true" }}
+{{- $trafficHandler := include "element-io.ess-library.inboundTrafficHandler.name" (dict "root" $root "context" (dict "component" .)) -}}
+{{- if and $trafficHandler (not (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)))) -}}
+{{ $messages = append $messages (printf "elementWeb.%s.host is required when elementWeb.enabled=true and inboundTrafficHandler is %s" $trafficHandler $trafficHandler) }}
 {{- end }}
 {{- with .additional }}
   {{- range $key := (. | keys | uniq | sortAlpha) }}

--- a/charts/matrix-stack/templates/element-web/httproute.yaml
+++ b/charts/matrix-stack/templates/element-web/httproute.yaml
@@ -1,4 +1,7 @@
 {{- /*
+Copyright 2026 New Vector Ltd
+Copyright 2026 Element Creations Ltd
+
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with .Values.elementWeb -}}

--- a/charts/matrix-stack/templates/element-web/httproute.yaml
+++ b/charts/matrix-stack/templates/element-web/httproute.yaml
@@ -1,0 +1,41 @@
+{{- /*
+SPDX-License-Identifier: AGPL-3.0-only
+*/ -}}
+{{- with .Values.elementWeb -}}
+{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "HTTPRoute"))) "true" -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress)) | nindent 2 }}
+  labels:
+    {{- include "element-io.element-web.labels" (dict "root" $ "context" .) | nindent 4 }}
+  name: {{ $.Release.Name }}-element-web
+  namespace: {{ $.Release.Namespace }}
+spec:
+  parentRefs:
+    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "serviceName" "element-web" "HTTPRoute" .ingress.HTTPRoute)) | nindent 4 }}
+  hostnames:
+    - {{ (tpl .ingress.host $) | quote }}
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      backendRefs:
+        - name: {{ $.Release.Name }}-element-web
+          port: 80
+          group: ""
+          kind: Service
+    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .ingress)) "true" }}
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      filters:
+      - requestRedirect:
+          scheme: https
+          statusCode: 301
+        type: RequestRedirect
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/matrix-stack/templates/element-web/httproute.yaml
+++ b/charts/matrix-stack/templates/element-web/httproute.yaml
@@ -9,16 +9,16 @@ SPDX-License-Identifier: AGPL-3.0-only
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress)) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .routes)) | nindent 2 }}
   labels:
     {{- include "element-io.element-web.labels" (dict "root" $ "context" .) | nindent 4 }}
   name: {{ $.Release.Name }}-element-web
   namespace: {{ $.Release.Namespace }}
 spec:
   parentRefs:
-    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "serviceName" "element-web" "HTTPRoute" .ingress.HTTPRoute)) | nindent 4 }}
+    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "component" . "serviceName" "element-web")) | nindent 4 }}
   hostnames:
-    - {{ (tpl .ingress.host $) | quote }}
+    - {{ (tpl .routes.host $) | quote }}
   rules:
     - matches:
       - path:
@@ -29,7 +29,7 @@ spec:
           port: 80
           group: ""
           kind: Service
-    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .ingress)) "true" }}
+    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
     - matches:
       - path:
           type: PathPrefix

--- a/charts/matrix-stack/templates/element-web/httproute.yaml
+++ b/charts/matrix-stack/templates/element-web/httproute.yaml
@@ -29,7 +29,7 @@ spec:
           port: 80
           group: ""
           kind: Service
-{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
+{{- if eq (include "element-io.ess-library.routes.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
 {{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "element-web" "host" (tpl .routes.host $) "labels" (include "element-io.element-web.labels" (dict "root" $ "context" .)))) }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/element-web/httproute.yaml
+++ b/charts/matrix-stack/templates/element-web/httproute.yaml
@@ -30,7 +30,7 @@ spec:
           group: ""
           kind: Service
 {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
-{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "element-web" "host" (tpl .routes.host $))) }}
+{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "element-web" "host" (tpl .routes.host $) "labels" (include "element-io.element-web.labels" (dict "root" $ "context" .)))) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/element-web/httproute.yaml
+++ b/charts/matrix-stack/templates/element-web/httproute.yaml
@@ -1,5 +1,4 @@
 {{- /*
-Copyright 2026 New Vector Ltd
 Copyright 2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/charts/matrix-stack/templates/element-web/httproute.yaml
+++ b/charts/matrix-stack/templates/element-web/httproute.yaml
@@ -29,16 +29,8 @@ spec:
           port: 80
           group: ""
           kind: Service
-    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
-    - matches:
-      - path:
-          type: PathPrefix
-          value: /
-      filters:
-      - requestRedirect:
-          scheme: https
-          statusCode: 301
-        type: RequestRedirect
-    {{- end }}
+{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
+{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "element-web" "host" (tpl .routes.host $))) }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/element-web/httproute.yaml
+++ b/charts/matrix-stack/templates/element-web/httproute.yaml
@@ -5,7 +5,7 @@ Copyright 2026 Element Creations Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with .Values.elementWeb -}}
-{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "HTTPRoute"))) "true" -}}
+{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "routes"))) "true" -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/matrix-stack/templates/element-web/ingress.yaml
+++ b/charts/matrix-stack/templates/element-web/ingress.yaml
@@ -5,7 +5,7 @@ Copyright 2025 Element Creations Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with .Values.elementWeb -}}
-{{- if .enabled -}}
+{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "Ingress"))) "true" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -16,7 +16,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
 {{- include "element-io.ess-library.ingress.tls" (dict "root" $ "context" (dict "ingress" .ingress "ingressName" "element-web")) | nindent 2 }}
-{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.className) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.Ingress.className) | nindent 2 }}
   rules:
   - host: {{ (tpl .ingress.host $) | quote }}
     http:

--- a/charts/matrix-stack/templates/element-web/ingress.yaml
+++ b/charts/matrix-stack/templates/element-web/ingress.yaml
@@ -5,7 +5,7 @@ Copyright 2025 Element Creations Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with .Values.elementWeb -}}
-{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "Ingress"))) "true" -}}
+{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "ingress"))) "true" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -16,7 +16,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
 {{- include "element-io.ess-library.ingress.tls" (dict "root" $ "context" (dict "ingress" .ingress "ingressName" "element-web")) | nindent 2 }}
-{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.Ingress.className) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.className) | nindent 2 }}
   rules:
   - host: {{ (tpl .ingress.host $) | quote }}
     http:

--- a/charts/matrix-stack/templates/ess-library/_httpRedirectRoute.tpl
+++ b/charts/matrix-stack/templates/ess-library/_httpRedirectRoute.tpl
@@ -1,0 +1,40 @@
+{{- /*
+Copyright 2024 New Vector Ltd
+Copyright 2025-2026 Element Creations Ltd
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/ -}}
+
+{{- define "element-io.ess-library.httpRedirectRoute" -}}
+{{- $root := .root -}}
+{{- with required "element-io.ess-library.httpRouteRedirect missing context" .context -}}
+{{- $serviceName := required "element-io.ess-library.httpRedirectRoute context missing ServiceName" .serviceName -}}
+{{- $component := required "element-io.ess-library.httpRedirectRoute context missing Component" .component -}}
+{{- $host := required "element-io.ess-library.httpRedirectRoute context missing Host" .host -}}
+{{- $path := .path | default "/" -}}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- include "element-io.ess-library.ingress.annotations" (dict "root" $root "context" (dict "ingress" $component.routes)) | nindent 2 }}
+  labels:
+    {{- include "element-io.element-admin.labels" (dict "root" $root "context" $component) | nindent 4 }}
+  name: {{ printf "%s-%s-redirect" $root.Release.Name $serviceName }}
+  namespace: {{ $root.Release.Namespace }}
+spec:
+  parentRefs:
+    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $root "context" (dict "component" $component "serviceName" $serviceName "protocol" "http")) | nindent 4 }}
+  hostnames:
+    - {{ $host | quote }}
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: {{ $path }}
+      filters:
+      - requestRedirect:
+          scheme: https
+          statusCode: 301
+        type: RequestRedirect
+{{- end -}}
+{{- end -}}

--- a/charts/matrix-stack/templates/ess-library/_inboundTrafficHandler.tpl
+++ b/charts/matrix-stack/templates/ess-library/_inboundTrafficHandler.tpl
@@ -35,6 +35,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- $serviceName := required "element-io.ess-library.httpRedirectRoute context missing ServiceName" .serviceName -}}
 {{- $component := required "element-io.ess-library.httpRedirectRoute context missing Component" .component -}}
 {{- $host := required "element-io.ess-library.httpRedirectRoute context missing Host" .host -}}
+{{- $labels := required "element-io.ess-library.httpRedirectRoute context missing Labels" .labels -}}
 {{- $path := .path | default "/" -}}
 ---
 apiVersion: gateway.networking.k8s.io/v1
@@ -42,7 +43,7 @@ kind: HTTPRoute
 metadata:
 {{- include "element-io.ess-library.ingress.annotations" (dict "root" $root "context" (dict "ingress" $component.routes)) | nindent 2 }}
   labels:
-    {{- include "element-io.element-admin.labels" (dict "root" $root "context" $component) | nindent 4 }}
+    {{- $labels | nindent 4 }}
   name: {{ printf "%s-%s-redirect" $root.Release.Name $serviceName }}
   namespace: {{ $root.Release.Namespace }}
 spec:

--- a/charts/matrix-stack/templates/ess-library/_inboundTrafficHandler.tpl
+++ b/charts/matrix-stack/templates/ess-library/_inboundTrafficHandler.tpl
@@ -34,9 +34,11 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- with required "element-io.ess-library.httpRouteRedirect missing context" .context -}}
 {{- $serviceName := required "element-io.ess-library.httpRedirectRoute context missing ServiceName" .serviceName -}}
 {{- $component := required "element-io.ess-library.httpRedirectRoute context missing Component" .component -}}
+{{- $disabled := coalesce $component.disableHTTPRedirect $root.Values.routes.disableHTTPRedirect false -}}
 {{- $host := required "element-io.ess-library.httpRedirectRoute context missing Host" .host -}}
 {{- $labels := required "element-io.ess-library.httpRedirectRoute context missing Labels" .labels -}}
 {{- $path := .path | default "/" -}}
+{{- if not $disabled -}}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -61,5 +63,6 @@ spec:
           scheme: https
           statusCode: 301
         type: RequestRedirect
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/matrix-stack/templates/ess-library/_inboundTrafficHandler.tpl
+++ b/charts/matrix-stack/templates/ess-library/_inboundTrafficHandler.tpl
@@ -5,6 +5,30 @@ Copyright 2025-2026 Element Creations Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 
+{{- define "element-io.ess-library.inboundTrafficHandler.host" -}}
+{{- $root := .root -}}
+{{- with required "element-io.ess-library.inboundTrafficHandler.host missing context" .context -}}
+{{- $component := required "element-io.ess-library.inboundTrafficHandler.host missing component" .component -}}
+{{- $handler := coalesce $component.inboundTrafficHandler $root.Values.inboundTrafficHandler "none" -}}
+{{- if eq $handler "ingress" -}}
+{{- tpl (dig "ingress" "host" "" $component) $root -}}
+{{- else if eq $handler "routes" -}}
+{{- tpl (dig "routes" "host" "" $component) $root -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "element-io.ess-library.inboundTrafficHandler.name" -}}
+{{- $root := .root -}}
+{{- with required "element-io.ess-library.inboundTrafficHandler.name missing context" .context -}}
+{{- $component := required "element-io.ess-library.inboundTrafficHandler.name missing component" .component -}}
+{{- $handler := coalesce $component.inboundTrafficHandler $root.Values.inboundTrafficHandler "none" -}}
+{{- if ne $handler "none" -}}
+{{- $handler -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "element-io.ess-library.httpRedirectRoute" -}}
 {{- $root := .root -}}
 {{- with required "element-io.ess-library.httpRouteRedirect missing context" .context -}}

--- a/charts/matrix-stack/templates/ess-library/_ingress.tpl
+++ b/charts/matrix-stack/templates/ess-library/_ingress.tpl
@@ -169,13 +169,14 @@ Prefix
 {{- end -}}
 {{- end -}}
 
-{{- define "element-io.ess-library.ingress.isEnabled" -}}
+{{- define "element-io.ess-library.inboundTrafficHandler.isEnabled" -}}
 {{- $root := .root -}}
-{{- with required "element-io.ess-library.ingress.isEnabled missing context" .context -}}
-{{- $ingress := required "element-io.ess-library.ingress.isEnabled missing ingress" .ingress -}}
-{{- $type := required "element-io.ess-library.ingress.isEnabled missing type" .type -}}
-{{- $desiredType := coalesce $ingress.type $root.Values.ingress.type -}}
-{{- $enabled := or $ingress.enabled $root.Values.ingress.enabled -}}
-{{- and $enabled (eq $type $desiredType) -}}
+{{- with required "element-io.ess-library.inboundTrafficHandler.isEnabled missing context" .context -}}
+{{- $component := required "element-io.ess-library.inboundTrafficHandler.isEnabled missing component in context" .component -}}
+{{- $trafficHandler := required "element-io.ess-library.inboundTrafficHandler.isEnabled missing trafficHandler in context" .trafficHandler -}}
+{{- $desiredTrafficHandler := coalesce $component.inboundTrafficHandler $root.Values.inboundTrafficHandler "none" -}}
+{{- if and $component.enabled (eq $trafficHandler $desiredTrafficHandler) -}}
+true
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/matrix-stack/templates/ess-library/_ingress.tpl
+++ b/charts/matrix-stack/templates/ess-library/_ingress.tpl
@@ -157,6 +157,10 @@ true
 {{- $root := .root -}}
 {{- with required "element-io.ess-library.ingress.parentRefs missing context" .context -}}
 {{- $serviceName := required "element-io.ess-library.ingress.parentRefs missing serviceName" .serviceName -}}
+{{- $protocol := .protocol -}}
+{{- if not $protocol -}}
+{{- $protocol = ternary "https" "http" (eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $root "context" (dig "routes" (dict) .component))) "true") -}}
+{{- end -}}
 {{- $globalGateways := (get (get $root.Values "routes" | default (dict)) "existingGateways" | default (list)) -}}
 {{- $componentGateways := dig "routes" "existingGateways" (list) .component -}}
 {{- $gateways := concat $globalGateways $componentGateways -}}
@@ -166,11 +170,11 @@ true
 {{ toYaml $gateways }}
 {{- end -}}
 {{ if $builtinGateway.create }}
-- name: {{ $root.Release.Name | quote }}
+- name: {{ include "element-io.gateway.name" (dict "root" $root) | quote }}
   namespace: {{ $root.Release.Namespace | quote }}
   kind: Gateway
   group: gateway.networking.k8s.io
-  sectionName: {{ printf "%s-%s" $root.Release.Name $serviceName | quote }}
+  sectionName: {{ include "element-io.gateway.listenerName" (dict "root" $root "context" (dict "serviceName" $serviceName "protocol" $protocol)) | quote }}
 {{ end }}
 {{- else -}}
 []

--- a/charts/matrix-stack/templates/ess-library/_ingress.tpl
+++ b/charts/matrix-stack/templates/ess-library/_ingress.tpl
@@ -77,6 +77,13 @@ ipFamilyPolicy: PreferDualStack
 {{- end -}}
 {{- end -}}
 
+{{- define "element-io.ess-library.routes.tls.isEnabled" -}}
+{{- $root := .root -}}
+{{- with required "element-io.ess-library.routes.tls.isEnabled missing context" .context -}}
+{{- and $root.Values.routes.tlsEnabled .tlsEnabled -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "element-io.ess-library.ingress.tls" -}}
 {{- $root := .root -}}
 {{- with required "element-io.ess-library.ingress.tls missing context" .context -}}

--- a/charts/matrix-stack/templates/ess-library/_ingress.tpl
+++ b/charts/matrix-stack/templates/ess-library/_ingress.tpl
@@ -141,34 +141,6 @@ Prefix
 {{- end -}}
 {{- end -}}
 
-{{- define "element-io.ess-library.ingress.parentRefs" -}}
-{{- $root := .root -}}
-{{- with required "element-io.ess-library.ingress.parentRefs missing context" .context -}}
-{{- $serviceName := required "element-io.ess-library.ingress.parentRefs missing serviceName" .serviceName -}}
-{{- $globalHTTPRouteConfig := $root.Values.ingress.HTTPRoute | default dict -}}
-{{- $httpRouteConfig := .HTTPRoute | default dict -}}
-{{- $gateways := concat
-    ($globalHTTPRouteConfig.existingGateways | default list)
-    ($httpRouteConfig.existingGateways | default list)
--}}
-{{- $builtinGateway := $root.Values.ingress.gateway | default dict -}}
-{{- if or (gt (len $gateways) 0) $builtinGateway.create -}}
-{{- if gt (len $gateways) 0 -}}
-{{ toYaml $gateways }}
-{{- end -}}
-{{ if $builtinGateway.create }}
-- name: {{ $root.Release.Name | quote }}
-  namespace: {{ $root.Release.Namespace | quote }}
-  kind: gateway
-  group: gateway.networking.k8s.io
-  sectionname: {{ printf "%s-%s" $root.Release.Name $serviceName | quote }}
-{{ end }}
-{{- else -}}
-[]
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
 {{- define "element-io.ess-library.inboundTrafficHandler.isEnabled" -}}
 {{- $root := .root -}}
 {{- with required "element-io.ess-library.inboundTrafficHandler.isEnabled missing context" .context -}}
@@ -177,6 +149,31 @@ Prefix
 {{- $desiredTrafficHandler := coalesce $component.inboundTrafficHandler $root.Values.inboundTrafficHandler "none" -}}
 {{- if and $component.enabled (eq $trafficHandler $desiredTrafficHandler) -}}
 true
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "element-io.ess-library.ingress.parentRefs" -}}
+{{- $root := .root -}}
+{{- with required "element-io.ess-library.ingress.parentRefs missing context" .context -}}
+{{- $serviceName := required "element-io.ess-library.ingress.parentRefs missing serviceName" .serviceName -}}
+{{- $globalGateways := (get (get $root.Values "routes" | default (dict)) "existingGateways" | default (list)) -}}
+{{- $componentGateways := dig "routes" "existingGateways" (list) .component -}}
+{{- $gateways := concat $globalGateways $componentGateways -}}
+{{- $builtinGateway := $root.Values.gateway | default dict -}}
+{{- if or (gt (len $gateways) 0) $builtinGateway.create -}}
+{{- if gt (len $gateways) 0 -}}
+{{ toYaml $gateways }}
+{{- end -}}
+{{ if $builtinGateway.create }}
+- name: {{ $root.Release.Name | quote }}
+  namespace: {{ $root.Release.Namespace | quote }}
+  kind: Gateway
+  group: gateway.networking.k8s.io
+  sectionName: {{ printf "%s-%s" $root.Release.Name $serviceName | quote }}
+{{ end }}
+{{- else -}}
+[]
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/matrix-stack/templates/gateway/_helpers.tpl
+++ b/charts/matrix-stack/templates/gateway/_helpers.tpl
@@ -1,4 +1,7 @@
 {{- /*
+Copyright 2026 New Vector Ltd
+Copyright 2026 Element Creations Ltd
+
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- define "element-io.gateway.tlsConfig" -}}

--- a/charts/matrix-stack/templates/gateway/_helpers.tpl
+++ b/charts/matrix-stack/templates/gateway/_helpers.tpl
@@ -1,0 +1,75 @@
+{{- /*
+SPDX-License-Identifier: AGPL-3.0-only
+*/ -}}
+{{- define "element-io.gateway.tlsConfig" -}}
+{{- $root := .root -}}
+{{- with required "element-io.gateway.tlsConfig missing context" .context -}}
+{{- $tlsSecret := coalesce
+    .tlsSecret
+    $root.Values.ingress.tlsSecret
+    (printf "%s-%s-certmanager-tls" $root.Release.Name .name)
+-}}
+tls:
+  certificateRefs:
+    - group: ""
+      kind: Secret
+      name: {{ $tlsSecret | quote }}
+  mode: Terminate
+{{- end -}}
+{{- end -}}
+
+{{- define "element-io.gateway.listeners" -}}
+{{- $root := .root -}}
+{{- $contexts := dict
+    "element-admin" $root.Values.elementAdmin
+    "element-web" $root.Values.elementWeb
+    "hookshot" $root.Values.hookshot
+    "matrix-authentication-service" $root.Values.matrixAuthenticationService
+    "matrix-rtc" $root.Values.matrixRTC
+    "synapse" $root.Values.synapse
+    "well-known" $root.Values.wellKnownDelegation
+-}}
+{{- $listenFor := $root.Values.ingress.gateway.listenFor | default (list
+    "element-admin"
+    "element-web"
+    "matrix-authentication-service"
+    "matrix-rtc"
+    "synapse"
+    "well-known")
+-}}
+{{- if and (not $root.Values.ingress.gateway.listenFor) $root.Values.hookshot.enabled -}}
+{{- $listenFor = append $listenFor "hookshot" -}}
+{{- end -}}
+{{- range $listenFor -}}
+{{- $service := . -}}
+{{- with required "element-io.gateway.listener missing context" (index $contexts $service) -}}
+{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $root "context" (dict "ingress" .ingress "type" "HTTPRoute"))) "true" }}
+- hostname: {{ .ingress.host | default $root.Values.serverName | quote }}
+  {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $root "context" .ingress)) "true" }}
+  port: 443
+  protocol: HTTPS
+  {{- include "element-io.gateway.tlsConfig" (dict "root" $root "context" (dict "tlsSecret" .ingress.tlsSecret "name" $service)) | nindent 2 }}
+  {{- else }}
+  port: 80
+  protocol: HTTP
+  {{- end }}
+  name: {{ printf "%s-%s" $root.Release.Name $service | quote }}
+  allowedRoutes:
+    namespaces:
+      from: Same
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "element-io.gateway.labels" -}}
+{{- $root := .root -}}
+{{- with required "element-io.gateway.labels missing context" .context -}}
+{{- $labels := .labels | default dict -}}
+{{ include "element-io.ess-library.labels.common" (dict "root" $root "context" (dict "labels" $labels)) }}
+app.kubernetes.io/component: matrix-stack-ingress
+app.kubernetes.io/name: {{ $root.Release.Name }}
+app.kubernetes.io/instance: {{ $root.Release.Name }}-gateway
+app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" $root.Chart.Version }}
+{{- end -}}
+{{- end -}}

--- a/charts/matrix-stack/templates/gateway/_helpers.tpl
+++ b/charts/matrix-stack/templates/gateway/_helpers.tpl
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- with required "element-io.gateway.tlsConfig missing context" .context -}}
 {{- $tlsSecret := coalesce
     .tlsSecret
-    $root.Values.ingress.tlsSecret
+    $root.Values.gateway.tlsSecret
     (printf "%s-%s-certmanager-tls" $root.Release.Name .name)
 -}}
 tls:
@@ -32,7 +32,7 @@ tls:
     "synapse" $root.Values.synapse
     "well-known" $root.Values.wellKnownDelegation
 -}}
-{{- $listenFor := $root.Values.ingress.gateway.listenFor | default (list
+{{- $listenFor := $root.Values.gateway.listenFor | default (list
     "element-admin"
     "element-web"
     "matrix-authentication-service"
@@ -40,18 +40,18 @@ tls:
     "synapse"
     "well-known")
 -}}
-{{- if and (not $root.Values.ingress.gateway.listenFor) $root.Values.hookshot.enabled -}}
+{{- if and (not $root.Values.gateway.listenFor) $root.Values.hookshot.enabled -}}
 {{- $listenFor = append $listenFor "hookshot" -}}
 {{- end -}}
 {{- range $listenFor -}}
 {{- $service := . -}}
 {{- with required "element-io.gateway.listener missing context" (index $contexts $service) -}}
-{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $root "context" (dict "ingress" .ingress "type" "HTTPRoute"))) "true" }}
-- hostname: {{ .ingress.host | default $root.Values.serverName | quote }}
-  {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $root "context" .ingress)) "true" }}
+{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $root "context" (dict "component" . "trafficHandler" "routes"))) "true" -}}
+- hostname: {{ .routes.host | default $root.Values.serverName | quote }}
+  {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $root "context" .routes)) "true" }}
   port: 443
   protocol: HTTPS
-  {{- include "element-io.gateway.tlsConfig" (dict "root" $root "context" (dict "tlsSecret" .ingress.tlsSecret "name" $service)) | nindent 2 }}
+  {{- include "element-io.gateway.tlsConfig" (dict "root" $root "context" (dict "tlsSecret" .routes.tlsSecret "name" $service)) | nindent 2 }}
   {{- else }}
   port: 80
   protocol: HTTP

--- a/charts/matrix-stack/templates/gateway/_helpers.tpl
+++ b/charts/matrix-stack/templates/gateway/_helpers.tpl
@@ -60,7 +60,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     "protocol" "HTTP"
     "allowedRoutes" $allowedRoutes
 ) -}}
-{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $root "context" $component.routes)) "true" -}}
+{{- if eq (include "element-io.ess-library.routes.tls.isEnabled" (dict "root" $root "context" $component.routes)) "true" -}}
 {{- $tlsSecret := include "element-io.gateway.tlsSecretName" (dict "root" $root "context" (dict "serviceName" $service "tlsSecret" $component.routes.tlsSecret)) -}}
 {{- $listeners = append $listeners (dict
     "name" (include "element-io.gateway.listenerName" (dict "root" $root "context" (dict "serviceName" $service "protocol" "https")))

--- a/charts/matrix-stack/templates/gateway/_helpers.tpl
+++ b/charts/matrix-stack/templates/gateway/_helpers.tpl
@@ -1,5 +1,4 @@
 {{- /*
-Copyright 2026 New Vector Ltd
 Copyright 2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/charts/matrix-stack/templates/gateway/_helpers.tpl
+++ b/charts/matrix-stack/templates/gateway/_helpers.tpl
@@ -4,20 +4,24 @@ Copyright 2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
-{{- define "element-io.gateway.tlsConfig" -}}
+{{- define "element-io.gateway.listenerName" -}}
 {{- $root := .root -}}
-{{- with required "element-io.gateway.tlsConfig missing context" .context -}}
-{{- $tlsSecret := coalesce
+{{- with required "element-io.gateway.listenerName missing context" .context -}}
+{{- $serviceName := required "element-io.gateway.listenerName missing context.serviceName" .serviceName -}}
+{{- $protocol := required "element-io.gateway.listenerName missing context.protocol" .protocol -}}
+{{- printf "%s-%s-%s" $root.Release.Name $serviceName $protocol -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "element-io.gateway.tlsSecretName" -}}
+{{- $root := .root -}}
+{{- with required "element-io.gateway.tlsSecretName missing context" .context -}}
+{{- $serviceName := required "element-io.gateway.listenerName missing context.serviceName" .serviceName -}}
+{{- coalesce
     .tlsSecret
-    $root.Values.gateway.tlsSecret
-    (printf "%s-%s-certmanager-tls" $root.Release.Name .name)
+    (get (get $root.Values "routes" | default dict) "tlsSecret")
+    (printf "%s-%s-certmanager-tls" $root.Release.Name $serviceName)
 -}}
-tls:
-  certificateRefs:
-    - group: ""
-      kind: Secret
-      name: {{ $tlsSecret | quote }}
-  mode: Terminate
 {{- end -}}
 {{- end -}}
 
@@ -43,26 +47,37 @@ tls:
 {{- if and (not $root.Values.gateway.listenFor) $root.Values.hookshot.enabled -}}
 {{- $listenFor = append $listenFor "hookshot" -}}
 {{- end -}}
-{{- range $listenFor -}}
-{{- $service := . -}}
-{{- with required "element-io.gateway.listener missing context" (index $contexts $service) -}}
-{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $root "context" (dict "component" . "trafficHandler" "routes"))) "true" -}}
-- hostname: {{ .routes.host | default $root.Values.serverName | quote }}
-  {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $root "context" .routes)) "true" }}
-  port: 443
-  protocol: HTTPS
-  {{- include "element-io.gateway.tlsConfig" (dict "root" $root "context" (dict "tlsSecret" .routes.tlsSecret "name" $service)) | nindent 2 }}
-  {{- else }}
-  port: 80
-  protocol: HTTP
-  {{- end }}
-  name: {{ printf "%s-%s" $root.Release.Name $service | quote }}
-  allowedRoutes:
-    namespaces:
-      from: Same
+{{- $allowedRoutes := dict "namespaces" (dict "from" "Same") -}}
+{{- $listeners := list -}}
+{{- range $service := $listenFor -}}
+{{- $component := required "element-io.gateway.listeners missing component context" (index $contexts $service) -}}
+{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $root "context" (dict "component" $component "trafficHandler" "routes"))) "true" -}}
+{{- $host := $component.routes.host | default $root.Values.serverName -}}
+{{- $listeners = append $listeners (dict
+    "name" (include "element-io.gateway.listenerName" (dict "root" $root "context" (dict "serviceName" $service "protocol" "http")))
+    "hostname" $host
+    "port" 80
+    "protocol" "HTTP"
+    "allowedRoutes" $allowedRoutes
+) -}}
+{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $root "context" $component.routes)) "true" -}}
+{{- $tlsSecret := include "element-io.gateway.tlsSecretName" (dict "root" $root "context" (dict "serviceName" $service "tlsSecret" $component.routes.tlsSecret)) -}}
+{{- $listeners = append $listeners (dict
+    "name" (include "element-io.gateway.listenerName" (dict "root" $root "context" (dict "serviceName" $service "protocol" "https")))
+    "hostname" $host
+    "port" 443
+    "protocol" "HTTPS"
+    "tls" (dict
+        "mode" "Terminate"
+        "certificateRefs" (list (dict "group" "" "kind" "Secret" "name" $tlsSecret))
+    )
+    "allowedRoutes" $allowedRoutes
+) -}}
+
 {{- end -}}
 {{- end -}}
 {{- end -}}
+{{- toYaml $listeners }}
 {{- end -}}
 
 {{- define "element-io.gateway.labels" -}}
@@ -71,8 +86,12 @@ tls:
 {{- $labels := .labels | default dict -}}
 {{ include "element-io.ess-library.labels.common" (dict "root" $root "context" (dict "labels" $labels)) }}
 app.kubernetes.io/component: matrix-stack-ingress
-app.kubernetes.io/name: {{ $root.Release.Name }}
+app.kubernetes.io/name: gateway
 app.kubernetes.io/instance: {{ $root.Release.Name }}-gateway
 app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" $root.Chart.Version }}
 {{- end -}}
+{{- end -}}
+
+{{- define "element-io.gateway.name" -}}
+{{ .root.Release.Name }}-gateway
 {{- end -}}

--- a/charts/matrix-stack/templates/gateway/gateway.yaml
+++ b/charts/matrix-stack/templates/gateway/gateway.yaml
@@ -1,4 +1,7 @@
 {{- /*
+Copyright 2026 New Vector Ltd
+Copyright 2026 Element Creations Ltd
+
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- if and .Values.ingress.gateway .Values.ingress.gateway.create }}

--- a/charts/matrix-stack/templates/gateway/gateway.yaml
+++ b/charts/matrix-stack/templates/gateway/gateway.yaml
@@ -1,0 +1,17 @@
+{{- /*
+SPDX-License-Identifier: AGPL-3.0-only
+*/ -}}
+{{- if and .Values.ingress.gateway .Values.ingress.gateway.create }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .Values.ingress.gateway)) | nindent 2 }}
+  labels:
+    {{- include "element-io.gateway.labels" (dict "root" $ "context" .Values.ingress.gateway) | nindent 4 }}
+  name: {{ $.Release.Name }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  gatewayClassName: {{ .Values.ingress.gateway.className }}
+  listeners:
+  {{- include "element-io.gateway.listeners" (dict "root" $) | nindent 4 -}}
+{{- end }}

--- a/charts/matrix-stack/templates/gateway/gateway.yaml
+++ b/charts/matrix-stack/templates/gateway/gateway.yaml
@@ -4,17 +4,19 @@ Copyright 2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
-{{- if and .Values.ingress.gateway .Values.ingress.gateway.create }}
+{{- if and .Values.gateway .Values.gateway.create }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .Values.ingress.gateway)) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .Values.gateway)) | nindent 2 }}
   labels:
-    {{- include "element-io.gateway.labels" (dict "root" $ "context" .Values.ingress.gateway) | nindent 4 }}
-  name: {{ $.Release.Name }}
+    {{- include "element-io.gateway.labels" (dict "root" $ "context" .Values.gateway) | nindent 4 }}
+  name: gateway
   namespace: {{ $.Release.Namespace }}
 spec:
-  gatewayClassName: {{ .Values.ingress.gateway.className }}
+  {{- if .Values.gateway.className }}
+  gatewayClassName: {{ .Values.gateway.className }}
+  {{- end }}
   listeners:
   {{- include "element-io.gateway.listeners" (dict "root" $) | nindent 4 -}}
 {{- end }}

--- a/charts/matrix-stack/templates/gateway/gateway.yaml
+++ b/charts/matrix-stack/templates/gateway/gateway.yaml
@@ -11,12 +11,10 @@ metadata:
 {{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .Values.gateway)) | nindent 2 }}
   labels:
     {{- include "element-io.gateway.labels" (dict "root" $ "context" .Values.gateway) | nindent 4 }}
-  name: gateway
+  name: {{ include "element-io.gateway.name" (dict "root" $) }}
   namespace: {{ $.Release.Namespace }}
 spec:
-  {{- if .Values.gateway.className }}
   gatewayClassName: {{ .Values.gateway.className }}
-  {{- end }}
   listeners:
   {{- include "element-io.gateway.listeners" (dict "root" $) | nindent 4 -}}
 {{- end }}

--- a/charts/matrix-stack/templates/gateway/gateway.yaml
+++ b/charts/matrix-stack/templates/gateway/gateway.yaml
@@ -1,5 +1,4 @@
 {{- /*
-Copyright 2026 New Vector Ltd
 Copyright 2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/charts/matrix-stack/templates/hookshot/_helpers.tpl
+++ b/charts/matrix-stack/templates/hookshot/_helpers.tpl
@@ -12,8 +12,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{ $messages = append $messages "serverName is required when hookshot.enabled=true" }}
 {{- end }}
 {{- $trafficHandler := include "element-io.ess-library.inboundTrafficHandler.name" (dict "root" $root "context" (dict "component" .)) -}}
-{{- if and $trafficHandler (not (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)))) -}}
-{{ $messages = append $messages (printf "hookshot.%s.host is required when hookshot.enabled=true and inboundTrafficHandler is %s" $trafficHandler $trafficHandler) }}
+{{- if and $trafficHandler (not $root.Values.synapse.enabled) (not (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)))) -}}
+{{ $messages = append $messages (printf "hookshot.%s.host is required when hookshot.enabled=true, synapse.enabled=false and inboundTrafficHandler is %s" $trafficHandler $trafficHandler) }}
 {{- end }}
 {{- if and ($root.Values.matrixAuthenticationService.enabled) (.enableEncryption) -}}
 {{ $messages = append $messages "hookshot.enableEncryption cannot be enabled when matrixAuthenticationService.enabled=true" }}

--- a/charts/matrix-stack/templates/hookshot/_helpers.tpl
+++ b/charts/matrix-stack/templates/hookshot/_helpers.tpl
@@ -11,8 +11,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- if not $root.Values.serverName -}}
 {{ $messages = append $messages "serverName is required when hookshot.enabled=true" }}
 {{- end }}
-{{- if and (not $root.Values.synapse.enabled) (not .ingress.host) -}}
-{{ $messages = append $messages "hookshot.ingress.host is required when hookshot.enabled=true and synapse.enabled=false" }}
+{{- $trafficHandler := include "element-io.ess-library.inboundTrafficHandler.name" (dict "root" $root "context" (dict "component" .)) -}}
+{{- if and $trafficHandler (not (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)))) -}}
+{{ $messages = append $messages (printf "hookshot.%s.host is required when hookshot.enabled=true and inboundTrafficHandler is %s" $trafficHandler $trafficHandler) }}
 {{- end }}
 {{- if and ($root.Values.matrixAuthenticationService.enabled) (.enableEncryption) -}}
 {{ $messages = append $messages "hookshot.enableEncryption cannot be enabled when matrixAuthenticationService.enabled=true" }}

--- a/charts/matrix-stack/templates/hookshot/hookshot_httproute.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_httproute.yaml
@@ -1,4 +1,7 @@
 {{- /*
+Copyright 2026 New Vector Ltd
+Copyright 2026 Element Creations Ltd
+
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with $.Values.hookshot -}}

--- a/charts/matrix-stack/templates/hookshot/hookshot_httproute.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_httproute.yaml
@@ -1,0 +1,51 @@
+{{- /*
+SPDX-License-Identifier: AGPL-3.0-only
+*/ -}}
+{{- with $.Values.hookshot -}}
+{{- if and (eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "HTTPRoute"))) "true") .ingress.host -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- $extraAnnotations := dict }}
+{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress "extraAnnotations" $extraAnnotations)) | nindent 2 }}
+  labels:
+    {{- include "element-io.hookshot.labels" (dict "root" $ "context" $.Values.haproxy) | nindent 4 }}
+  name: {{ $.Release.Name }}-hookshot
+  namespace: {{ $.Release.Namespace }}
+spec:
+  parentRefs:
+    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "serviceName" "hookshot" "HTTPRoute" .ingress.HTTPRoute)) | nindent 4 }}
+  hostnames:
+    - {{ (tpl .ingress.host $) | quote }}
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /widgetapi/v1
+      backendRefs:
+        - name: "{{ $.Release.Name }}-hookshot"
+          port: 7778
+          group: ""
+          kind: Service
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      backendRefs:
+        - name: "{{ $.Release.Name }}-hookshot"
+          port: 7775
+          group: ""
+          kind: Service
+    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .ingress)) "true" }}
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      filters:
+      - requestRedirect:
+          scheme: https
+          statusCode: 301
+        type: RequestRedirect
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/matrix-stack/templates/hookshot/hookshot_httproute.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_httproute.yaml
@@ -39,7 +39,7 @@ spec:
           port: 7775
           group: ""
           kind: Service
-{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
+{{- if eq (include "element-io.ess-library.routes.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
 {{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "hookshot" "host" (tpl .routes.host $) "labels" (include "element-io.hookshot.labels" (dict "root" $ "context" $.Values.haproxy)))) }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/hookshot/hookshot_httproute.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_httproute.yaml
@@ -1,5 +1,4 @@
 {{- /*
-Copyright 2026 New Vector Ltd
 Copyright 2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/charts/matrix-stack/templates/hookshot/hookshot_httproute.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_httproute.yaml
@@ -5,7 +5,7 @@ Copyright 2026 Element Creations Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with $.Values.hookshot -}}
-{{- if and (eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "HTTPRoute"))) "true") .ingress.host -}}
+{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "routes"))) "true" -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/matrix-stack/templates/hookshot/hookshot_httproute.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_httproute.yaml
@@ -17,9 +17,9 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   parentRefs:
-    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "serviceName" "hookshot" "HTTPRoute" .ingress.HTTPRoute)) | nindent 4 }}
+    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "component" . "serviceName" "hookshot")) | nindent 4 }}
   hostnames:
-    - {{ (tpl .ingress.host $) | quote }}
+    - {{ (tpl .routes.host $) | quote }}
   rules:
     - matches:
       - path:
@@ -39,7 +39,7 @@ spec:
           port: 7775
           group: ""
           kind: Service
-    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .ingress)) "true" }}
+    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
     - matches:
       - path:
           type: PathPrefix

--- a/charts/matrix-stack/templates/hookshot/hookshot_httproute.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_httproute.yaml
@@ -39,16 +39,8 @@ spec:
           port: 7775
           group: ""
           kind: Service
-    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
-    - matches:
-      - path:
-          type: PathPrefix
-          value: /
-      filters:
-      - requestRedirect:
-          scheme: https
-          statusCode: 301
-        type: RequestRedirect
-    {{- end }}
+{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
+{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "hookshot" "host" (tpl .routes.host $))) }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/hookshot/hookshot_httproute.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_httproute.yaml
@@ -5,7 +5,7 @@ Copyright 2026 Element Creations Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with $.Values.hookshot -}}
-{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "routes"))) "true" -}}
+{{- if and (eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "routes"))) "true") (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $ "context" (dict "component" .))) -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -40,7 +40,7 @@ spec:
           group: ""
           kind: Service
 {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
-{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "hookshot" "host" (tpl .routes.host $))) }}
+{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "hookshot" "host" (tpl .routes.host $) "labels" (include "element-io.hookshot.labels" (dict "root" $ "context" $.Values.haproxy)))) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/hookshot/hookshot_ingress.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_ingress.yaml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 
 {{- with $.Values.hookshot -}}
-{{- if and .enabled .ingress.host }}
+{{- if and (eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "Ingress"))) "true") .ingress.host -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -18,7 +18,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
 {{- include "element-io.ess-library.ingress.tls" (dict "root" $ "context" (dict "ingress" .ingress "ingressName" "hookshot")) | nindent 2 }}
-{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.className) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.Ingress.className) | nindent 2 }}
   rules:
   - host: {{ (tpl .ingress.host $) | quote }}
     http:

--- a/charts/matrix-stack/templates/hookshot/hookshot_ingress.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_ingress.yaml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 
 {{- with $.Values.hookshot -}}
-{{- if and (eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "Ingress"))) "true") .ingress.host -}}
+{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "ingress"))) "true" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -18,7 +18,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
 {{- include "element-io.ess-library.ingress.tls" (dict "root" $ "context" (dict "ingress" .ingress "ingressName" "hookshot")) | nindent 2 }}
-{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.Ingress.className) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.className) | nindent 2 }}
   rules:
   - host: {{ (tpl .ingress.host $) | quote }}
     http:

--- a/charts/matrix-stack/templates/hookshot/hookshot_ingress.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_ingress.yaml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 
 {{- with $.Values.hookshot -}}
-{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "ingress"))) "true" -}}
+{{- if and (eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "ingress"))) "true") (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $ "context" (dict "component" .))) -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/matrix-stack/templates/matrix-authentication-service/_helpers.tpl
+++ b/charts/matrix-stack/templates/matrix-authentication-service/_helpers.tpl
@@ -9,8 +9,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- $root := .root -}}
 {{- with required "element-io.matrix-authentication-service.validations missing context" .context -}}
 {{ $messages := list }}
-{{- if not .ingress.host -}}
-{{ $messages = append $messages "matrixAuthenticationService.ingress.host is required when matrixAuthenticationService.enabled=true" }}
+{{- $trafficHandler := include "element-io.ess-library.inboundTrafficHandler.name" (dict "root" $root "context" (dict "component" .)) -}}
+{{- if and $trafficHandler (not (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)))) -}}
+{{ $messages = append $messages (printf "matrixAuthenticationService.%s.host is required when matrixAuthenticationService.enabled=true and inboundTrafficHandler is %s" $trafficHandler $trafficHandler) }}
 {{- end }}
 {{- if and (not $root.Values.postgres.enabled) (not .postgres) -}}
 {{ $messages = append $messages "matrixAuthenticationService.postgres is required when matrixAuthenticationService.enabled=true but postgres.enabled=false" }}

--- a/charts/matrix-stack/templates/matrix-authentication-service/httproute.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/httproute.yaml
@@ -1,4 +1,7 @@
 {{- /*
+Copyright 2026 New Vector Ltd
+Copyright 2026 Element Creations Ltd
+
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with .Values.matrixAuthenticationService -}}

--- a/charts/matrix-stack/templates/matrix-authentication-service/httproute.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/httproute.yaml
@@ -1,0 +1,41 @@
+{{- /*
+SPDX-License-Identifier: AGPL-3.0-only
+*/ -}}
+{{- with .Values.matrixAuthenticationService -}}
+{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "HTTPRoute"))) "true" -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress)) | nindent 2 }}
+  labels:
+    {{- include "element-io.matrix-authentication-service.labels" (dict "root" $ "context" .) | nindent 4 }}
+  name: {{ $.Release.Name }}-matrix-authentication-service
+  namespace: {{ $.Release.Namespace }}
+spec:
+  parentRefs:
+    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "serviceName" "matrix-authentication-service" "HTTPRoute" .ingress.HTTPRoute)) | nindent 4 }}
+  hostnames:
+    - {{ (tpl .ingress.host $) | quote }}
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      backendRefs:
+        - name: {{ $.Release.Name }}-matrix-authentication-service
+          port: 8080
+          group: ""
+          kind: Service
+    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .ingress)) "true" }}
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      filters:
+      - requestRedirect:
+          scheme: https
+          statusCode: 301
+        type: RequestRedirect
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/matrix-stack/templates/matrix-authentication-service/httproute.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/httproute.yaml
@@ -29,16 +29,8 @@ spec:
           port: 8080
           group: ""
           kind: Service
-    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
-    - matches:
-      - path:
-          type: PathPrefix
-          value: /
-      filters:
-      - requestRedirect:
-          scheme: https
-          statusCode: 301
-        type: RequestRedirect
-    {{- end }}
+{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
+{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "matrix-authentication-service" "host" (tpl .routes.host $))) }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-authentication-service/httproute.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/httproute.yaml
@@ -29,7 +29,7 @@ spec:
           port: 8080
           group: ""
           kind: Service
-{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
+{{- if eq (include "element-io.ess-library.routes.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
 {{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "matrix-authentication-service" "host" (tpl .routes.host $) "labels" (include "element-io.matrix-authentication-service.labels" (dict "root" $ "context" .)))) }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-authentication-service/httproute.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/httproute.yaml
@@ -1,5 +1,4 @@
 {{- /*
-Copyright 2026 New Vector Ltd
 Copyright 2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/charts/matrix-stack/templates/matrix-authentication-service/httproute.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/httproute.yaml
@@ -30,7 +30,7 @@ spec:
           group: ""
           kind: Service
 {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
-{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "matrix-authentication-service" "host" (tpl .routes.host $))) }}
+{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "matrix-authentication-service" "host" (tpl .routes.host $) "labels" (include "element-io.matrix-authentication-service.labels" (dict "root" $ "context" .)))) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-authentication-service/httproute.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/httproute.yaml
@@ -9,16 +9,16 @@ SPDX-License-Identifier: AGPL-3.0-only
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress)) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .routes)) | nindent 2 }}
   labels:
     {{- include "element-io.matrix-authentication-service.labels" (dict "root" $ "context" .) | nindent 4 }}
   name: {{ $.Release.Name }}-matrix-authentication-service
   namespace: {{ $.Release.Namespace }}
 spec:
   parentRefs:
-    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "serviceName" "matrix-authentication-service" "HTTPRoute" .ingress.HTTPRoute)) | nindent 4 }}
+    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "component" . "serviceName" "matrix-authentication-service")) | nindent 4 }}
   hostnames:
-    - {{ (tpl .ingress.host $) | quote }}
+    - {{ (tpl .routes.host $) | quote }}
   rules:
     - matches:
       - path:
@@ -29,7 +29,7 @@ spec:
           port: 8080
           group: ""
           kind: Service
-    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .ingress)) "true" }}
+    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
     - matches:
       - path:
           type: PathPrefix

--- a/charts/matrix-stack/templates/matrix-authentication-service/httproute.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/httproute.yaml
@@ -5,7 +5,7 @@ Copyright 2026 Element Creations Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with .Values.matrixAuthenticationService -}}
-{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "HTTPRoute"))) "true" -}}
+{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "routes"))) "true" -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/matrix-stack/templates/matrix-authentication-service/ingress.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/ingress.yaml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 
 {{- with .Values.matrixAuthenticationService -}}
-{{- if .enabled -}}
+{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "Ingress"))) "true" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -17,7 +17,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
 {{- include "element-io.ess-library.ingress.tls" (dict "root" $ "context" (dict "ingress" .ingress "ingressName" "matrix-authentication-service")) | nindent 2 }}
-{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.className) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.Ingress.className) | nindent 2 }}
   rules:
   - host: {{ (tpl .ingress.host $) | quote }}
     http:

--- a/charts/matrix-stack/templates/matrix-authentication-service/ingress.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/ingress.yaml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 
 {{- with .Values.matrixAuthenticationService -}}
-{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "Ingress"))) "true" -}}
+{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "ingress"))) "true" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -17,7 +17,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
 {{- include "element-io.ess-library.ingress.tls" (dict "root" $ "context" (dict "ingress" .ingress "ingressName" "matrix-authentication-service")) | nindent 2 }}
-{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.Ingress.className) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.className) | nindent 2 }}
   rules:
   - host: {{ (tpl .ingress.host $) | quote }}
     http:

--- a/charts/matrix-stack/templates/matrix-rtc/_helpers.tpl
+++ b/charts/matrix-stack/templates/matrix-rtc/_helpers.tpl
@@ -9,8 +9,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- $root := .root -}}
 {{- with required "element-io.matrix-rtc.validations missing context" .context -}}
 {{ $messages := list }}
-{{- if not .ingress.host -}}
-{{ $messages = append $messages "matrixRTC.ingress.host is required when matrixRTC.enabled=true" }}
+{{- $trafficHandler := include "element-io.ess-library.inboundTrafficHandler.name" (dict "root" $root "context" (dict "component" .)) -}}
+{{- if and $trafficHandler (not (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)))) -}}
+{{ $messages = append $messages (printf "matrixRTC.%s.host is required when matrixRTC.enabled=true and inboundTrafficHandler is %s" $trafficHandler $trafficHandler) }}
 {{- end }}
 {{- if and .sfu.exposedServices.turnTLS.enabled .sfu.exposedServices.turnTLS.tlsTerminationOnPod (not .sfu.exposedServices.turnTLS.tlsSecret) (not $root.Values.certManager) -}}
 {{ $messages = append $messages "matrixRTC.sfu.exposedServices.turnTLS.enabled with tlsTerminationOnPod=true requires either .sfu.exposedServices.turnTLS.tlsSecret or certManager to be configured." }}
@@ -78,7 +79,7 @@ env:
         )) }}
 {{- if .sfu.enabled }}
 - name: "LIVEKIT_URL"
-  value: {{ printf "wss://%s" (tpl .ingress.host $root) }}
+  value: {{ printf "wss://%s" (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .))) }}
 {{- end }}
 - name: "LIVEKIT_FULL_ACCESS_HOMESERVERS"
 {{- if $root.Values.serverName }}

--- a/charts/matrix-stack/templates/matrix-rtc/httproute.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/httproute.yaml
@@ -1,0 +1,53 @@
+{{- /*
+SPDX-License-Identifier: AGPL-3.0-only
+*/ -}}
+{{- with .Values.matrixRTC -}}
+{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "HTTPRoute"))) "true" -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- $extraAnnotations := dict }}
+{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress "extraAnnotations" $extraAnnotations)) | nindent 2 }}
+  labels:
+    {{- include "element-io.matrix-rtc-ingress.labels" (dict "root" $ "context" .) | nindent 4 }}
+  name: {{ $.Release.Name }}-matrix-rtc
+  namespace: {{ $.Release.Namespace }}
+spec:
+  parentRefs:
+    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "serviceName" "matrix-rtc" "HTTPRoute" .ingress.HTTPRoute)) | nindent 4 }}
+  hostnames:
+    - {{ (tpl .ingress.host $) | quote }}
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /sfu/get
+      backendRefs:
+        - name: {{ $.Release.Name }}-matrix-rtc-authorisation-service
+          port: 8080
+          group: ""
+          kind: Service
+    {{- if .sfu.enabled }}
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      backendRefs:
+        - name: {{ $.Release.Name }}-matrix-rtc-sfu
+          port: 7880
+          group: ""
+          kind: Service
+    {{- end }}
+    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .ingress)) "true" }}
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      filters:
+      - requestRedirect:
+          scheme: https
+          statusCode: 301
+        type: RequestRedirect
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/matrix-stack/templates/matrix-rtc/httproute.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/httproute.yaml
@@ -1,4 +1,7 @@
 {{- /*
+Copyright 2026 New Vector Ltd
+Copyright 2026 Element Creations Ltd
+
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with .Values.matrixRTC -}}

--- a/charts/matrix-stack/templates/matrix-rtc/httproute.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/httproute.yaml
@@ -42,7 +42,7 @@ spec:
           kind: Service
     {{- end }}
 {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
-{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "matrix-rtc" "host" (tpl .routes.host $))) }}
+{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "matrix-rtc" "host" (tpl .routes.host $) "labels" (include "element-io.matrix-rtc-ingress.labels" (dict "root" $ "context" .)))) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-rtc/httproute.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/httproute.yaml
@@ -41,7 +41,7 @@ spec:
           group: ""
           kind: Service
     {{- end }}
-{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
+{{- if eq (include "element-io.ess-library.routes.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
 {{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "matrix-rtc" "host" (tpl .routes.host $) "labels" (include "element-io.matrix-rtc-ingress.labels" (dict "root" $ "context" .)))) }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-rtc/httproute.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/httproute.yaml
@@ -10,16 +10,16 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
 {{- $extraAnnotations := dict }}
-{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress "extraAnnotations" $extraAnnotations)) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .routes "extraAnnotations" $extraAnnotations)) | nindent 2 }}
   labels:
     {{- include "element-io.matrix-rtc-ingress.labels" (dict "root" $ "context" .) | nindent 4 }}
   name: {{ $.Release.Name }}-matrix-rtc
   namespace: {{ $.Release.Namespace }}
 spec:
   parentRefs:
-    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "serviceName" "matrix-rtc" "HTTPRoute" .ingress.HTTPRoute)) | nindent 4 }}
+    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "component" . "serviceName" "matrix-rtc")) | nindent 4 }}
   hostnames:
-    - {{ (tpl .ingress.host $) | quote }}
+    - {{ (tpl .routes.host $) | quote }}
   rules:
     - matches:
       - path:
@@ -41,7 +41,7 @@ spec:
           group: ""
           kind: Service
     {{- end }}
-    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .ingress)) "true" }}
+    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
     - matches:
       - path:
           type: PathPrefix

--- a/charts/matrix-stack/templates/matrix-rtc/httproute.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/httproute.yaml
@@ -5,7 +5,7 @@ Copyright 2026 Element Creations Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with .Values.matrixRTC -}}
-{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "HTTPRoute"))) "true" -}}
+{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "routes"))) "true" -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/matrix-stack/templates/matrix-rtc/httproute.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/httproute.yaml
@@ -1,5 +1,4 @@
 {{- /*
-Copyright 2026 New Vector Ltd
 Copyright 2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/charts/matrix-stack/templates/matrix-rtc/httproute.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/httproute.yaml
@@ -41,16 +41,8 @@ spec:
           group: ""
           kind: Service
     {{- end }}
-    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
-    - matches:
-      - path:
-          type: PathPrefix
-          value: /
-      filters:
-      - requestRedirect:
-          scheme: https
-          statusCode: 301
-        type: RequestRedirect
-    {{- end }}
+{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
+{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "matrix-rtc" "host" (tpl .routes.host $))) }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-rtc/ingress.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/ingress.yaml
@@ -5,13 +5,13 @@ Copyright 2025-2026 Element Creations Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with .Values.matrixRTC -}}
-{{- if .enabled -}}
+{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "Ingress"))) "true" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
 {{- $extraAnnotations := dict }}
 {{- if .sfu.enabled }}
-{{- if eq "ingress-nginx" (include "element-io.ess-library.ingress-controller-type" (dict "root" $ "context" .ingress.controllerType)) }}
+{{- if eq "ingress-nginx" (include "element-io.ess-library.ingress-controller-type" (dict "root" $ "context" .ingress.Ingress.controllerType)) }}
 {{- $_ := set $extraAnnotations "nginx.ingress.kubernetes.io/proxy-send-timeout" "120" }}
 {{- $_ := set $extraAnnotations "nginx.ingress.kubernetes.io/proxy-read-timeout" "120" }}
 {{- $_ := set $extraAnnotations "nginx.ingress.kubernetes.io/proxy-buffering" "off" }}
@@ -24,7 +24,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
 {{- include "element-io.ess-library.ingress.tls" (dict "root" $ "context" (dict "ingress" .ingress "ingressName" "matrix-rtc")) | nindent 2 }}
-{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.className) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.Ingress.className) | nindent 2 }}
   rules:
   - host: {{ (tpl .ingress.host $) | quote }}
     http:

--- a/charts/matrix-stack/templates/matrix-rtc/ingress.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/ingress.yaml
@@ -5,13 +5,13 @@ Copyright 2025-2026 Element Creations Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with .Values.matrixRTC -}}
-{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "Ingress"))) "true" -}}
+{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "ingress"))) "true" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
 {{- $extraAnnotations := dict }}
 {{- if .sfu.enabled }}
-{{- if eq "ingress-nginx" (include "element-io.ess-library.ingress-controller-type" (dict "root" $ "context" .ingress.Ingress.controllerType)) }}
+{{- if eq "ingress-nginx" (include "element-io.ess-library.ingress-controller-type" (dict "root" $ "context" .ingress.controllerType)) }}
 {{- $_ := set $extraAnnotations "nginx.ingress.kubernetes.io/proxy-send-timeout" "120" }}
 {{- $_ := set $extraAnnotations "nginx.ingress.kubernetes.io/proxy-read-timeout" "120" }}
 {{- $_ := set $extraAnnotations "nginx.ingress.kubernetes.io/proxy-buffering" "off" }}
@@ -24,7 +24,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
 {{- include "element-io.ess-library.ingress.tls" (dict "root" $ "context" (dict "ingress" .ingress "ingressName" "matrix-rtc")) | nindent 2 }}
-{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.Ingress.className) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.className) | nindent 2 }}
   rules:
   - host: {{ (tpl .ingress.host $) | quote }}
     http:

--- a/charts/matrix-stack/templates/synapse/_helpers.tpl
+++ b/charts/matrix-stack/templates/synapse/_helpers.tpl
@@ -108,6 +108,8 @@ env:
 
 {{- define "element-io.synapse.ingress.additionalPaths" -}}
 {{- $root := .root -}}
+{{- $ingress := $root.Values.synapse.ingress | default dict }}
+{{- $type := coalesce $ingress.type $root.Values.ingress.type }}
 {{- with required "element-io.synapse.ingress.additionalPaths missing context" .context -}}
 {{- if include "element-io.matrix-authentication-service.readyToHandleAuth" (dict "root" $root) }}
 {{- range $apiVersion := list "api/v1" "r0" "v3" "unstable" }}
@@ -118,6 +120,9 @@ env:
     name: "{{ $root.Release.Name }}-matrix-authentication-service"
     port:
       name: http
+      {{- if eq $type "HTTPRoute" }}
+      number: 8080
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -128,12 +133,18 @@ env:
     name: "{{ $root.Release.Name }}-hookshot"
     port:
       name: widgets
+      {{- if eq $type "HTTPRoute" }}
+      number: 7778
+      {{- end }}
 - path: "/_matrix/hookshot"
   availability: only_externally
   service:
     name: "{{ $root.Release.Name }}-hookshot"
     port:
       name: webhooks
+      {{- if eq $type "HTTPRoute" }}
+      number: 7775
+      {{- end }}
 {{- end -}}
 {{- range $root.Values.synapse.ingress.additionalPaths }}
 - {{ . | toYaml | indent 2 | trim }}

--- a/charts/matrix-stack/templates/synapse/_helpers.tpl
+++ b/charts/matrix-stack/templates/synapse/_helpers.tpl
@@ -9,8 +9,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{ $root := .root }}
 {{- with required "element-io.synapse.validations missing context" .context -}}
 {{ $messages := list }}
-{{- if not .ingress.host -}}
-{{ $messages = append $messages "synapse.ingress.host is required when synapse.enabled=true" }}
+{{- $trafficHandler := include "element-io.ess-library.inboundTrafficHandler.name" (dict "root" $root "context" (dict "component" .)) -}}
+{{- if and $trafficHandler (not (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" .)))) -}}
+{{ $messages = append $messages (printf "synapse.%s.host is required when synapse.enabled=true and inboundTrafficHandler is %s" $trafficHandler $trafficHandler) }}
 {{- end }}
 {{- if not $root.Values.serverName -}}
 {{ $messages = append $messages "serverName is required when synapse.enabled=true" }}

--- a/charts/matrix-stack/templates/synapse/_helpers.tpl
+++ b/charts/matrix-stack/templates/synapse/_helpers.tpl
@@ -129,8 +129,7 @@ env:
 
 {{- define "element-io.synapse.ingress.additionalPaths" -}}
 {{- $root := .root -}}
-{{- $ingress := $root.Values.synapse.ingress | default dict }}
-{{- $type := coalesce $ingress.type $root.Values.ingress.type }}
+{{- $type := include "element-io.ess-library.inboundTrafficHandler.name" (dict "root" $root "context" (dict "component" $root.Values.synapse)) }}
 {{- with required "element-io.synapse.ingress.additionalPaths missing context" .context -}}
 {{- if include "element-io.matrix-authentication-service.readyToHandleAuth" (dict "root" $root) }}
 {{- range $apiVersion := list "api/v1" "r0" "v3" "unstable" }}
@@ -141,20 +140,20 @@ env:
     name: "{{ $root.Release.Name }}-matrix-authentication-service"
     port:
       name: http
-      {{- if eq $type "HTTPRoute" }}
+      {{- if eq $type "routes" }}
       number: 8080
       {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if and $root.Values.hookshot.enabled (not $root.Values.hookshot.ingress.host) }}
+{{- if and $root.Values.hookshot.enabled (not (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" $root.Values.hookshot)))) }}
 - path: "/_matrix/hookshot/widgetapi/v1"
   availability: only_externally
   service:
     name: "{{ $root.Release.Name }}-hookshot"
     port:
       name: widgets
-      {{- if eq $type "HTTPRoute" }}
+      {{- if eq $type "routes" }}
       number: 7778
       {{- end }}
 - path: "/_matrix/hookshot"
@@ -163,7 +162,7 @@ env:
     name: "{{ $root.Release.Name }}-hookshot"
     port:
       name: webhooks
-      {{- if eq $type "HTTPRoute" }}
+      {{- if eq $type "routes" }}
       number: 7775
       {{- end }}
 {{- end -}}

--- a/charts/matrix-stack/templates/synapse/_helpers.tpl
+++ b/charts/matrix-stack/templates/synapse/_helpers.tpl
@@ -128,6 +128,8 @@ env:
 
 {{- define "element-io.synapse.ingress.additionalPaths" -}}
 {{- $root := .root -}}
+{{- $ingress := $root.Values.synapse.ingress | default dict }}
+{{- $type := coalesce $ingress.type $root.Values.ingress.type }}
 {{- with required "element-io.synapse.ingress.additionalPaths missing context" .context -}}
 {{- if include "element-io.matrix-authentication-service.readyToHandleAuth" (dict "root" $root) }}
 {{- range $apiVersion := list "api/v1" "r0" "v3" "unstable" }}
@@ -138,6 +140,9 @@ env:
     name: "{{ $root.Release.Name }}-matrix-authentication-service"
     port:
       name: http
+      {{- if eq $type "HTTPRoute" }}
+      number: 8080
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -148,12 +153,18 @@ env:
     name: "{{ $root.Release.Name }}-hookshot"
     port:
       name: widgets
+      {{- if eq $type "HTTPRoute" }}
+      number: 7778
+      {{- end }}
 - path: "/_matrix/hookshot"
   availability: only_externally
   service:
     name: "{{ $root.Release.Name }}-hookshot"
     port:
       name: webhooks
+      {{- if eq $type "HTTPRoute" }}
+      number: 7775
+      {{- end }}
 {{- end -}}
 {{- range $root.Values.synapse.ingress.additionalPaths }}
 - {{ . | toYaml | indent 2 | trim }}

--- a/charts/matrix-stack/templates/synapse/synapse_httproute.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_httproute.yaml
@@ -1,4 +1,7 @@
 {{- /*
+Copyright 2026 New Vector Ltd
+Copyright 2026 Element Creations Ltd
+
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with $.Values.synapse -}}

--- a/charts/matrix-stack/templates/synapse/synapse_httproute.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_httproute.yaml
@@ -1,0 +1,82 @@
+{{- /*
+SPDX-License-Identifier: AGPL-3.0-only
+*/ -}}
+{{- with $.Values.synapse -}}
+{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "HTTPRoute"))) "true" -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- $extraAnnotations := dict }}
+{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress "extraAnnotations" $extraAnnotations)) | nindent 2 }}
+  labels:
+    {{- include "element-io.synapse-ingress.labels" (dict "root" $ "context" $.Values.haproxy) | nindent 4 }}
+  name: {{ $.Release.Name }}-synapse
+  namespace: {{ $.Release.Namespace }}
+spec:
+  parentRefs:
+    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "serviceName" "synapse" "HTTPRoute" .ingress.HTTPRoute)) | nindent 4 }}
+  hostnames:
+    - {{ (tpl .ingress.host $) | quote }}
+  rules:
+{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .ingress)) "true" }}
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      filters:
+      - requestRedirect:
+          scheme: https
+          statusCode: 301
+        type: RequestRedirect
+{{- end }}
+{{- range (include "element-io.synapse.ingress.additionalPaths" (dict "root" $ "context" .)) | fromYamlArray -}}
+{{- if eq .availability "only_externally" }}
+    - matches:
+      - path:
+          type: PathPrefix
+          value: {{ .path }}
+      backendRefs:
+        - name: {{ (tpl .service.name $) | quote }}
+          port: {{ .service.port.number }}
+          group: ""
+          kind: Service
+{{- else if eq .availability "blocked" }}
+    - matches:
+      - path:
+          type: PathPrefix
+          value: {{ .path }}
+      backendRefs:
+        - name: "{{ $.Release.Name }}-synapse"
+          port: 8009
+          group: ""
+          kind: Service
+{{- end }}
+{{- end }}
+{{- range $synapsePath := (list "/_matrix" "/_synapse") -}}
+{{- /* Determine if this path is equal to, or a subset of, one of the
+   defined additional paths. If so, let the other service handle it and don't
+   add it here. */}}
+{{- $_pathAlreadyDefined := false }}
+{{- range (include "element-io.synapse.ingress.additionalPaths" (dict "root" $ "context" .)) | fromYamlArray -}}
+{{- if has .availability (list "only_externally" "blocked") }}
+{{- if hasPrefix .path $synapsePath }}
+{{- $_pathAlreadyDefined = true }}
+{{- end }}
+{{- end }}
+{{- end -}}
+{{- /* The path, or a superset of, has not already been defined in _additional_paths.
+   Define it here.*/}}
+{{- if not $_pathAlreadyDefined }}
+    - matches:
+      - path:
+          type: PathPrefix
+          value: {{ $synapsePath }}
+      backendRefs:
+        - name: "{{ $.Release.Name }}-synapse"
+          port: 8008
+          group: ""
+          kind: Service
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/matrix-stack/templates/synapse/synapse_httproute.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_httproute.yaml
@@ -5,7 +5,7 @@ Copyright 2026 Element Creations Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with $.Values.synapse -}}
-{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "HTTPRoute"))) "true" -}}
+{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "routes"))) "true" -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/matrix-stack/templates/synapse/synapse_httproute.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_httproute.yaml
@@ -71,7 +71,7 @@ spec:
 {{- end }}
 {{- end }}
 {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
-{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "synapse" "host" (tpl .routes.host $))) }}
+{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "synapse" "host" (tpl .routes.host $) "labels" (include "element-io.synapse-ingress.labels" (dict "root" $ "context" $.Values.haproxy)))) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/synapse_httproute.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_httproute.yaml
@@ -70,7 +70,7 @@ spec:
           kind: Service
 {{- end }}
 {{- end }}
-{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
+{{- if eq (include "element-io.ess-library.routes.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
 {{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "synapse" "host" (tpl .routes.host $) "labels" (include "element-io.synapse-ingress.labels" (dict "root" $ "context" $.Values.haproxy)))) }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/synapse_httproute.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_httproute.yaml
@@ -10,18 +10,18 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
 {{- $extraAnnotations := dict }}
-{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress "extraAnnotations" $extraAnnotations)) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .routes "extraAnnotations" $extraAnnotations)) | nindent 2 }}
   labels:
     {{- include "element-io.synapse-ingress.labels" (dict "root" $ "context" $.Values.haproxy) | nindent 4 }}
   name: {{ $.Release.Name }}-synapse
   namespace: {{ $.Release.Namespace }}
 spec:
   parentRefs:
-    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "serviceName" "synapse" "HTTPRoute" .ingress.HTTPRoute)) | nindent 4 }}
+    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "component" . "serviceName" "synapse")) | nindent 4 }}
   hostnames:
-    - {{ (tpl .ingress.host $) | quote }}
+    - {{ (tpl .routes.host $) | quote }}
   rules:
-{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .ingress)) "true" }}
+{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
     - matches:
       - path:
           type: PathPrefix

--- a/charts/matrix-stack/templates/synapse/synapse_httproute.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_httproute.yaml
@@ -1,5 +1,4 @@
 {{- /*
-Copyright 2026 New Vector Ltd
 Copyright 2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/charts/matrix-stack/templates/synapse/synapse_httproute.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_httproute.yaml
@@ -21,17 +21,6 @@ spec:
   hostnames:
     - {{ (tpl .routes.host $) | quote }}
   rules:
-{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
-    - matches:
-      - path:
-          type: PathPrefix
-          value: /
-      filters:
-      - requestRedirect:
-          scheme: https
-          statusCode: 301
-        type: RequestRedirect
-{{- end }}
 {{- range (include "element-io.synapse.ingress.additionalPaths" (dict "root" $ "context" .)) | fromYamlArray -}}
 {{- if eq .availability "only_externally" }}
     - matches:
@@ -80,6 +69,9 @@ spec:
           group: ""
           kind: Service
 {{- end }}
+{{- end }}
+{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
+{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "synapse" "host" (tpl .routes.host $))) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/synapse_ingress.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_ingress.yaml
@@ -6,22 +6,23 @@ SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 
 {{- with $.Values.synapse -}}
-{{- if .enabled -}}
+{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "Ingress"))) "true" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
 {{- $extraAnnotations := dict }}
-{{- if eq (include "element-io.ess-library.ingress-controller-type" (dict "root" $ "context" .ingress.controllerType)) "ingress-nginx" }}
+{{- if eq (include "element-io.ess-library.ingress-controller-type" (dict "root" $ "context" .ingress.Ingress.controllerType)) "ingress-nginx" }}
 {{- $_ := set $extraAnnotations "nginx.ingress.kubernetes.io/proxy-body-size" .media.maxUploadSize }}
 {{- end }}
 {{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress "extraAnnotations" $extraAnnotations)) | nindent 2 }}
+  test: {{ include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "Ingress")) }}
   labels:
     {{- include "element-io.synapse-ingress.labels" (dict "root" $ "context" $.Values.haproxy) | nindent 4 }}
   name: {{ $.Release.Name }}-synapse
   namespace: {{ $.Release.Namespace }}
 spec:
 {{- include "element-io.ess-library.ingress.tls" (dict "root" $ "context" (dict "ingress" .ingress "ingressName" "synapse")) | nindent 2 }}
-{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.className) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.Ingress.className) | nindent 2 }}
   rules:
   - host: {{ (tpl .ingress.host $) | quote }}
     http:

--- a/charts/matrix-stack/templates/synapse/synapse_ingress.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_ingress.yaml
@@ -15,7 +15,6 @@ metadata:
 {{- $_ := set $extraAnnotations "nginx.ingress.kubernetes.io/proxy-body-size" .media.maxUploadSize }}
 {{- end }}
 {{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress "extraAnnotations" $extraAnnotations)) | nindent 2 }}
-  test: {{- include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "ingress")) -}}
   labels:
     {{- include "element-io.synapse-ingress.labels" (dict "root" $ "context" $.Values.haproxy) | nindent 4 }}
   name: {{ $.Release.Name }}-synapse

--- a/charts/matrix-stack/templates/synapse/synapse_ingress.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_ingress.yaml
@@ -6,23 +6,23 @@ SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 
 {{- with $.Values.synapse -}}
-{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "Ingress"))) "true" -}}
+{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "ingress"))) "true" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
 {{- $extraAnnotations := dict }}
-{{- if eq (include "element-io.ess-library.ingress-controller-type" (dict "root" $ "context" .ingress.Ingress.controllerType)) "ingress-nginx" }}
+{{- if eq (include "element-io.ess-library.ingress-controller-type" (dict "root" $ "context" .ingress.controllerType)) "ingress-nginx" }}
 {{- $_ := set $extraAnnotations "nginx.ingress.kubernetes.io/proxy-body-size" .media.maxUploadSize }}
 {{- end }}
 {{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress "extraAnnotations" $extraAnnotations)) | nindent 2 }}
-  test: {{ include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "Ingress")) }}
+  test: {{- include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "ingress")) -}}
   labels:
     {{- include "element-io.synapse-ingress.labels" (dict "root" $ "context" $.Values.haproxy) | nindent 4 }}
   name: {{ $.Release.Name }}-synapse
   namespace: {{ $.Release.Namespace }}
 spec:
 {{- include "element-io.ess-library.ingress.tls" (dict "root" $ "context" (dict "ingress" .ingress "ingressName" "synapse")) | nindent 2 }}
-{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.Ingress.className) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.className) | nindent 2 }}
   rules:
   - host: {{ (tpl .ingress.host $) | quote }}
     http:

--- a/charts/matrix-stack/templates/synapse/synapse_service_monitor.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_service_monitor.yaml
@@ -23,7 +23,7 @@ spec:
     relabelings:
     - targetLabel: instance
       action: replace
-      replacement: {{ tpl .ingress.host $ }}
+      replacement: {{ include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $ "context" (dict "component" .)) }}
     - sourceLabels: [__meta_kubernetes_pod_name]
       targetLabel: index
       regex: '.*-([0-9]+)'

--- a/charts/matrix-stack/templates/well-known/_helpers.tpl
+++ b/charts/matrix-stack/templates/well-known/_helpers.tpl
@@ -93,3 +93,14 @@ support: |
   {{- (tpl (include "element-io.well-known-delegation.support" (dict "root" $root "context" .)) $root) | nindent 2 }}
 {{- end -}}
 {{- end -}}
+
+{{- define "element-io.well-known-delegation.httproute-path" -}}
+{{- $root := .root -}}
+{{- with required "element-io.well-known-delegation.httproute-path missing context" .context -}}
+{{- if and .enabled (or $root.Values.elementWeb.enabled .url) -}}
+/
+{{- else -}}
+/.well-known/matrix
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/matrix-stack/templates/well-known/_helpers.tpl
+++ b/charts/matrix-stack/templates/well-known/_helpers.tpl
@@ -56,13 +56,13 @@ k8s.element.io/target-instance: {{ $root.Release.Name }}-haproxy
 {{- with required "element-io.well-known-delegation.client missing context" .context -}}
 {{- $config := dict -}}
 {{- if $root.Values.synapse.enabled -}}
-{{- with required "WellKnownDelegation requires synapse.ingress.host set" $root.Values.synapse.ingress.host -}}
+{{- with required "WellKnownDelegation requires a host to be set for Synapse's active inbound traffic handler" (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" $root.Values.synapse))) -}}
 {{- $mHomeserver := dict "base_url" (printf "https://%s" .) -}}
 {{- $_ := set $config "m.homeserver" $mHomeserver -}}
 {{- end -}}
 {{- end -}}
 {{- if $root.Values.matrixRTC.enabled -}}
-{{- $_ := set $config "org.matrix.msc4143.rtc_foci" (list (dict "type" "livekit" "livekit_service_url" (printf "https://%s" $root.Values.matrixRTC.ingress.host))) -}}
+{{- $_ := set $config "org.matrix.msc4143.rtc_foci" (list (dict "type" "livekit" "livekit_service_url" (printf "https://%s" (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" $root.Values.matrixRTC)))))) -}}
 {{- end -}}
 {{- $additional := .additional.client | fromJson -}}
 {{- tpl (toPrettyJson (mustMergeOverwrite $additional $config)) $root -}}
@@ -74,7 +74,7 @@ k8s.element.io/target-instance: {{ $root.Release.Name }}-haproxy
 {{- with required "element-io.well-known-delegation.server missing context" .context -}}
 {{- $config := dict -}}
 {{- if $root.Values.synapse.enabled -}}
-{{- with required "WellKnownDelegation requires synapse.ingress.host set" $root.Values.synapse.ingress.host -}}
+{{- with required "WellKnownDelegation requires a host to be set for Synapse's active inbound traffic handler" (include "element-io.ess-library.inboundTrafficHandler.host" (dict "root" $root "context" (dict "component" $root.Values.synapse))) -}}
 {{- $_ := set $config "m.server" (printf "%s:443" .) -}}
 {{- end -}}
 {{- end -}}

--- a/charts/matrix-stack/templates/well-known/_helpers.tpl
+++ b/charts/matrix-stack/templates/well-known/_helpers.tpl
@@ -103,3 +103,14 @@ support: |
   {{- (tpl (include "element-io.well-known-delegation.support" (dict "root" $root "context" .)) $root) | nindent 2 }}
 {{- end -}}
 {{- end -}}
+
+{{- define "element-io.well-known-delegation.httproute-path" -}}
+{{- $root := .root -}}
+{{- with required "element-io.well-known-delegation.httproute-path missing context" .context -}}
+{{- if and .enabled (or $root.Values.elementWeb.enabled .url) -}}
+/
+{{- else -}}
+/.well-known/matrix
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/matrix-stack/templates/well-known/httproute.yaml
+++ b/charts/matrix-stack/templates/well-known/httproute.yaml
@@ -1,0 +1,41 @@
+{{- /*
+SPDX-License-Identifier: AGPL-3.0-only
+*/ -}}
+{{- with $.Values.wellKnownDelegation -}}
+{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "HTTPRoute"))) "true" -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress)) | nindent 2 }}
+  labels:
+    {{- include "element-io.well-known-delegation-ingress.labels" (dict "root" $ "context" $.Values.haproxy) | nindent 4 }}
+  name: {{ $.Release.Name }}-well-known
+  namespace: {{ $.Release.Namespace }}
+spec:
+  parentRefs:
+    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "serviceName" "well-known" "HTTPRoute" .ingress.HTTPRoute)) | nindent 4 }}
+  hostnames:
+    - {{ tpl $.Values.serverName $ }}
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: {{ include "element-io.well-known-delegation.httproute-path" (dict "root" $ "context" .baseDomainRedirect) }}
+      backendRefs:
+        - name: {{ $.Release.Name }}-well-known
+          port: 8010
+          group: ""
+          kind: Service
+    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .ingress)) "true" }}
+    - matches:
+      - path:
+          type: PathPrefix
+          value: {{ include "element-io.well-known-delegation.httproute-path" (dict "root" $ "context" .baseDomainRedirect) }}
+      filters:
+      - requestRedirect:
+          scheme: https
+          statusCode: 301
+        type: RequestRedirect
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/matrix-stack/templates/well-known/httproute.yaml
+++ b/charts/matrix-stack/templates/well-known/httproute.yaml
@@ -1,4 +1,7 @@
 {{- /*
+Copyright 2026 New Vector Ltd
+Copyright 2026 Element Creations Ltd
+
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with $.Values.wellKnownDelegation -}}

--- a/charts/matrix-stack/templates/well-known/httproute.yaml
+++ b/charts/matrix-stack/templates/well-known/httproute.yaml
@@ -29,16 +29,8 @@ spec:
           port: 8010
           group: ""
           kind: Service
-    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
-    - matches:
-      - path:
-          type: PathPrefix
-          value: {{ include "element-io.well-known-delegation.httproute-path" (dict "root" $ "context" .baseDomainRedirect) }}
-      filters:
-      - requestRedirect:
-          scheme: https
-          statusCode: 301
-        type: RequestRedirect
-    {{- end }}
+{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
+{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "well-known" "host" (tpl .routes.host $))) }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/well-known/httproute.yaml
+++ b/charts/matrix-stack/templates/well-known/httproute.yaml
@@ -30,7 +30,7 @@ spec:
           group: ""
           kind: Service
 {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
-{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "well-known" "host" (tpl .routes.host $))) }}
+{{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "well-known" "host" (tpl $.Values.serverName $) "path" (include "element-io.well-known-delegation.httproute-path" (dict "root" $ "context" .baseDomainRedirect)) "labels" (include "element-io.well-known-delegation-ingress.labels" (dict "root" $ "context" $.Values.haproxy)))) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/well-known/httproute.yaml
+++ b/charts/matrix-stack/templates/well-known/httproute.yaml
@@ -9,14 +9,14 @@ SPDX-License-Identifier: AGPL-3.0-only
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .ingress)) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.annotations" (dict "root" $ "context" (dict "ingress" .routes)) | nindent 2 }}
   labels:
     {{- include "element-io.well-known-delegation-ingress.labels" (dict "root" $ "context" $.Values.haproxy) | nindent 4 }}
   name: {{ $.Release.Name }}-well-known
   namespace: {{ $.Release.Namespace }}
 spec:
   parentRefs:
-    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "serviceName" "well-known" "HTTPRoute" .ingress.HTTPRoute)) | nindent 4 }}
+    {{- include "element-io.ess-library.ingress.parentRefs" (dict "root" $ "context" (dict "component" . "serviceName" "well-known")) | nindent 4 }}
   hostnames:
     - {{ tpl $.Values.serverName $ }}
   rules:
@@ -29,7 +29,7 @@ spec:
           port: 8010
           group: ""
           kind: Service
-    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .ingress)) "true" }}
+    {{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
     - matches:
       - path:
           type: PathPrefix

--- a/charts/matrix-stack/templates/well-known/httproute.yaml
+++ b/charts/matrix-stack/templates/well-known/httproute.yaml
@@ -1,5 +1,4 @@
 {{- /*
-Copyright 2026 New Vector Ltd
 Copyright 2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/charts/matrix-stack/templates/well-known/httproute.yaml
+++ b/charts/matrix-stack/templates/well-known/httproute.yaml
@@ -5,7 +5,7 @@ Copyright 2026 Element Creations Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 {{- with $.Values.wellKnownDelegation -}}
-{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "HTTPRoute"))) "true" -}}
+{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "routes"))) "true" -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/matrix-stack/templates/well-known/httproute.yaml
+++ b/charts/matrix-stack/templates/well-known/httproute.yaml
@@ -29,7 +29,7 @@ spec:
           port: 8010
           group: ""
           kind: Service
-{{- if eq (include "element-io.ess-library.ingress.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
+{{- if eq (include "element-io.ess-library.routes.tls.isEnabled" (dict "root" $ "context" .routes)) "true" }}
 {{ include "element-io.ess-library.httpRedirectRoute" (dict "root" $ "context" (dict "component" . "serviceName" "well-known" "host" (tpl $.Values.serverName $) "path" (include "element-io.well-known-delegation.httproute-path" (dict "root" $ "context" .baseDomainRedirect)) "labels" (include "element-io.well-known-delegation-ingress.labels" (dict "root" $ "context" $.Values.haproxy)))) }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/well-known/ingress.yaml
+++ b/charts/matrix-stack/templates/well-known/ingress.yaml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 
 {{- with $.Values.wellKnownDelegation -}}
-{{- if .enabled -}}
+{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "Ingress"))) "true" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -17,7 +17,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
 {{- include "element-io.ess-library.ingress.tls" (dict "root" $ "context" (dict "host" $.Values.serverName "ingress" .ingress "ingressName" "well-known")) | nindent 2 }}
-{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.className) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.Ingress.className) | nindent 2 }}
   rules:
   - host: "{{ tpl $.Values.serverName $ }}"
     http:
@@ -32,7 +32,7 @@ spec:
               name: haproxy-wkd
 {{- else }}
       - path: /.well-known/matrix
-        pathType: {{ include "element-io.ess-library.ingress.ingress-nginx-dot-path-type" (dict "root" $ "context" .ingress.controllerType) }}
+        pathType: {{ include "element-io.ess-library.ingress.ingress-nginx-dot-path-type" (dict "root" $ "context" .ingress.Ingress.controllerType) }}
         backend:
           service:
             name: "{{ $.Release.Name }}-well-known"

--- a/charts/matrix-stack/templates/well-known/ingress.yaml
+++ b/charts/matrix-stack/templates/well-known/ingress.yaml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 
 {{- with $.Values.wellKnownDelegation -}}
-{{- if eq (include "element-io.ess-library.ingress.isEnabled" (dict "root" $ "context" (dict "ingress" .ingress "type" "Ingress"))) "true" -}}
+{{- if eq (include "element-io.ess-library.inboundTrafficHandler.isEnabled" (dict "root" $ "context" (dict "component" . "trafficHandler" "ingress"))) "true" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -17,7 +17,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
 {{- include "element-io.ess-library.ingress.tls" (dict "root" $ "context" (dict "host" $.Values.serverName "ingress" .ingress "ingressName" "well-known")) | nindent 2 }}
-{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.Ingress.className) | nindent 2 }}
+{{- include "element-io.ess-library.ingress.className" (dict "root" $ "context" .ingress.className) | nindent 2 }}
   rules:
   - host: "{{ tpl $.Values.serverName $ }}"
     http:
@@ -32,7 +32,7 @@ spec:
               name: haproxy-wkd
 {{- else }}
       - path: /.well-known/matrix
-        pathType: {{ include "element-io.ess-library.ingress.ingress-nginx-dot-path-type" (dict "root" $ "context" .ingress.Ingress.controllerType) }}
+        pathType: {{ include "element-io.ess-library.ingress.ingress-nginx-dot-path-type" (dict "root" $ "context" .ingress.controllerType) }}
         backend:
           service:
             name: "{{ $.Release.Name }}-well-known"

--- a/charts/matrix-stack/templates/z_validation/validation.txt
+++ b/charts/matrix-stack/templates/z_validation/validation.txt
@@ -51,6 +51,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- end }}
 {{- end }}
 
+{{- with $.Values.gateway }}
+{{- if and .create (not .className) }}
+{{- $messages = append $messages "gateway.className is required when gateway.create is true" }}
+{{- end }}
+{{- end }}
+
 {{- if gt (len $messages) 0 }}
 {{ fail (printf "\n- %s" ($messages | join "\n- " )) }}
 {{- end }}

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -230,25 +230,6 @@
           },
           "additionalProperties": false
         },
-        "gateway": {
-          "type": "object",
-          "properties": {
-            "create": {
-              "type": "boolean",
-              "default": false
-            },
-            "className": {
-              "type": "string"
-            },
-            "annotations": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            }
-          },
-          "additionalProperties": false
-        },
         "annotations": {
           "type": "object",
           "additionalProperties": {
@@ -450,6 +431,32 @@
         }
       },
       "additionalProperties": false
+    },
+    "gateway": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "inboundTrafficHandler": {
+      "type": "string",
+      "enum": [
+        "ingress",
+        "routes",
+        "none"
+      ]
     },
     "deploymentMarkers": {
       "$id": "file://deployment-markers",

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -161,27 +161,105 @@
     },
     "ingress": {
       "type": "object",
+      "required": [
+        "enabled",
+        "type"
+      ],
       "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "HTTPRoute",
+            "Ingress"
+          ],
+          "default": "Ingress"
+        },
+        "HTTPRoute": {
+          "type": "object",
+          "properties": {
+            "existingGateways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "minItems": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "Ingress": {
+          "type": "object",
+          "properties": {
+            "className": {
+              "type": "string"
+            },
+            "controllerType": {
+              "type": "string",
+              "enum": [
+                "ingress-nginx"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "gateway": {
+          "type": "object",
+          "properties": {
+            "create": {
+              "type": "boolean",
+              "default": false
+            },
+            "className": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
         "annotations": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           }
         },
-        "className": {
-          "type": "string"
-        },
         "tlsEnabled": {
           "type": "boolean"
         },
         "tlsSecret": {
           "type": "string"
-        },
-        "controllerType": {
-          "type": "string",
-          "enum": [
-            "ingress-nginx"
-          ]
         },
         "service": {
           "type": "object",
@@ -1480,6 +1558,67 @@
         "ingress": {
           "type": "object",
           "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "HTTPRoute",
+                "Ingress"
+              ]
+            },
+            "HTTPRoute": {
+              "type": "object",
+              "properties": {
+                "existingGateways": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "sectionName": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "Ingress": {
+              "type": "object",
+              "properties": {
+                "className": {
+                  "type": "string"
+                },
+                "controllerType": {
+                  "type": "string",
+                  "enum": [
+                    "ingress-nginx"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -1492,20 +1631,11 @@
             "host": {
               "type": "string"
             },
-            "className": {
-              "type": "string"
-            },
             "tlsEnabled": {
               "type": "boolean"
             },
             "tlsSecret": {
               "type": "string"
-            },
-            "controllerType": {
-              "type": "string",
-              "enum": [
-                "ingress-nginx"
-              ]
             },
             "service": {
               "type": "object",
@@ -3117,6 +3247,67 @@
         "ingress": {
           "type": "object",
           "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "HTTPRoute",
+                "Ingress"
+              ]
+            },
+            "HTTPRoute": {
+              "type": "object",
+              "properties": {
+                "existingGateways": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "sectionName": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "Ingress": {
+              "type": "object",
+              "properties": {
+                "className": {
+                  "type": "string"
+                },
+                "controllerType": {
+                  "type": "string",
+                  "enum": [
+                    "ingress-nginx"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -3129,20 +3320,11 @@
             "host": {
               "type": "string"
             },
-            "className": {
-              "type": "string"
-            },
             "tlsEnabled": {
               "type": "boolean"
             },
             "tlsSecret": {
               "type": "string"
-            },
-            "controllerType": {
-              "type": "string",
-              "enum": [
-                "ingress-nginx"
-              ]
             },
             "service": {
               "type": "object",
@@ -3895,6 +4077,67 @@
         "ingress": {
           "type": "object",
           "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "HTTPRoute",
+                "Ingress"
+              ]
+            },
+            "HTTPRoute": {
+              "type": "object",
+              "properties": {
+                "existingGateways": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "sectionName": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "Ingress": {
+              "type": "object",
+              "properties": {
+                "className": {
+                  "type": "string"
+                },
+                "controllerType": {
+                  "type": "string",
+                  "enum": [
+                    "ingress-nginx"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -3907,20 +4150,11 @@
             "host": {
               "type": "string"
             },
-            "className": {
-              "type": "string"
-            },
             "tlsEnabled": {
               "type": "boolean"
             },
             "tlsSecret": {
               "type": "string"
-            },
-            "controllerType": {
-              "type": "string",
-              "enum": [
-                "ingress-nginx"
-              ]
             },
             "service": {
               "type": "object",
@@ -5220,6 +5454,67 @@
         "ingress": {
           "type": "object",
           "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "HTTPRoute",
+                "Ingress"
+              ]
+            },
+            "HTTPRoute": {
+              "type": "object",
+              "properties": {
+                "existingGateways": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "sectionName": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "Ingress": {
+              "type": "object",
+              "properties": {
+                "className": {
+                  "type": "string"
+                },
+                "controllerType": {
+                  "type": "string",
+                  "enum": [
+                    "ingress-nginx"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -5232,20 +5527,11 @@
             "host": {
               "type": "string"
             },
-            "className": {
-              "type": "string"
-            },
             "tlsEnabled": {
               "type": "boolean"
             },
             "tlsSecret": {
               "type": "string"
-            },
-            "controllerType": {
-              "type": "string",
-              "enum": [
-                "ingress-nginx"
-              ]
             },
             "service": {
               "type": "object",
@@ -6659,6 +6945,67 @@
         "ingress": {
           "type": "object",
           "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "HTTPRoute",
+                "Ingress"
+              ]
+            },
+            "HTTPRoute": {
+              "type": "object",
+              "properties": {
+                "existingGateways": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "sectionName": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "Ingress": {
+              "type": "object",
+              "properties": {
+                "className": {
+                  "type": "string"
+                },
+                "controllerType": {
+                  "type": "string",
+                  "enum": [
+                    "ingress-nginx"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -6671,20 +7018,11 @@
             "host": {
               "type": "string"
             },
-            "className": {
-              "type": "string"
-            },
             "tlsEnabled": {
               "type": "boolean"
             },
             "tlsSecret": {
               "type": "string"
-            },
-            "controllerType": {
-              "type": "string",
-              "enum": [
-                "ingress-nginx"
-              ]
             },
             "service": {
               "type": "object",
@@ -9411,6 +9749,67 @@
         "ingress": {
           "type": "object",
           "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "HTTPRoute",
+                "Ingress"
+              ]
+            },
+            "HTTPRoute": {
+              "type": "object",
+              "properties": {
+                "existingGateways": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "sectionName": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "Ingress": {
+              "type": "object",
+              "properties": {
+                "className": {
+                  "type": "string"
+                },
+                "controllerType": {
+                  "type": "string",
+                  "enum": [
+                    "ingress-nginx"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -9423,20 +9822,11 @@
             "host": {
               "type": "string"
             },
-            "className": {
-              "type": "string"
-            },
             "tlsEnabled": {
               "type": "boolean"
             },
             "tlsSecret": {
               "type": "string"
-            },
-            "controllerType": {
-              "type": "string",
-              "enum": [
-                "ingress-nginx"
-              ]
             },
             "service": {
               "type": "object",
@@ -15202,6 +15592,67 @@
         "ingress": {
           "type": "object",
           "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "HTTPRoute",
+                "Ingress"
+              ]
+            },
+            "HTTPRoute": {
+              "type": "object",
+              "properties": {
+                "existingGateways": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "sectionName": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "Ingress": {
+              "type": "object",
+              "properties": {
+                "className": {
+                  "type": "string"
+                },
+                "controllerType": {
+                  "type": "string",
+                  "enum": [
+                    "ingress-nginx"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -15211,20 +15662,11 @@
                 ]
               }
             },
-            "className": {
-              "type": "string"
-            },
             "tlsEnabled": {
               "type": "boolean"
             },
             "tlsSecret": {
               "type": "string"
-            },
-            "controllerType": {
-              "type": "string",
-              "enum": [
-                "ingress-nginx"
-              ]
             },
             "service": {
               "type": "object",

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -161,74 +161,102 @@
     },
     "ingress": {
       "type": "object",
-      "required": [
-        "enabled",
-        "type"
-      ],
       "properties": {
-        "enabled": {
-          "type": "boolean",
-          "default": true
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
-        "type": {
+        "className": {
+          "type": "string"
+        },
+        "tlsEnabled": {
+          "type": "boolean"
+        },
+        "tlsSecret": {
+          "type": "string"
+        },
+        "controllerType": {
           "type": "string",
           "enum": [
-            "HTTPRoute",
-            "Ingress"
+            "ingress-nginx"
+          ]
+        },
+        "service": {
+          "type": "object",
+          "required": [
+            "type",
+            "internalTrafficPolicy"
           ],
-          "default": "Ingress"
-        },
-        "HTTPRoute": {
-          "type": "object",
           "properties": {
-            "existingGateways": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "namespace": {
-                    "type": "string"
-                  },
-                  "group": {
-                    "type": "string"
-                  },
-                  "kind": {
-                    "type": "string"
-                  },
-                  "sectionName": {
-                    "type": "string"
-                  },
-                  "port": {
-                    "type": "integer"
-                  }
-                },
-                "additionalProperties": false
-              },
-              "minItems": 1
-            }
-          },
-          "additionalProperties": false
-        },
-        "Ingress": {
-          "type": "object",
-          "properties": {
-            "className": {
-              "type": "string"
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             },
-            "controllerType": {
+            "type": {
               "type": "string",
               "enum": [
-                "ingress-nginx"
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer"
+              ]
+            },
+            "internalTrafficPolicy": {
+              "type": "string",
+              "enum": [
+                "Cluster",
+                "Local"
+              ]
+            },
+            "externalTrafficPolicy": {
+              "type": "string",
+              "enum": [
+                "Cluster",
+                "Local"
               ]
             }
           },
           "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "routes": {
+      "type": "object",
+      "properties": {
+        "existingGateways": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "namespace": {
+                "type": "string"
+              },
+              "group": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "sectionName": {
+                "type": "string"
+              },
+              "port": {
+                "type": "integer"
+              }
+            },
+            "additionalProperties": false
+          },
+          "minItems": 1
         },
         "annotations": {
           "type": "object",
@@ -1392,6 +1420,14 @@
           },
           "additionalProperties": false
         },
+        "inboundTrafficHandler": {
+          "type": "string",
+          "enum": [
+            "ingress",
+            "routes",
+            "none"
+          ]
+        },
         "replicas": {
           "type": "integer"
         },
@@ -1565,67 +1601,6 @@
         "ingress": {
           "type": "object",
           "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "HTTPRoute",
-                "Ingress"
-              ]
-            },
-            "HTTPRoute": {
-              "type": "object",
-              "properties": {
-                "existingGateways": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "name"
-                    ],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "type": "string"
-                      },
-                      "group": {
-                        "type": "string"
-                      },
-                      "kind": {
-                        "type": "string"
-                      },
-                      "sectionName": {
-                        "type": "string"
-                      },
-                      "port": {
-                        "type": "integer"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "additionalProperties": false
-            },
-            "Ingress": {
-              "type": "object",
-              "properties": {
-                "className": {
-                  "type": "string"
-                },
-                "controllerType": {
-                  "type": "string",
-                  "enum": [
-                    "ingress-nginx"
-                  ]
-                }
-              },
-              "additionalProperties": false
-            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -1637,6 +1612,110 @@
             },
             "host": {
               "type": "string"
+            },
+            "className": {
+              "type": "string"
+            },
+            "tlsEnabled": {
+              "type": "boolean"
+            },
+            "tlsSecret": {
+              "type": "string"
+            },
+            "controllerType": {
+              "type": "string",
+              "enum": [
+                "ingress-nginx"
+              ]
+            },
+            "service": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ClusterIP",
+                    "NodePort",
+                    "LoadBalancer"
+                  ]
+                },
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalIPs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "routes": {
+          "type": "object",
+          "properties": {
+            "existingGateways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "minItems": 1
+            },
+            "host": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             },
             "tlsEnabled": {
               "type": "boolean"
@@ -3176,6 +3255,14 @@
           "minimum": 1,
           "type": "integer"
         },
+        "inboundTrafficHandler": {
+          "type": "string",
+          "enum": [
+            "ingress",
+            "routes",
+            "none"
+          ]
+        },
         "image": {
           "type": "object",
           "required": [
@@ -3254,67 +3341,6 @@
         "ingress": {
           "type": "object",
           "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "HTTPRoute",
-                "Ingress"
-              ]
-            },
-            "HTTPRoute": {
-              "type": "object",
-              "properties": {
-                "existingGateways": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "name"
-                    ],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "type": "string"
-                      },
-                      "group": {
-                        "type": "string"
-                      },
-                      "kind": {
-                        "type": "string"
-                      },
-                      "sectionName": {
-                        "type": "string"
-                      },
-                      "port": {
-                        "type": "integer"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "additionalProperties": false
-            },
-            "Ingress": {
-              "type": "object",
-              "properties": {
-                "className": {
-                  "type": "string"
-                },
-                "controllerType": {
-                  "type": "string",
-                  "enum": [
-                    "ingress-nginx"
-                  ]
-                }
-              },
-              "additionalProperties": false
-            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -3326,6 +3352,110 @@
             },
             "host": {
               "type": "string"
+            },
+            "className": {
+              "type": "string"
+            },
+            "tlsEnabled": {
+              "type": "boolean"
+            },
+            "tlsSecret": {
+              "type": "string"
+            },
+            "controllerType": {
+              "type": "string",
+              "enum": [
+                "ingress-nginx"
+              ]
+            },
+            "service": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ClusterIP",
+                    "NodePort",
+                    "LoadBalancer"
+                  ]
+                },
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalIPs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "routes": {
+          "type": "object",
+          "properties": {
+            "existingGateways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "minItems": 1
+            },
+            "host": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             },
             "tlsEnabled": {
               "type": "boolean"
@@ -3933,6 +4063,14 @@
           "minimum": 1,
           "type": "integer"
         },
+        "inboundTrafficHandler": {
+          "type": "string",
+          "enum": [
+            "ingress",
+            "routes",
+            "none"
+          ]
+        },
         "extraVolumes": {
           "type": "array",
           "items": {
@@ -4084,67 +4222,6 @@
         "ingress": {
           "type": "object",
           "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "HTTPRoute",
-                "Ingress"
-              ]
-            },
-            "HTTPRoute": {
-              "type": "object",
-              "properties": {
-                "existingGateways": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "name"
-                    ],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "type": "string"
-                      },
-                      "group": {
-                        "type": "string"
-                      },
-                      "kind": {
-                        "type": "string"
-                      },
-                      "sectionName": {
-                        "type": "string"
-                      },
-                      "port": {
-                        "type": "integer"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "additionalProperties": false
-            },
-            "Ingress": {
-              "type": "object",
-              "properties": {
-                "className": {
-                  "type": "string"
-                },
-                "controllerType": {
-                  "type": "string",
-                  "enum": [
-                    "ingress-nginx"
-                  ]
-                }
-              },
-              "additionalProperties": false
-            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -4156,6 +4233,110 @@
             },
             "host": {
               "type": "string"
+            },
+            "className": {
+              "type": "string"
+            },
+            "tlsEnabled": {
+              "type": "boolean"
+            },
+            "tlsSecret": {
+              "type": "string"
+            },
+            "controllerType": {
+              "type": "string",
+              "enum": [
+                "ingress-nginx"
+              ]
+            },
+            "service": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ClusterIP",
+                    "NodePort",
+                    "LoadBalancer"
+                  ]
+                },
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalIPs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "routes": {
+          "type": "object",
+          "properties": {
+            "existingGateways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "minItems": 1
+            },
+            "host": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             },
             "tlsEnabled": {
               "type": "boolean"
@@ -5415,6 +5596,14 @@
           },
           "additionalProperties": false
         },
+        "inboundTrafficHandler": {
+          "type": "string",
+          "enum": [
+            "ingress",
+            "routes",
+            "none"
+          ]
+        },
         "additional": {
           "type": "object",
           "additionalProperties": {
@@ -5461,67 +5650,6 @@
         "ingress": {
           "type": "object",
           "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "HTTPRoute",
-                "Ingress"
-              ]
-            },
-            "HTTPRoute": {
-              "type": "object",
-              "properties": {
-                "existingGateways": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "name"
-                    ],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "type": "string"
-                      },
-                      "group": {
-                        "type": "string"
-                      },
-                      "kind": {
-                        "type": "string"
-                      },
-                      "sectionName": {
-                        "type": "string"
-                      },
-                      "port": {
-                        "type": "integer"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "additionalProperties": false
-            },
-            "Ingress": {
-              "type": "object",
-              "properties": {
-                "className": {
-                  "type": "string"
-                },
-                "controllerType": {
-                  "type": "string",
-                  "enum": [
-                    "ingress-nginx"
-                  ]
-                }
-              },
-              "additionalProperties": false
-            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -5533,6 +5661,110 @@
             },
             "host": {
               "type": "string"
+            },
+            "className": {
+              "type": "string"
+            },
+            "tlsEnabled": {
+              "type": "boolean"
+            },
+            "tlsSecret": {
+              "type": "string"
+            },
+            "controllerType": {
+              "type": "string",
+              "enum": [
+                "ingress-nginx"
+              ]
+            },
+            "service": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ClusterIP",
+                    "NodePort",
+                    "LoadBalancer"
+                  ]
+                },
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalIPs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "routes": {
+          "type": "object",
+          "properties": {
+            "existingGateways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "minItems": 1
+            },
+            "host": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             },
             "tlsEnabled": {
               "type": "boolean"
@@ -6949,70 +7181,17 @@
           },
           "additionalProperties": false
         },
+        "inboundTrafficHandler": {
+          "type": "string",
+          "enum": [
+            "ingress",
+            "routes",
+            "none"
+          ]
+        },
         "ingress": {
           "type": "object",
           "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "HTTPRoute",
-                "Ingress"
-              ]
-            },
-            "HTTPRoute": {
-              "type": "object",
-              "properties": {
-                "existingGateways": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "name"
-                    ],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "type": "string"
-                      },
-                      "group": {
-                        "type": "string"
-                      },
-                      "kind": {
-                        "type": "string"
-                      },
-                      "sectionName": {
-                        "type": "string"
-                      },
-                      "port": {
-                        "type": "integer"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "additionalProperties": false
-            },
-            "Ingress": {
-              "type": "object",
-              "properties": {
-                "className": {
-                  "type": "string"
-                },
-                "controllerType": {
-                  "type": "string",
-                  "enum": [
-                    "ingress-nginx"
-                  ]
-                }
-              },
-              "additionalProperties": false
-            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -7024,6 +7203,110 @@
             },
             "host": {
               "type": "string"
+            },
+            "className": {
+              "type": "string"
+            },
+            "tlsEnabled": {
+              "type": "boolean"
+            },
+            "tlsSecret": {
+              "type": "string"
+            },
+            "controllerType": {
+              "type": "string",
+              "enum": [
+                "ingress-nginx"
+              ]
+            },
+            "service": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ClusterIP",
+                    "NodePort",
+                    "LoadBalancer"
+                  ]
+                },
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalIPs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "routes": {
+          "type": "object",
+          "properties": {
+            "existingGateways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "minItems": 1
+            },
+            "host": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             },
             "tlsEnabled": {
               "type": "boolean"
@@ -9753,69 +10036,193 @@
             "type": "string"
           }
         },
+        "inboundTrafficHandler": {
+          "type": "string",
+          "enum": [
+            "ingress",
+            "routes",
+            "none"
+          ]
+        },
         "ingress": {
           "type": "object",
           "properties": {
-            "enabled": {
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "host": {
+              "type": "string"
+            },
+            "className": {
+              "type": "string"
+            },
+            "tlsEnabled": {
               "type": "boolean"
             },
-            "type": {
+            "tlsSecret": {
+              "type": "string"
+            },
+            "controllerType": {
               "type": "string",
               "enum": [
-                "HTTPRoute",
-                "Ingress"
+                "ingress-nginx"
               ]
             },
-            "HTTPRoute": {
+            "service": {
               "type": "object",
               "properties": {
-                "existingGateways": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ClusterIP",
+                    "NodePort",
+                    "LoadBalancer"
+                  ]
+                },
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalIPs": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "required": [
-                      "name"
-                    ],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "type": "string"
-                      },
-                      "group": {
-                        "type": "string"
-                      },
-                      "kind": {
-                        "type": "string"
-                      },
-                      "sectionName": {
-                        "type": "string"
-                      },
-                      "port": {
-                        "type": "integer"
-                      }
-                    },
-                    "additionalProperties": false
+                    "type": "string"
                   }
                 }
               },
               "additionalProperties": false
             },
-            "Ingress": {
-              "type": "object",
-              "properties": {
-                "className": {
-                  "type": "string"
+            "additionalPaths": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "path",
+                  "availability"
+                ],
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "availability": {
+                    "type": "string",
+                    "enum": [
+                      "internally_and_externally",
+                      "only_externally",
+                      "blocked"
+                    ]
+                  },
+                  "service": {
+                    "type": "object",
+                    "required": [
+                      "name",
+                      "port"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "object",
+                        "oneOf": [
+                          {
+                            "required": [
+                              "name"
+                            ],
+                            "not": {
+                              "required": [
+                                "number"
+                              ]
+                            }
+                          },
+                          {
+                            "required": [
+                              "number"
+                            ],
+                            "not": {
+                              "required": [
+                                "name"
+                              ]
+                            }
+                          }
+                        ],
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "number": {
+                            "type": "integer"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  }
                 },
-                "controllerType": {
-                  "type": "string",
-                  "enum": [
-                    "ingress-nginx"
-                  ]
-                }
-              },
-              "additionalProperties": false
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "routes": {
+          "type": "object",
+          "properties": {
+            "existingGateways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              }
             },
             "annotations": {
               "type": "object",
@@ -15596,70 +16003,17 @@
         "enabled": {
           "type": "boolean"
         },
+        "inboundTrafficHandler": {
+          "type": "string",
+          "enum": [
+            "ingress",
+            "routes",
+            "none"
+          ]
+        },
         "ingress": {
           "type": "object",
           "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "HTTPRoute",
-                "Ingress"
-              ]
-            },
-            "HTTPRoute": {
-              "type": "object",
-              "properties": {
-                "existingGateways": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "name"
-                    ],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "type": "string"
-                      },
-                      "group": {
-                        "type": "string"
-                      },
-                      "kind": {
-                        "type": "string"
-                      },
-                      "sectionName": {
-                        "type": "string"
-                      },
-                      "port": {
-                        "type": "integer"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "additionalProperties": false
-            },
-            "Ingress": {
-              "type": "object",
-              "properties": {
-                "className": {
-                  "type": "string"
-                },
-                "controllerType": {
-                  "type": "string",
-                  "enum": [
-                    "ingress-nginx"
-                  ]
-                }
-              },
-              "additionalProperties": false
-            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -15667,6 +16021,107 @@
                   "string",
                   "null"
                 ]
+              }
+            },
+            "className": {
+              "type": "string"
+            },
+            "tlsEnabled": {
+              "type": "boolean"
+            },
+            "tlsSecret": {
+              "type": "string"
+            },
+            "controllerType": {
+              "type": "string",
+              "enum": [
+                "ingress-nginx"
+              ]
+            },
+            "service": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ClusterIP",
+                    "NodePort",
+                    "LoadBalancer"
+                  ]
+                },
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalIPs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "routes": {
+          "type": "object",
+          "properties": {
+            "existingGateways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "minItems": 1
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
               }
             },
             "tlsEnabled": {

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -224,6 +224,22 @@
       },
       "additionalProperties": false
     },
+    "storage": {
+      "type": "object",
+      "properties": {
+        "storageClassName": {
+          "type": "string"
+        },
+        "resourcePolicy": {
+          "type": "string",
+          "enum": [
+            "keep",
+            "delete"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "routes": {
       "type": "object",
       "properties": {
@@ -307,22 +323,6 @@
             }
           },
           "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "storage": {
-      "type": "object",
-      "properties": {
-        "storageClassName": {
-          "type": "string"
-        },
-        "resourcePolicy": {
-          "type": "string",
-          "enum": [
-            "keep",
-            "delete"
-          ]
         }
       },
       "additionalProperties": false
@@ -1249,6 +1249,12 @@
         "annotations": {
           "type": "object",
           "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "listenFor": {
+          "type": "array",
+          "items": {
             "type": "string"
           }
         }

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -161,27 +161,105 @@
     },
     "ingress": {
       "type": "object",
+      "required": [
+        "enabled",
+        "type"
+      ],
       "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "HTTPRoute",
+            "Ingress"
+          ],
+          "default": "Ingress"
+        },
+        "HTTPRoute": {
+          "type": "object",
+          "properties": {
+            "existingGateways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "minItems": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "Ingress": {
+          "type": "object",
+          "properties": {
+            "className": {
+              "type": "string"
+            },
+            "controllerType": {
+              "type": "string",
+              "enum": [
+                "ingress-nginx"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "gateway": {
+          "type": "object",
+          "properties": {
+            "create": {
+              "type": "boolean",
+              "default": false
+            },
+            "className": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
         "annotations": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           }
         },
-        "className": {
-          "type": "string"
-        },
         "tlsEnabled": {
           "type": "boolean"
         },
         "tlsSecret": {
           "type": "string"
-        },
-        "controllerType": {
-          "type": "string",
-          "enum": [
-            "ingress-nginx"
-          ]
         },
         "service": {
           "type": "object",
@@ -3774,6 +3852,67 @@
         "ingress": {
           "type": "object",
           "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "HTTPRoute",
+                "Ingress"
+              ]
+            },
+            "HTTPRoute": {
+              "type": "object",
+              "properties": {
+                "existingGateways": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "sectionName": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "Ingress": {
+              "type": "object",
+              "properties": {
+                "className": {
+                  "type": "string"
+                },
+                "controllerType": {
+                  "type": "string",
+                  "enum": [
+                    "ingress-nginx"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -3786,20 +3925,11 @@
             "host": {
               "type": "string"
             },
-            "className": {
-              "type": "string"
-            },
             "tlsEnabled": {
               "type": "boolean"
             },
             "tlsSecret": {
               "type": "string"
-            },
-            "controllerType": {
-              "type": "string",
-              "enum": [
-                "ingress-nginx"
-              ]
             },
             "service": {
               "type": "object",
@@ -7256,6 +7386,67 @@
         "ingress": {
           "type": "object",
           "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "HTTPRoute",
+                "Ingress"
+              ]
+            },
+            "HTTPRoute": {
+              "type": "object",
+              "properties": {
+                "existingGateways": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "sectionName": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "Ingress": {
+              "type": "object",
+              "properties": {
+                "className": {
+                  "type": "string"
+                },
+                "controllerType": {
+                  "type": "string",
+                  "enum": [
+                    "ingress-nginx"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -7268,20 +7459,11 @@
             "host": {
               "type": "string"
             },
-            "className": {
-              "type": "string"
-            },
             "tlsEnabled": {
               "type": "boolean"
             },
             "tlsSecret": {
               "type": "string"
-            },
-            "controllerType": {
-              "type": "string",
-              "enum": [
-                "ingress-nginx"
-              ]
             },
             "service": {
               "type": "object",
@@ -8798,6 +8980,67 @@
         "ingress": {
           "type": "object",
           "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "HTTPRoute",
+                "Ingress"
+              ]
+            },
+            "HTTPRoute": {
+              "type": "object",
+              "properties": {
+                "existingGateways": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "sectionName": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "Ingress": {
+              "type": "object",
+              "properties": {
+                "className": {
+                  "type": "string"
+                },
+                "controllerType": {
+                  "type": "string",
+                  "enum": [
+                    "ingress-nginx"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -8810,20 +9053,11 @@
             "host": {
               "type": "string"
             },
-            "className": {
-              "type": "string"
-            },
             "tlsEnabled": {
               "type": "boolean"
             },
             "tlsSecret": {
               "type": "string"
-            },
-            "controllerType": {
-              "type": "string",
-              "enum": [
-                "ingress-nginx"
-              ]
             },
             "service": {
               "type": "object",
@@ -11878,6 +12112,67 @@
         "ingress": {
           "type": "object",
           "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "HTTPRoute",
+                "Ingress"
+              ]
+            },
+            "HTTPRoute": {
+              "type": "object",
+              "properties": {
+                "existingGateways": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "sectionName": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "Ingress": {
+              "type": "object",
+              "properties": {
+                "className": {
+                  "type": "string"
+                },
+                "controllerType": {
+                  "type": "string",
+                  "enum": [
+                    "ingress-nginx"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -11890,20 +12185,11 @@
             "host": {
               "type": "string"
             },
-            "className": {
-              "type": "string"
-            },
             "tlsEnabled": {
               "type": "boolean"
             },
             "tlsSecret": {
               "type": "string"
-            },
-            "controllerType": {
-              "type": "string",
-              "enum": [
-                "ingress-nginx"
-              ]
             },
             "service": {
               "type": "object",
@@ -15216,6 +15502,67 @@
         "ingress": {
           "type": "object",
           "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "HTTPRoute",
+                "Ingress"
+              ]
+            },
+            "HTTPRoute": {
+              "type": "object",
+              "properties": {
+                "existingGateways": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "sectionName": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "Ingress": {
+              "type": "object",
+              "properties": {
+                "className": {
+                  "type": "string"
+                },
+                "controllerType": {
+                  "type": "string",
+                  "enum": [
+                    "ingress-nginx"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -15228,20 +15575,11 @@
             "host": {
               "type": "string"
             },
-            "className": {
-              "type": "string"
-            },
             "tlsEnabled": {
               "type": "boolean"
             },
             "tlsSecret": {
               "type": "string"
-            },
-            "controllerType": {
-              "type": "string",
-              "enum": [
-                "ingress-nginx"
-              ]
             },
             "service": {
               "type": "object",
@@ -21428,6 +21766,67 @@
         "ingress": {
           "type": "object",
           "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "HTTPRoute",
+                "Ingress"
+              ]
+            },
+            "HTTPRoute": {
+              "type": "object",
+              "properties": {
+                "existingGateways": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "sectionName": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "Ingress": {
+              "type": "object",
+              "properties": {
+                "className": {
+                  "type": "string"
+                },
+                "controllerType": {
+                  "type": "string",
+                  "enum": [
+                    "ingress-nginx"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -21440,20 +21839,11 @@
             "host": {
               "type": "string"
             },
-            "className": {
-              "type": "string"
-            },
             "tlsEnabled": {
               "type": "boolean"
             },
             "tlsSecret": {
               "type": "string"
-            },
-            "controllerType": {
-              "type": "string",
-              "enum": [
-                "ingress-nginx"
-              ]
             },
             "service": {
               "type": "object",
@@ -28459,6 +28849,67 @@
         "ingress": {
           "type": "object",
           "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "HTTPRoute",
+                "Ingress"
+              ]
+            },
+            "HTTPRoute": {
+              "type": "object",
+              "properties": {
+                "existingGateways": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      },
+                      "group": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "sectionName": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "integer"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "Ingress": {
+              "type": "object",
+              "properties": {
+                "className": {
+                  "type": "string"
+                },
+                "controllerType": {
+                  "type": "string",
+                  "enum": [
+                    "ingress-nginx"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -28468,20 +28919,11 @@
                 ]
               }
             },
-            "className": {
-              "type": "string"
-            },
             "tlsEnabled": {
               "type": "boolean"
             },
             "tlsSecret": {
               "type": "string"
-            },
-            "controllerType": {
-              "type": "string",
-              "enum": [
-                "ingress-nginx"
-              ]
             },
             "service": {
               "type": "object",

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -161,74 +161,102 @@
     },
     "ingress": {
       "type": "object",
-      "required": [
-        "enabled",
-        "type"
-      ],
       "properties": {
-        "enabled": {
-          "type": "boolean",
-          "default": true
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
-        "type": {
+        "className": {
+          "type": "string"
+        },
+        "tlsEnabled": {
+          "type": "boolean"
+        },
+        "tlsSecret": {
+          "type": "string"
+        },
+        "controllerType": {
           "type": "string",
           "enum": [
-            "HTTPRoute",
-            "Ingress"
+            "ingress-nginx"
+          ]
+        },
+        "service": {
+          "type": "object",
+          "required": [
+            "type",
+            "internalTrafficPolicy"
           ],
-          "default": "Ingress"
-        },
-        "HTTPRoute": {
-          "type": "object",
           "properties": {
-            "existingGateways": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "namespace": {
-                    "type": "string"
-                  },
-                  "group": {
-                    "type": "string"
-                  },
-                  "kind": {
-                    "type": "string"
-                  },
-                  "sectionName": {
-                    "type": "string"
-                  },
-                  "port": {
-                    "type": "integer"
-                  }
-                },
-                "additionalProperties": false
-              },
-              "minItems": 1
-            }
-          },
-          "additionalProperties": false
-        },
-        "Ingress": {
-          "type": "object",
-          "properties": {
-            "className": {
-              "type": "string"
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             },
-            "controllerType": {
+            "type": {
               "type": "string",
               "enum": [
-                "ingress-nginx"
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer"
+              ]
+            },
+            "internalTrafficPolicy": {
+              "type": "string",
+              "enum": [
+                "Cluster",
+                "Local"
+              ]
+            },
+            "externalTrafficPolicy": {
+              "type": "string",
+              "enum": [
+                "Cluster",
+                "Local"
               ]
             }
           },
           "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "routes": {
+      "type": "object",
+      "properties": {
+        "existingGateways": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "namespace": {
+                "type": "string"
+              },
+              "group": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "sectionName": {
+                "type": "string"
+              },
+              "port": {
+                "type": "integer"
+              }
+            },
+            "additionalProperties": false
+          },
+          "minItems": 1
         },
         "annotations": {
           "type": "object",
@@ -3685,6 +3713,14 @@
           },
           "additionalProperties": false
         },
+        "inboundTrafficHandler": {
+          "type": "string",
+          "enum": [
+            "ingress",
+            "routes",
+            "none"
+          ]
+        },
         "replicas": {
           "minimum": 0,
           "type": "integer"
@@ -3859,67 +3895,6 @@
         "ingress": {
           "type": "object",
           "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "HTTPRoute",
-                "Ingress"
-              ]
-            },
-            "HTTPRoute": {
-              "type": "object",
-              "properties": {
-                "existingGateways": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "name"
-                    ],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "type": "string"
-                      },
-                      "group": {
-                        "type": "string"
-                      },
-                      "kind": {
-                        "type": "string"
-                      },
-                      "sectionName": {
-                        "type": "string"
-                      },
-                      "port": {
-                        "type": "integer"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "additionalProperties": false
-            },
-            "Ingress": {
-              "type": "object",
-              "properties": {
-                "className": {
-                  "type": "string"
-                },
-                "controllerType": {
-                  "type": "string",
-                  "enum": [
-                    "ingress-nginx"
-                  ]
-                }
-              },
-              "additionalProperties": false
-            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -3931,6 +3906,110 @@
             },
             "host": {
               "type": "string"
+            },
+            "className": {
+              "type": "string"
+            },
+            "tlsEnabled": {
+              "type": "boolean"
+            },
+            "tlsSecret": {
+              "type": "string"
+            },
+            "controllerType": {
+              "type": "string",
+              "enum": [
+                "ingress-nginx"
+              ]
+            },
+            "service": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ClusterIP",
+                    "NodePort",
+                    "LoadBalancer"
+                  ]
+                },
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalIPs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "routes": {
+          "type": "object",
+          "properties": {
+            "existingGateways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "minItems": 1
+            },
+            "host": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             },
             "tlsEnabled": {
               "type": "boolean"
@@ -7315,6 +7394,14 @@
           "minimum": 0,
           "type": "integer"
         },
+        "inboundTrafficHandler": {
+          "type": "string",
+          "enum": [
+            "ingress",
+            "routes",
+            "none"
+          ]
+        },
         "image": {
           "type": "object",
           "required": [
@@ -7393,67 +7480,6 @@
         "ingress": {
           "type": "object",
           "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "HTTPRoute",
-                "Ingress"
-              ]
-            },
-            "HTTPRoute": {
-              "type": "object",
-              "properties": {
-                "existingGateways": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "name"
-                    ],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "type": "string"
-                      },
-                      "group": {
-                        "type": "string"
-                      },
-                      "kind": {
-                        "type": "string"
-                      },
-                      "sectionName": {
-                        "type": "string"
-                      },
-                      "port": {
-                        "type": "integer"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "additionalProperties": false
-            },
-            "Ingress": {
-              "type": "object",
-              "properties": {
-                "className": {
-                  "type": "string"
-                },
-                "controllerType": {
-                  "type": "string",
-                  "enum": [
-                    "ingress-nginx"
-                  ]
-                }
-              },
-              "additionalProperties": false
-            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -7465,6 +7491,110 @@
             },
             "host": {
               "type": "string"
+            },
+            "className": {
+              "type": "string"
+            },
+            "tlsEnabled": {
+              "type": "boolean"
+            },
+            "tlsSecret": {
+              "type": "string"
+            },
+            "controllerType": {
+              "type": "string",
+              "enum": [
+                "ingress-nginx"
+              ]
+            },
+            "service": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ClusterIP",
+                    "NodePort",
+                    "LoadBalancer"
+                  ]
+                },
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalIPs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "routes": {
+          "type": "object",
+          "properties": {
+            "existingGateways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "minItems": 1
+            },
+            "host": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             },
             "tlsEnabled": {
               "type": "boolean"
@@ -8836,6 +8966,14 @@
           "minimum": 0,
           "type": "integer"
         },
+        "inboundTrafficHandler": {
+          "type": "string",
+          "enum": [
+            "ingress",
+            "routes",
+            "none"
+          ]
+        },
         "extraVolumes": {
           "type": "array",
           "items": {
@@ -8987,67 +9125,6 @@
         "ingress": {
           "type": "object",
           "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "HTTPRoute",
-                "Ingress"
-              ]
-            },
-            "HTTPRoute": {
-              "type": "object",
-              "properties": {
-                "existingGateways": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "name"
-                    ],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "type": "string"
-                      },
-                      "group": {
-                        "type": "string"
-                      },
-                      "kind": {
-                        "type": "string"
-                      },
-                      "sectionName": {
-                        "type": "string"
-                      },
-                      "port": {
-                        "type": "integer"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "additionalProperties": false
-            },
-            "Ingress": {
-              "type": "object",
-              "properties": {
-                "className": {
-                  "type": "string"
-                },
-                "controllerType": {
-                  "type": "string",
-                  "enum": [
-                    "ingress-nginx"
-                  ]
-                }
-              },
-              "additionalProperties": false
-            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -9059,6 +9136,110 @@
             },
             "host": {
               "type": "string"
+            },
+            "className": {
+              "type": "string"
+            },
+            "tlsEnabled": {
+              "type": "boolean"
+            },
+            "tlsSecret": {
+              "type": "string"
+            },
+            "controllerType": {
+              "type": "string",
+              "enum": [
+                "ingress-nginx"
+              ]
+            },
+            "service": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ClusterIP",
+                    "NodePort",
+                    "LoadBalancer"
+                  ]
+                },
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalIPs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "routes": {
+          "type": "object",
+          "properties": {
+            "existingGateways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "minItems": 1
+            },
+            "host": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             },
             "tlsEnabled": {
               "type": "boolean"
@@ -12073,6 +12254,14 @@
           },
           "additionalProperties": false
         },
+        "inboundTrafficHandler": {
+          "type": "string",
+          "enum": [
+            "ingress",
+            "routes",
+            "none"
+          ]
+        },
         "additional": {
           "type": "object",
           "additionalProperties": {
@@ -12119,67 +12308,6 @@
         "ingress": {
           "type": "object",
           "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "HTTPRoute",
-                "Ingress"
-              ]
-            },
-            "HTTPRoute": {
-              "type": "object",
-              "properties": {
-                "existingGateways": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "name"
-                    ],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "type": "string"
-                      },
-                      "group": {
-                        "type": "string"
-                      },
-                      "kind": {
-                        "type": "string"
-                      },
-                      "sectionName": {
-                        "type": "string"
-                      },
-                      "port": {
-                        "type": "integer"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "additionalProperties": false
-            },
-            "Ingress": {
-              "type": "object",
-              "properties": {
-                "className": {
-                  "type": "string"
-                },
-                "controllerType": {
-                  "type": "string",
-                  "enum": [
-                    "ingress-nginx"
-                  ]
-                }
-              },
-              "additionalProperties": false
-            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -12191,6 +12319,110 @@
             },
             "host": {
               "type": "string"
+            },
+            "className": {
+              "type": "string"
+            },
+            "tlsEnabled": {
+              "type": "boolean"
+            },
+            "tlsSecret": {
+              "type": "string"
+            },
+            "controllerType": {
+              "type": "string",
+              "enum": [
+                "ingress-nginx"
+              ]
+            },
+            "service": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ClusterIP",
+                    "NodePort",
+                    "LoadBalancer"
+                  ]
+                },
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalIPs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "routes": {
+          "type": "object",
+          "properties": {
+            "existingGateways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "minItems": 1
+            },
+            "host": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             },
             "tlsEnabled": {
               "type": "boolean"
@@ -15506,70 +15738,17 @@
           },
           "additionalProperties": false
         },
+        "inboundTrafficHandler": {
+          "type": "string",
+          "enum": [
+            "ingress",
+            "routes",
+            "none"
+          ]
+        },
         "ingress": {
           "type": "object",
           "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "HTTPRoute",
-                "Ingress"
-              ]
-            },
-            "HTTPRoute": {
-              "type": "object",
-              "properties": {
-                "existingGateways": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "name"
-                    ],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "type": "string"
-                      },
-                      "group": {
-                        "type": "string"
-                      },
-                      "kind": {
-                        "type": "string"
-                      },
-                      "sectionName": {
-                        "type": "string"
-                      },
-                      "port": {
-                        "type": "integer"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "additionalProperties": false
-            },
-            "Ingress": {
-              "type": "object",
-              "properties": {
-                "className": {
-                  "type": "string"
-                },
-                "controllerType": {
-                  "type": "string",
-                  "enum": [
-                    "ingress-nginx"
-                  ]
-                }
-              },
-              "additionalProperties": false
-            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -15581,6 +15760,110 @@
             },
             "host": {
               "type": "string"
+            },
+            "className": {
+              "type": "string"
+            },
+            "tlsEnabled": {
+              "type": "boolean"
+            },
+            "tlsSecret": {
+              "type": "string"
+            },
+            "controllerType": {
+              "type": "string",
+              "enum": [
+                "ingress-nginx"
+              ]
+            },
+            "service": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ClusterIP",
+                    "NodePort",
+                    "LoadBalancer"
+                  ]
+                },
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalIPs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "routes": {
+          "type": "object",
+          "properties": {
+            "existingGateways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "minItems": 1
+            },
+            "host": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             },
             "tlsEnabled": {
               "type": "boolean"
@@ -21770,69 +22053,193 @@
           "maximum": 1,
           "type": "integer"
         },
+        "inboundTrafficHandler": {
+          "type": "string",
+          "enum": [
+            "ingress",
+            "routes",
+            "none"
+          ]
+        },
         "ingress": {
           "type": "object",
           "properties": {
-            "enabled": {
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "host": {
+              "type": "string"
+            },
+            "className": {
+              "type": "string"
+            },
+            "tlsEnabled": {
               "type": "boolean"
             },
-            "type": {
+            "tlsSecret": {
+              "type": "string"
+            },
+            "controllerType": {
               "type": "string",
               "enum": [
-                "HTTPRoute",
-                "Ingress"
+                "ingress-nginx"
               ]
             },
-            "HTTPRoute": {
+            "service": {
               "type": "object",
               "properties": {
-                "existingGateways": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ClusterIP",
+                    "NodePort",
+                    "LoadBalancer"
+                  ]
+                },
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalIPs": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "required": [
-                      "name"
-                    ],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "type": "string"
-                      },
-                      "group": {
-                        "type": "string"
-                      },
-                      "kind": {
-                        "type": "string"
-                      },
-                      "sectionName": {
-                        "type": "string"
-                      },
-                      "port": {
-                        "type": "integer"
-                      }
-                    },
-                    "additionalProperties": false
+                    "type": "string"
                   }
                 }
               },
               "additionalProperties": false
             },
-            "Ingress": {
-              "type": "object",
-              "properties": {
-                "className": {
-                  "type": "string"
+            "additionalPaths": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "path",
+                  "availability"
+                ],
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "availability": {
+                    "type": "string",
+                    "enum": [
+                      "internally_and_externally",
+                      "only_externally",
+                      "blocked"
+                    ]
+                  },
+                  "service": {
+                    "type": "object",
+                    "required": [
+                      "name",
+                      "port"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "object",
+                        "oneOf": [
+                          {
+                            "required": [
+                              "name"
+                            ],
+                            "not": {
+                              "required": [
+                                "number"
+                              ]
+                            }
+                          },
+                          {
+                            "required": [
+                              "number"
+                            ],
+                            "not": {
+                              "required": [
+                                "name"
+                              ]
+                            }
+                          }
+                        ],
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "number": {
+                            "type": "integer"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  }
                 },
-                "controllerType": {
-                  "type": "string",
-                  "enum": [
-                    "ingress-nginx"
-                  ]
-                }
-              },
-              "additionalProperties": false
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "routes": {
+          "type": "object",
+          "properties": {
+            "existingGateways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              }
             },
             "annotations": {
               "type": "object",
@@ -28853,70 +29260,17 @@
         "enabled": {
           "type": "boolean"
         },
+        "inboundTrafficHandler": {
+          "type": "string",
+          "enum": [
+            "ingress",
+            "routes",
+            "none"
+          ]
+        },
         "ingress": {
           "type": "object",
           "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "HTTPRoute",
-                "Ingress"
-              ]
-            },
-            "HTTPRoute": {
-              "type": "object",
-              "properties": {
-                "existingGateways": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "name"
-                    ],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "type": "string"
-                      },
-                      "group": {
-                        "type": "string"
-                      },
-                      "kind": {
-                        "type": "string"
-                      },
-                      "sectionName": {
-                        "type": "string"
-                      },
-                      "port": {
-                        "type": "integer"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "additionalProperties": false
-            },
-            "Ingress": {
-              "type": "object",
-              "properties": {
-                "className": {
-                  "type": "string"
-                },
-                "controllerType": {
-                  "type": "string",
-                  "enum": [
-                    "ingress-nginx"
-                  ]
-                }
-              },
-              "additionalProperties": false
-            },
             "annotations": {
               "type": "object",
               "additionalProperties": {
@@ -28924,6 +29278,107 @@
                   "string",
                   "null"
                 ]
+              }
+            },
+            "className": {
+              "type": "string"
+            },
+            "tlsEnabled": {
+              "type": "boolean"
+            },
+            "tlsSecret": {
+              "type": "string"
+            },
+            "controllerType": {
+              "type": "string",
+              "enum": [
+                "ingress-nginx"
+              ]
+            },
+            "service": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ClusterIP",
+                    "NodePort",
+                    "LoadBalancer"
+                  ]
+                },
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "internalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalTrafficPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Cluster",
+                    "Local"
+                  ]
+                },
+                "externalIPs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "routes": {
+          "type": "object",
+          "properties": {
+            "existingGateways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "sectionName": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "minItems": 1
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
               }
             },
             "tlsEnabled": {

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -286,6 +286,9 @@
         "tlsSecret": {
           "type": "string"
         },
+        "disableHTTPRedirect": {
+          "type": "boolean"
+        },
         "service": {
           "type": "object",
           "required": [
@@ -4023,6 +4026,9 @@
             "tlsSecret": {
               "type": "string"
             },
+            "disableHTTPRedirect": {
+              "type": "boolean"
+            },
             "service": {
               "type": "object",
               "properties": {
@@ -7608,6 +7614,9 @@
             "tlsSecret": {
               "type": "string"
             },
+            "disableHTTPRedirect": {
+              "type": "boolean"
+            },
             "service": {
               "type": "object",
               "properties": {
@@ -9252,6 +9261,9 @@
             },
             "tlsSecret": {
               "type": "string"
+            },
+            "disableHTTPRedirect": {
+              "type": "boolean"
             },
             "service": {
               "type": "object",
@@ -12435,6 +12447,9 @@
             },
             "tlsSecret": {
               "type": "string"
+            },
+            "disableHTTPRedirect": {
+              "type": "boolean"
             },
             "service": {
               "type": "object",
@@ -15876,6 +15891,9 @@
             },
             "tlsSecret": {
               "type": "string"
+            },
+            "disableHTTPRedirect": {
+              "type": "boolean"
             },
             "service": {
               "type": "object",
@@ -22307,6 +22325,9 @@
                 }
               },
               "additionalProperties": false
+            },
+            "disableHTTPRedirect": {
+              "type": "boolean"
             },
             "additionalPaths": {
               "type": "array",
@@ -29392,6 +29413,9 @@
             },
             "tlsSecret": {
               "type": "string"
+            },
+            "disableHTTPRedirect": {
+              "type": "boolean"
             },
             "service": {
               "type": "object",

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -230,25 +230,6 @@
           },
           "additionalProperties": false
         },
-        "gateway": {
-          "type": "object",
-          "properties": {
-            "create": {
-              "type": "boolean",
-              "default": false
-            },
-            "className": {
-              "type": "string"
-            },
-            "annotations": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            }
-          },
-          "additionalProperties": false
-        },
         "annotations": {
           "type": "object",
           "additionalProperties": {
@@ -1227,6 +1208,32 @@
         }
       },
       "additionalProperties": false
+    },
+    "gateway": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "inboundTrafficHandler": {
+      "type": "string",
+      "enum": [
+        "ingress",
+        "routes",
+        "none"
+      ]
     },
     "deploymentMarkers": {
       "$id": "file://deployment-markers",

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -91,17 +91,6 @@ ingress:
     ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
     # existingGateways: {}
 
-  ## Configuration for the generated Gateway
-  gateway:
-    ## Should we generate a Gateway resource for the HTTPRoutes
-    create: false
-
-    ## Gateway controller class name to use
-    # className: ""
-
-    ## Additional annotations for the Gateway
-    annotations: {}
-
 ## Common image properties that are applied as defaults to all components.
 image:
   ## The pullPolicy to use for all images. This overrides the pullPolicy used by the templates
@@ -159,6 +148,20 @@ clusterDomain: "cluster.local."
 networking:
   ## Whether components should attempt to bind IPv4 (ipv4) /IPv6 (ipv6) / both (dual-stack)
   ipFamily: dual-stack
+
+## Gateway configuration options
+gateway:
+  ## Create a default gateway for all routes
+  create: false
+  
+  ## Set the gateway class to use. If not set it will use the cluster default
+  # className: ""
+
+  ## Additional annotations to add to the gateway resource
+  annotations: {}
+
+## Set the default inbound traffic handler type. Options are ingress | routes | none
+inboundTrafficHandler: ingress
 
 ## Components
 initSecrets:

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -53,11 +53,13 @@ labels: {}
 
 ## How all ingresses should be constructed by default, unless overridden
 ingress:
+  ## Should we generate any Ingress resources
+  enabled: true
+  ## What type of ingress resource should be used (Ingress, HTTPRoute)
+  type: Ingress
+
   ## Annotations to be added to all Ingresses. Will be merged with component specific Ingress annotations
   annotations: {}
-
-  ## What Ingress Class Name that should be used for all Ingresses by default
-  # className:
 
   ## Disable TLS configuration by setting it to false
   tlsEnabled: true
@@ -73,9 +75,32 @@ ingress:
     # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
     externalTrafficPolicy: Cluster
     internalTrafficPolicy: Cluster
-  ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-  ## This can be set to `ingress-nginx`.
-  # controllerType:
+
+  ## Ingress specific configuration
+  Ingress: {}
+    ## What Ingress Class Name that should be used for all Ingresses by default
+    # className:
+
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
+
+  ## HTTPRoute specific configuration
+  HTTPRoute: {}
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
+
+  ## Configuration for the generated Gateway
+  gateway:
+    ## Should we generate a Gateway resource for the HTTPRoutes
+    create: false
+
+    ## Gateway controller class name to use
+    # className: ""
+
+    ## Additional annotations for the Gateway
+    annotations: {}
 
 ## Common image properties that are applied as defaults to all components.
 image:
@@ -478,11 +503,13 @@ matrixRTC:
     ## What hostname should be used for this Ingress
     # host:
 
+    ## Should we generate this Ingress resource
+    enabled: true
+    ## What type of ingress resource should be used (Ingress, HTTPRoute)
+    type: Ingress
+
     ## Annotations to be added to this Ingress
     annotations: {}
-
-    ## What Ingress Class Name that should be used for this Ingress
-    # className:
 
     ## Disable TLS configuration by setting it to false
     tlsEnabled: true
@@ -500,9 +527,21 @@ matrixRTC:
     #   # External IPs addresses of this service.
     #   externalIPs: []
     service: {}
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+
+    ## Ingress specific configuration
+    Ingress: {}
+      ## What Ingress Class Name that should be used for this Ingress
+      # className:
+
+      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+      ## This can be set to `ingress-nginx`.
+      # controllerType:
+
+    ## HTTPRoute specific configuration
+    HTTPRoute: {}
+      ## List of existing Gateway parent refs to connect the routes to.
+      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+      # existingGateways: {}
   # Details of the image to be used
   image:
     ## The host and (optional) port of the container image registry for this component.
@@ -1145,11 +1184,13 @@ elementAdmin:
     ## What hostname should be used for this Ingress
     # host:
 
+    ## Should we generate this Ingress resource
+    enabled: true
+    ## What type of ingress resource should be used (Ingress, HTTPRoute)
+    type: Ingress
+
     ## Annotations to be added to this Ingress
     annotations: {}
-
-    ## What Ingress Class Name that should be used for this Ingress
-    # className:
 
     ## Disable TLS configuration by setting it to false
     tlsEnabled: true
@@ -1167,9 +1208,21 @@ elementAdmin:
     #   # External IPs addresses of this service.
     #   externalIPs: []
     service: {}
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+
+    ## Ingress specific configuration
+    Ingress: {}
+      ## What Ingress Class Name that should be used for this Ingress
+      # className:
+
+      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+      ## This can be set to `ingress-nginx`.
+      # controllerType:
+
+    ## HTTPRoute specific configuration
+    HTTPRoute: {}
+      ## List of existing Gateway parent refs to connect the routes to.
+      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+      # existingGateways: {}
   ## Labels to add to all manifest for this component
   labels: {}
   ## Defines the annotations to add to the workload
@@ -1407,11 +1460,13 @@ elementWeb:
     ## What hostname should be used for this Ingress
     # host:
 
+    ## Should we generate this Ingress resource
+    enabled: true
+    ## What type of ingress resource should be used (Ingress, HTTPRoute)
+    type: Ingress
+
     ## Annotations to be added to this Ingress
     annotations: {}
-
-    ## What Ingress Class Name that should be used for this Ingress
-    # className:
 
     ## Disable TLS configuration by setting it to false
     tlsEnabled: true
@@ -1429,9 +1484,21 @@ elementWeb:
     #   # External IPs addresses of this service.
     #   externalIPs: []
     service: {}
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+
+    ## Ingress specific configuration
+    Ingress: {}
+      ## What Ingress Class Name that should be used for this Ingress
+      # className:
+
+      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+      ## This can be set to `ingress-nginx`.
+      # controllerType:
+
+    ## HTTPRoute specific configuration
+    HTTPRoute: {}
+      ## List of existing Gateway parent refs to connect the routes to.
+      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+      # existingGateways: {}
   ## Labels to add to all manifest for this component
   labels: {}
   ## Defines the annotations to add to the workload
@@ -1952,11 +2019,13 @@ hookshot:
     ## What hostname should be used for this Ingress
     # host:
 
+    ## Should we generate this Ingress resource
+    enabled: true
+    ## What type of ingress resource should be used (Ingress, HTTPRoute)
+    type: Ingress
+
     ## Annotations to be added to this Ingress
     annotations: {}
-
-    ## What Ingress Class Name that should be used for this Ingress
-    # className:
 
     ## Disable TLS configuration by setting it to false
     tlsEnabled: true
@@ -1974,9 +2043,21 @@ hookshot:
     #   # External IPs addresses of this service.
     #   externalIPs: []
     service: {}
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+
+    ## Ingress specific configuration
+    Ingress: {}
+      ## What Ingress Class Name that should be used for this Ingress
+      # className:
+
+      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+      ## This can be set to `ingress-nginx`.
+      # controllerType:
+
+    ## HTTPRoute specific configuration
+    HTTPRoute: {}
+      ## List of existing Gateway parent refs to connect the routes to.
+      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+      # existingGateways: {}
 
   ## Additional configuration to provide to Hookshot.
   ## You can, if you whish, override it in the additional config.
@@ -2402,11 +2483,13 @@ matrixAuthenticationService:
     ## What hostname should be used for this Ingress
     # host:
 
+    ## Should we generate this Ingress resource
+    enabled: true
+    ## What type of ingress resource should be used (Ingress, HTTPRoute)
+    type: Ingress
+
     ## Annotations to be added to this Ingress
     annotations: {}
-
-    ## What Ingress Class Name that should be used for this Ingress
-    # className:
 
     ## Disable TLS configuration by setting it to false
     tlsEnabled: true
@@ -2424,9 +2507,21 @@ matrixAuthenticationService:
     #   # External IPs addresses of this service.
     #   externalIPs: []
     service: {}
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+
+    ## Ingress specific configuration
+    Ingress: {}
+      ## What Ingress Class Name that should be used for this Ingress
+      # className:
+
+      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+      ## This can be set to `ingress-nginx`.
+      # controllerType:
+
+    ## HTTPRoute specific configuration
+    HTTPRoute: {}
+      ## List of existing Gateway parent refs to connect the routes to.
+      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+      # existingGateways: {}
 
   ## Kubernetes resources to allocate to each instance.
   resources:
@@ -4947,11 +5042,13 @@ synapse:
     ## What hostname should be used for this Ingress
     # host:
 
+    ## Should we generate this Ingress resource
+    enabled: true
+    ## What type of ingress resource should be used (Ingress, HTTPRoute)
+    type: Ingress
+
     ## Annotations to be added to this Ingress
     annotations: {}
-
-    ## What Ingress Class Name that should be used for this Ingress
-    # className:
 
     ## Disable TLS configuration by setting it to false
     tlsEnabled: true
@@ -4969,9 +5066,21 @@ synapse:
     #   # External IPs addresses of this service.
     #   externalIPs: []
     service: {}
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+
+    ## Ingress specific configuration
+    Ingress: {}
+      ## What Ingress Class Name that should be used for this Ingress
+      # className:
+
+      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+      ## This can be set to `ingress-nginx`.
+      # controllerType:
+
+    ## HTTPRoute specific configuration
+    HTTPRoute: {}
+      ## List of existing Gateway parent refs to connect the routes to.
+      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+      # existingGateways: {}
   ## Labels to add to all manifest for this component
   labels: {}
   ## Defines the annotations to add to the workload
@@ -5186,11 +5295,13 @@ wellKnownDelegation:
     ## What hostname should be used for this Ingress
     # host:
 
+    ## Should we generate this Ingress resource
+    enabled: true
+    ## What type of ingress resource should be used (Ingress, HTTPRoute)
+    type: Ingress
+
     ## Annotations to be added to this Ingress
     annotations: {}
-
-    ## What Ingress Class Name that should be used for this Ingress
-    # className:
 
     ## Disable TLS configuration by setting it to false
     tlsEnabled: true
@@ -5208,9 +5319,21 @@ wellKnownDelegation:
     #   # External IPs addresses of this service.
     #   externalIPs: []
     service: {}
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+
+    ## Ingress specific configuration
+    Ingress: {}
+      ## What Ingress Class Name that should be used for this Ingress
+      # className:
+
+      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+      ## This can be set to `ingress-nginx`.
+      # controllerType:
+
+    ## HTTPRoute specific configuration
+    HTTPRoute: {}
+      ## List of existing Gateway parent refs to connect the routes to.
+      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+      # existingGateways: {}
 
   ## If ElementWeb is deployed, the base domain will redirect to it's ingress host by default
   ## If ElementWeb is not deployed or this is disabled, no base domain URL redirect will be set.

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -506,7 +506,7 @@ matrixRTC:
     ## Should we generate this Ingress resource
     enabled: true
     ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    type: Ingress
+    # type: Ingress
 
     ## Annotations to be added to this Ingress
     annotations: {}
@@ -1187,7 +1187,7 @@ elementAdmin:
     ## Should we generate this Ingress resource
     enabled: true
     ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    type: Ingress
+    # type: Ingress
 
     ## Annotations to be added to this Ingress
     annotations: {}
@@ -1463,7 +1463,7 @@ elementWeb:
     ## Should we generate this Ingress resource
     enabled: true
     ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    type: Ingress
+    # type: Ingress
 
     ## Annotations to be added to this Ingress
     annotations: {}
@@ -2022,7 +2022,7 @@ hookshot:
     ## Should we generate this Ingress resource
     enabled: true
     ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    type: Ingress
+    # type: Ingress
 
     ## Annotations to be added to this Ingress
     annotations: {}
@@ -2486,7 +2486,7 @@ matrixAuthenticationService:
     ## Should we generate this Ingress resource
     enabled: true
     ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    type: Ingress
+    # type: Ingress
 
     ## Annotations to be added to this Ingress
     annotations: {}
@@ -5045,7 +5045,7 @@ synapse:
     ## Should we generate this Ingress resource
     enabled: true
     ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    type: Ingress
+    # type: Ingress
 
     ## Annotations to be added to this Ingress
     annotations: {}
@@ -5298,7 +5298,7 @@ wellKnownDelegation:
     ## Should we generate this Ingress resource
     enabled: true
     ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    type: Ingress
+    # type: Ingress
 
     ## Annotations to be added to this Ingress
     annotations: {}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -53,11 +53,6 @@ labels: {}
 
 ## How all ingresses should be constructed by default, unless overridden
 ingress:
-  ## Should we generate any Ingress resources
-  enabled: true
-  ## What type of ingress resource should be used (Ingress, HTTPRoute)
-  type: Ingress
-
   ## Annotations to be added to all Ingresses. Will be merged with component specific Ingress annotations
   annotations: {}
 
@@ -76,20 +71,36 @@ ingress:
     externalTrafficPolicy: Cluster
     internalTrafficPolicy: Cluster
 
-  ## Ingress specific configuration
-  Ingress: {}
-    ## What Ingress Class Name that should be used for all Ingresses by default
-    # className:
+  ## What Ingress Class Name that should be used for all Ingresses by default
+  # className:
 
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+  ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+  ## This can be set to `ingress-nginx`.
+  # controllerType:
 
-  ## HTTPRoute specific configuration
-  HTTPRoute: {}
-    ## List of existing Gateway parent refs to connect the routes to.
-    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-    # existingGateways: {}
+## How all routes should be constructed by default, unless overridden
+routes:
+  ## Annotations to be added to all routes. Will be merged with component specific route annotations
+  annotations: {}
+
+  ## Disable TLS configuration by setting it to false
+  tlsEnabled: true
+
+  ## The name of the Secret containing the TLS certificate and the key that should be used for all routes by default
+  # tlsSecret:
+
+  ## How the Services behind all routes is constructed by default
+  service:
+    type: ClusterIP
+    ## Annotations to be added to all routes services. Will be merged with component specific route services annotations
+    annotations: {}
+    # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    externalTrafficPolicy: Cluster
+    internalTrafficPolicy: Cluster
+
+  ## List of existing Gateway parent refs to connect the routes to.
+  ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+  # existingGateways: {}
 
 ## Common image properties that are applied as defaults to all components.
 image:
@@ -506,11 +517,6 @@ matrixRTC:
     ## What hostname should be used for this Ingress
     # host:
 
-    ## Should we generate this Ingress resource
-    enabled: true
-    ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    # type: Ingress
-
     ## Annotations to be added to this Ingress
     annotations: {}
 
@@ -531,20 +537,40 @@ matrixRTC:
     #   externalIPs: []
     service: {}
 
-    ## Ingress specific configuration
-    Ingress: {}
-      ## What Ingress Class Name that should be used for this Ingress
-      # className:
+    ## What Ingress Class Name that should be used for this Ingress
+    # className:
 
-      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-      ## This can be set to `ingress-nginx`.
-      # controllerType:
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
+  ## How this component's routes should be constructed
+  routes:
+    ## What hostname should be used for this component
+    # host:
 
-    ## HTTPRoute specific configuration
-    HTTPRoute: {}
-      ## List of existing Gateway parent refs to connect the routes to.
-      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-      # existingGateways: {}
+    ## Annotations to be added to this route
+    annotations: {}
+
+    ## Disable TLS configuration by setting it to false
+    tlsEnabled: true
+
+    ## The name of the Secret containing the TLS certificate and the key that should be used for this route
+    # tlsSecret:
+
+    ## How the Service behind this route is constructed
+    # service:
+    #   type: ClusterIP
+    #   annotations: {}
+    #   # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    #   externalTrafficPolicy: Cluster
+    #   internalTrafficPolicy: Cluster
+    #   # External IPs addresses of this service.
+    #   externalIPs: []
+    service: {}
+
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
   # Details of the image to be used
   image:
     ## The host and (optional) port of the container image registry for this component.
@@ -1187,11 +1213,6 @@ elementAdmin:
     ## What hostname should be used for this Ingress
     # host:
 
-    ## Should we generate this Ingress resource
-    enabled: true
-    ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    # type: Ingress
-
     ## Annotations to be added to this Ingress
     annotations: {}
 
@@ -1212,20 +1233,40 @@ elementAdmin:
     #   externalIPs: []
     service: {}
 
-    ## Ingress specific configuration
-    Ingress: {}
-      ## What Ingress Class Name that should be used for this Ingress
-      # className:
+    ## What Ingress Class Name that should be used for this Ingress
+    # className:
 
-      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-      ## This can be set to `ingress-nginx`.
-      # controllerType:
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
+  ## How this component's routes should be constructed
+  routes:
+    ## What hostname should be used for this component
+    # host:
 
-    ## HTTPRoute specific configuration
-    HTTPRoute: {}
-      ## List of existing Gateway parent refs to connect the routes to.
-      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-      # existingGateways: {}
+    ## Annotations to be added to this route
+    annotations: {}
+
+    ## Disable TLS configuration by setting it to false
+    tlsEnabled: true
+
+    ## The name of the Secret containing the TLS certificate and the key that should be used for this route
+    # tlsSecret:
+
+    ## How the Service behind this route is constructed
+    # service:
+    #   type: ClusterIP
+    #   annotations: {}
+    #   # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    #   externalTrafficPolicy: Cluster
+    #   internalTrafficPolicy: Cluster
+    #   # External IPs addresses of this service.
+    #   externalIPs: []
+    service: {}
+
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
   ## Labels to add to all manifest for this component
   labels: {}
   ## Defines the annotations to add to the workload
@@ -1463,11 +1504,6 @@ elementWeb:
     ## What hostname should be used for this Ingress
     # host:
 
-    ## Should we generate this Ingress resource
-    enabled: true
-    ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    # type: Ingress
-
     ## Annotations to be added to this Ingress
     annotations: {}
 
@@ -1488,20 +1524,40 @@ elementWeb:
     #   externalIPs: []
     service: {}
 
-    ## Ingress specific configuration
-    Ingress: {}
-      ## What Ingress Class Name that should be used for this Ingress
-      # className:
+    ## What Ingress Class Name that should be used for this Ingress
+    # className:
 
-      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-      ## This can be set to `ingress-nginx`.
-      # controllerType:
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
+  ## How this component's routes should be constructed
+  routes:
+    ## What hostname should be used for this component
+    # host:
 
-    ## HTTPRoute specific configuration
-    HTTPRoute: {}
-      ## List of existing Gateway parent refs to connect the routes to.
-      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-      # existingGateways: {}
+    ## Annotations to be added to this route
+    annotations: {}
+
+    ## Disable TLS configuration by setting it to false
+    tlsEnabled: true
+
+    ## The name of the Secret containing the TLS certificate and the key that should be used for this route
+    # tlsSecret:
+
+    ## How the Service behind this route is constructed
+    # service:
+    #   type: ClusterIP
+    #   annotations: {}
+    #   # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    #   externalTrafficPolicy: Cluster
+    #   internalTrafficPolicy: Cluster
+    #   # External IPs addresses of this service.
+    #   externalIPs: []
+    service: {}
+
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
   ## Labels to add to all manifest for this component
   labels: {}
   ## Defines the annotations to add to the workload
@@ -2022,11 +2078,6 @@ hookshot:
     ## What hostname should be used for this Ingress
     # host:
 
-    ## Should we generate this Ingress resource
-    enabled: true
-    ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    # type: Ingress
-
     ## Annotations to be added to this Ingress
     annotations: {}
 
@@ -2047,20 +2098,41 @@ hookshot:
     #   externalIPs: []
     service: {}
 
-    ## Ingress specific configuration
-    Ingress: {}
-      ## What Ingress Class Name that should be used for this Ingress
-      # className:
+    ## What Ingress Class Name that should be used for this Ingress
+    # className:
 
-      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-      ## This can be set to `ingress-nginx`.
-      # controllerType:
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
 
-    ## HTTPRoute specific configuration
-    HTTPRoute: {}
-      ## List of existing Gateway parent refs to connect the routes to.
-      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-      # existingGateways: {}
+  ## How this component's routes should be constructed
+  routes:
+    ## What hostname should be used for this component
+    # host:
+
+    ## Annotations to be added to this route
+    annotations: {}
+
+    ## Disable TLS configuration by setting it to false
+    tlsEnabled: true
+
+    ## The name of the Secret containing the TLS certificate and the key that should be used for this route
+    # tlsSecret:
+
+    ## How the Service behind this route is constructed
+    # service:
+    #   type: ClusterIP
+    #   annotations: {}
+    #   # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    #   externalTrafficPolicy: Cluster
+    #   internalTrafficPolicy: Cluster
+    #   # External IPs addresses of this service.
+    #   externalIPs: []
+    service: {}
+
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
 
   ## Additional configuration to provide to Hookshot.
   ## You can, if you whish, override it in the additional config.
@@ -2486,11 +2558,6 @@ matrixAuthenticationService:
     ## What hostname should be used for this Ingress
     # host:
 
-    ## Should we generate this Ingress resource
-    enabled: true
-    ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    # type: Ingress
-
     ## Annotations to be added to this Ingress
     annotations: {}
 
@@ -2511,20 +2578,41 @@ matrixAuthenticationService:
     #   externalIPs: []
     service: {}
 
-    ## Ingress specific configuration
-    Ingress: {}
-      ## What Ingress Class Name that should be used for this Ingress
-      # className:
+    ## What Ingress Class Name that should be used for this Ingress
+    # className:
 
-      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-      ## This can be set to `ingress-nginx`.
-      # controllerType:
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
 
-    ## HTTPRoute specific configuration
-    HTTPRoute: {}
-      ## List of existing Gateway parent refs to connect the routes to.
-      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-      # existingGateways: {}
+  ## How this component's routes should be constructed
+  routes:
+    ## What hostname should be used for this component
+    # host:
+
+    ## Annotations to be added to this route
+    annotations: {}
+
+    ## Disable TLS configuration by setting it to false
+    tlsEnabled: true
+
+    ## The name of the Secret containing the TLS certificate and the key that should be used for this route
+    # tlsSecret:
+
+    ## How the Service behind this route is constructed
+    # service:
+    #   type: ClusterIP
+    #   annotations: {}
+    #   # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    #   externalTrafficPolicy: Cluster
+    #   internalTrafficPolicy: Cluster
+    #   # External IPs addresses of this service.
+    #   externalIPs: []
+    service: {}
+
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
 
   ## Kubernetes resources to allocate to each instance.
   resources:
@@ -5045,11 +5133,6 @@ synapse:
     ## What hostname should be used for this Ingress
     # host:
 
-    ## Should we generate this Ingress resource
-    enabled: true
-    ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    # type: Ingress
-
     ## Annotations to be added to this Ingress
     annotations: {}
 
@@ -5070,20 +5153,40 @@ synapse:
     #   externalIPs: []
     service: {}
 
-    ## Ingress specific configuration
-    Ingress: {}
-      ## What Ingress Class Name that should be used for this Ingress
-      # className:
+    ## What Ingress Class Name that should be used for this Ingress
+    # className:
 
-      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-      ## This can be set to `ingress-nginx`.
-      # controllerType:
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
+  ## How this component's routes should be constructed
+  routes:
+    ## What hostname should be used for this component
+    # host:
 
-    ## HTTPRoute specific configuration
-    HTTPRoute: {}
-      ## List of existing Gateway parent refs to connect the routes to.
-      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-      # existingGateways: {}
+    ## Annotations to be added to this route
+    annotations: {}
+
+    ## Disable TLS configuration by setting it to false
+    tlsEnabled: true
+
+    ## The name of the Secret containing the TLS certificate and the key that should be used for this route
+    # tlsSecret:
+
+    ## How the Service behind this route is constructed
+    # service:
+    #   type: ClusterIP
+    #   annotations: {}
+    #   # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    #   externalTrafficPolicy: Cluster
+    #   internalTrafficPolicy: Cluster
+    #   # External IPs addresses of this service.
+    #   externalIPs: []
+    service: {}
+
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
   ## Labels to add to all manifest for this component
   labels: {}
   ## Defines the annotations to add to the workload
@@ -5298,11 +5401,6 @@ wellKnownDelegation:
     ## What hostname should be used for this Ingress
     # host:
 
-    ## Should we generate this Ingress resource
-    enabled: true
-    ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    # type: Ingress
-
     ## Annotations to be added to this Ingress
     annotations: {}
 
@@ -5323,20 +5421,38 @@ wellKnownDelegation:
     #   externalIPs: []
     service: {}
 
-    ## Ingress specific configuration
-    Ingress: {}
-      ## What Ingress Class Name that should be used for this Ingress
-      # className:
+    ## What Ingress Class Name that should be used for this Ingress
+    # className:
 
-      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-      ## This can be set to `ingress-nginx`.
-      # controllerType:
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
 
-    ## HTTPRoute specific configuration
-    HTTPRoute: {}
-      ## List of existing Gateway parent refs to connect the routes to.
-      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-      # existingGateways: {}
+  ## How this component's routes should be constructed
+  routes:
+    ## Annotations to be added to this route
+    annotations: {}
+
+    ## Disable TLS configuration by setting it to false
+    tlsEnabled: true
+
+    ## The name of the Secret containing the TLS certificate and the key that should be used for this route
+    # tlsSecret:
+
+    ## How the Service behind this route is constructed
+    # service:
+    #   type: ClusterIP
+    #   annotations: {}
+    #   # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    #   externalTrafficPolicy: Cluster
+    #   internalTrafficPolicy: Cluster
+    #   # External IPs addresses of this service.
+    #   externalIPs: []
+    service: {}
+
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
 
   ## If ElementWeb is deployed, the base domain will redirect to it's ingress host by default
   ## If ElementWeb is not deployed or this is disabled, no base domain URL redirect will be set.

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -89,6 +89,9 @@ routes:
   ## The name of the Secret containing the TLS certificate and the key that should be used for all routes by default
   # tlsSecret:
 
+  ## Disable automatic HTTP redirect route generation by setting true
+  disableHTTPRedirect: false
+
   ## How the Services behind all routes is constructed by default
   service:
     type: ClusterIP
@@ -670,6 +673,9 @@ matrixRTC:
 
     ## The name of the Secret containing the TLS certificate and the key that should be used for this route
     # tlsSecret:
+
+    ## Disable automatic HTTP redirect route generation by setting true
+    disableHTTPRedirect: false
 
     ## How the Service behind this route is constructed
     # service:
@@ -1446,6 +1452,9 @@ elementAdmin:
     ## The name of the Secret containing the TLS certificate and the key that should be used for this route
     # tlsSecret:
 
+    ## Disable automatic HTTP redirect route generation by setting true
+    disableHTTPRedirect: false
+
     ## How the Service behind this route is constructed
     # service:
     #   type: ClusterIP
@@ -1762,6 +1771,9 @@ elementWeb:
 
     ## The name of the Secret containing the TLS certificate and the key that should be used for this route
     # tlsSecret:
+
+    ## Disable automatic HTTP redirect route generation by setting true
+    disableHTTPRedirect: false
 
     ## How the Service behind this route is constructed
     # service:
@@ -2401,6 +2413,9 @@ hookshot:
     ## The name of the Secret containing the TLS certificate and the key that should be used for this route
     # tlsSecret:
 
+    ## Disable automatic HTTP redirect route generation by setting true
+    disableHTTPRedirect: false
+
     ## How the Service behind this route is constructed
     # service:
     #   type: ClusterIP
@@ -2921,6 +2936,9 @@ matrixAuthenticationService:
 
     ## The name of the Secret containing the TLS certificate and the key that should be used for this route
     # tlsSecret:
+
+    ## Disable automatic HTTP redirect route generation by setting true
+    disableHTTPRedirect: false
 
     ## How the Service behind this route is constructed
     # service:
@@ -5876,6 +5894,9 @@ synapse:
     ## The name of the Secret containing the TLS certificate and the key that should be used for this route
     # tlsSecret:
 
+    ## Disable automatic HTTP redirect route generation by setting true
+    disableHTTPRedirect: false
+
     ## How the Service behind this route is constructed
     # service:
     #   type: ClusterIP
@@ -6175,6 +6196,9 @@ wellKnownDelegation:
 
     ## The name of the Secret containing the TLS certificate and the key that should be used for this route
     # tlsSecret:
+
+    ## Disable automatic HTTP redirect route generation by setting true
+    disableHTTPRedirect: false
 
     ## How the Service behind this route is constructed
     # service:

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -236,11 +236,14 @@ gateway:
   ## Create a default gateway for all routes
   create: false
   
-  ## Set the gateway class to use. If not set it will use the cluster default
+  ## Set the gateway class to use, required when create=true.
   # className: ""
 
   ## Additional annotations to add to the gateway resource
   annotations: {}
+
+  ## Override which services the generated gateway creates listeners for
+  # listenFor: []
 
 ## Set the default inbound traffic handler type. Options are ingress | routes | none
 inboundTrafficHandler: ingress

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -617,7 +617,7 @@ matrixRTC:
     ## Should we generate this Ingress resource
     enabled: true
     ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    type: Ingress
+    # type: Ingress
 
     ## Annotations to be added to this Ingress
     annotations: {}
@@ -1377,7 +1377,7 @@ elementAdmin:
     ## Should we generate this Ingress resource
     enabled: true
     ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    type: Ingress
+    # type: Ingress
 
     ## Annotations to be added to this Ingress
     annotations: {}
@@ -1679,7 +1679,7 @@ elementWeb:
     ## Should we generate this Ingress resource
     enabled: true
     ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    type: Ingress
+    # type: Ingress
 
     ## Annotations to be added to this Ingress
     annotations: {}
@@ -2301,7 +2301,7 @@ hookshot:
     ## Should we generate this Ingress resource
     enabled: true
     ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    type: Ingress
+    # type: Ingress
 
     ## Annotations to be added to this Ingress
     annotations: {}
@@ -2806,7 +2806,7 @@ matrixAuthenticationService:
     ## Should we generate this Ingress resource
     enabled: true
     ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    type: Ingress
+    # type: Ingress
 
     ## Annotations to be added to this Ingress
     annotations: {}
@@ -5745,7 +5745,7 @@ synapse:
     ## Should we generate this Ingress resource
     enabled: true
     ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    type: Ingress
+    # type: Ingress
 
     ## Annotations to be added to this Ingress
     annotations: {}
@@ -6032,7 +6032,7 @@ wellKnownDelegation:
     ## Should we generate this Ingress resource
     enabled: true
     ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    type: Ingress
+    # type: Ingress
 
     ## Annotations to be added to this Ingress
     annotations: {}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -53,11 +53,13 @@ labels: {}
 
 ## How all ingresses should be constructed by default, unless overridden
 ingress:
+  ## Should we generate any Ingress resources
+  enabled: true
+  ## What type of ingress resource should be used (Ingress, HTTPRoute)
+  type: Ingress
+
   ## Annotations to be added to all Ingresses. Will be merged with component specific Ingress annotations
   annotations: {}
-
-  ## What Ingress Class Name that should be used for all Ingresses by default
-  # className:
 
   ## Disable TLS configuration by setting it to false
   tlsEnabled: true
@@ -73,9 +75,32 @@ ingress:
     # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
     externalTrafficPolicy: Cluster
     internalTrafficPolicy: Cluster
-  ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-  ## This can be set to `ingress-nginx`.
-  # controllerType:
+
+  ## Ingress specific configuration
+  Ingress: {}
+    ## What Ingress Class Name that should be used for all Ingresses by default
+    # className:
+
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
+
+  ## HTTPRoute specific configuration
+  HTTPRoute: {}
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
+
+  ## Configuration for the generated Gateway
+  gateway:
+    ## Should we generate a Gateway resource for the HTTPRoutes
+    create: false
+
+    ## Gateway controller class name to use
+    # className: ""
+
+    ## Additional annotations for the Gateway
+    annotations: {}
 
 ## Common image properties that are applied as defaults to all components.
 image:
@@ -589,11 +614,13 @@ matrixRTC:
     ## What hostname should be used for this Ingress
     # host:
 
+    ## Should we generate this Ingress resource
+    enabled: true
+    ## What type of ingress resource should be used (Ingress, HTTPRoute)
+    type: Ingress
+
     ## Annotations to be added to this Ingress
     annotations: {}
-
-    ## What Ingress Class Name that should be used for this Ingress
-    # className:
 
     ## Disable TLS configuration by setting it to false
     tlsEnabled: true
@@ -611,9 +638,21 @@ matrixRTC:
     #   # External IPs addresses of this service.
     #   externalIPs: []
     service: {}
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+
+    ## Ingress specific configuration
+    Ingress: {}
+      ## What Ingress Class Name that should be used for this Ingress
+      # className:
+
+      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+      ## This can be set to `ingress-nginx`.
+      # controllerType:
+
+    ## HTTPRoute specific configuration
+    HTTPRoute: {}
+      ## List of existing Gateway parent refs to connect the routes to.
+      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+      # existingGateways: {}
   # Details of the image to be used
   image:
     ## The host and (optional) port of the container image registry for this component.
@@ -1335,11 +1374,13 @@ elementAdmin:
     ## What hostname should be used for this Ingress
     # host:
 
+    ## Should we generate this Ingress resource
+    enabled: true
+    ## What type of ingress resource should be used (Ingress, HTTPRoute)
+    type: Ingress
+
     ## Annotations to be added to this Ingress
     annotations: {}
-
-    ## What Ingress Class Name that should be used for this Ingress
-    # className:
 
     ## Disable TLS configuration by setting it to false
     tlsEnabled: true
@@ -1357,9 +1398,21 @@ elementAdmin:
     #   # External IPs addresses of this service.
     #   externalIPs: []
     service: {}
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+
+    ## Ingress specific configuration
+    Ingress: {}
+      ## What Ingress Class Name that should be used for this Ingress
+      # className:
+
+      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+      ## This can be set to `ingress-nginx`.
+      # controllerType:
+
+    ## HTTPRoute specific configuration
+    HTTPRoute: {}
+      ## List of existing Gateway parent refs to connect the routes to.
+      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+      # existingGateways: {}
   ## Labels to add to all manifest for this component
   labels: {}
   ## Defines the annotations to add to the workload
@@ -1623,11 +1676,13 @@ elementWeb:
     ## What hostname should be used for this Ingress
     # host:
 
+    ## Should we generate this Ingress resource
+    enabled: true
+    ## What type of ingress resource should be used (Ingress, HTTPRoute)
+    type: Ingress
+
     ## Annotations to be added to this Ingress
     annotations: {}
-
-    ## What Ingress Class Name that should be used for this Ingress
-    # className:
 
     ## Disable TLS configuration by setting it to false
     tlsEnabled: true
@@ -1645,9 +1700,21 @@ elementWeb:
     #   # External IPs addresses of this service.
     #   externalIPs: []
     service: {}
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+
+    ## Ingress specific configuration
+    Ingress: {}
+      ## What Ingress Class Name that should be used for this Ingress
+      # className:
+
+      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+      ## This can be set to `ingress-nginx`.
+      # controllerType:
+
+    ## HTTPRoute specific configuration
+    HTTPRoute: {}
+      ## List of existing Gateway parent refs to connect the routes to.
+      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+      # existingGateways: {}
   ## Labels to add to all manifest for this component
   labels: {}
   ## Defines the annotations to add to the workload
@@ -2231,11 +2298,13 @@ hookshot:
     ## What hostname should be used for this Ingress
     # host:
 
+    ## Should we generate this Ingress resource
+    enabled: true
+    ## What type of ingress resource should be used (Ingress, HTTPRoute)
+    type: Ingress
+
     ## Annotations to be added to this Ingress
     annotations: {}
-
-    ## What Ingress Class Name that should be used for this Ingress
-    # className:
 
     ## Disable TLS configuration by setting it to false
     tlsEnabled: true
@@ -2253,9 +2322,21 @@ hookshot:
     #   # External IPs addresses of this service.
     #   externalIPs: []
     service: {}
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+
+    ## Ingress specific configuration
+    Ingress: {}
+      ## What Ingress Class Name that should be used for this Ingress
+      # className:
+
+      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+      ## This can be set to `ingress-nginx`.
+      # controllerType:
+
+    ## HTTPRoute specific configuration
+    HTTPRoute: {}
+      ## List of existing Gateway parent refs to connect the routes to.
+      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+      # existingGateways: {}
 
   ## Additional configuration to provide to Hookshot.
   ## You can, if you whish, override it in the additional config.
@@ -2722,11 +2803,13 @@ matrixAuthenticationService:
     ## What hostname should be used for this Ingress
     # host:
 
+    ## Should we generate this Ingress resource
+    enabled: true
+    ## What type of ingress resource should be used (Ingress, HTTPRoute)
+    type: Ingress
+
     ## Annotations to be added to this Ingress
     annotations: {}
-
-    ## What Ingress Class Name that should be used for this Ingress
-    # className:
 
     ## Disable TLS configuration by setting it to false
     tlsEnabled: true
@@ -2744,9 +2827,21 @@ matrixAuthenticationService:
     #   # External IPs addresses of this service.
     #   externalIPs: []
     service: {}
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+
+    ## Ingress specific configuration
+    Ingress: {}
+      ## What Ingress Class Name that should be used for this Ingress
+      # className:
+
+      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+      ## This can be set to `ingress-nginx`.
+      # controllerType:
+
+    ## HTTPRoute specific configuration
+    HTTPRoute: {}
+      ## List of existing Gateway parent refs to connect the routes to.
+      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+      # existingGateways: {}
 
   ## Kubernetes resources to allocate to each instance.
   resources:
@@ -5647,11 +5742,13 @@ synapse:
     ## What hostname should be used for this Ingress
     # host:
 
+    ## Should we generate this Ingress resource
+    enabled: true
+    ## What type of ingress resource should be used (Ingress, HTTPRoute)
+    type: Ingress
+
     ## Annotations to be added to this Ingress
     annotations: {}
-
-    ## What Ingress Class Name that should be used for this Ingress
-    # className:
 
     ## Disable TLS configuration by setting it to false
     tlsEnabled: true
@@ -5669,9 +5766,21 @@ synapse:
     #   # External IPs addresses of this service.
     #   externalIPs: []
     service: {}
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+
+    ## Ingress specific configuration
+    Ingress: {}
+      ## What Ingress Class Name that should be used for this Ingress
+      # className:
+
+      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+      ## This can be set to `ingress-nginx`.
+      # controllerType:
+
+    ## HTTPRoute specific configuration
+    HTTPRoute: {}
+      ## List of existing Gateway parent refs to connect the routes to.
+      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+      # existingGateways: {}
   ## Labels to add to all manifest for this component
   labels: {}
   ## Defines the annotations to add to the workload
@@ -5920,11 +6029,13 @@ wellKnownDelegation:
     ## What hostname should be used for this Ingress
     # host:
 
+    ## Should we generate this Ingress resource
+    enabled: true
+    ## What type of ingress resource should be used (Ingress, HTTPRoute)
+    type: Ingress
+
     ## Annotations to be added to this Ingress
     annotations: {}
-
-    ## What Ingress Class Name that should be used for this Ingress
-    # className:
 
     ## Disable TLS configuration by setting it to false
     tlsEnabled: true
@@ -5942,9 +6053,21 @@ wellKnownDelegation:
     #   # External IPs addresses of this service.
     #   externalIPs: []
     service: {}
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+
+    ## Ingress specific configuration
+    Ingress: {}
+      ## What Ingress Class Name that should be used for this Ingress
+      # className:
+
+      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+      ## This can be set to `ingress-nginx`.
+      # controllerType:
+
+    ## HTTPRoute specific configuration
+    HTTPRoute: {}
+      ## List of existing Gateway parent refs to connect the routes to.
+      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+      # existingGateways: {}
 
   ## If ElementWeb is deployed, the base domain will redirect to it's ingress host by default
   ## If ElementWeb is not deployed or this is disabled, no base domain URL redirect will be set.

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -238,7 +238,7 @@ networking:
 gateway:
   ## Create a default gateway for all routes
   create: false
-  
+
   ## Set the gateway class to use, required when create=true.
   # className: ""
 

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -91,17 +91,6 @@ ingress:
     ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
     # existingGateways: {}
 
-  ## Configuration for the generated Gateway
-  gateway:
-    ## Should we generate a Gateway resource for the HTTPRoutes
-    create: false
-
-    ## Gateway controller class name to use
-    # className: ""
-
-    ## Additional annotations for the Gateway
-    annotations: {}
-
 ## Common image properties that are applied as defaults to all components.
 image:
   ## The pullPolicy to use for all images. This overrides the pullPolicy used by the templates
@@ -230,6 +219,20 @@ clusterDomain: "cluster.local."
 networking:
   ## Whether components should attempt to bind IPv4 (ipv4) /IPv6 (ipv6) / both (dual-stack)
   ipFamily: dual-stack
+
+## Gateway configuration options
+gateway:
+  ## Create a default gateway for all routes
+  create: false
+  
+  ## Set the gateway class to use. If not set it will use the cluster default
+  # className: ""
+
+  ## Additional annotations to add to the gateway resource
+  annotations: {}
+
+## Set the default inbound traffic handler type. Options are ingress | routes | none
+inboundTrafficHandler: ingress
 
 ## Components
 initSecrets:

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -53,11 +53,6 @@ labels: {}
 
 ## How all ingresses should be constructed by default, unless overridden
 ingress:
-  ## Should we generate any Ingress resources
-  enabled: true
-  ## What type of ingress resource should be used (Ingress, HTTPRoute)
-  type: Ingress
-
   ## Annotations to be added to all Ingresses. Will be merged with component specific Ingress annotations
   annotations: {}
 
@@ -76,20 +71,36 @@ ingress:
     externalTrafficPolicy: Cluster
     internalTrafficPolicy: Cluster
 
-  ## Ingress specific configuration
-  Ingress: {}
-    ## What Ingress Class Name that should be used for all Ingresses by default
-    # className:
+  ## What Ingress Class Name that should be used for all Ingresses by default
+  # className:
 
-    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-    ## This can be set to `ingress-nginx`.
-    # controllerType:
+  ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+  ## This can be set to `ingress-nginx`.
+  # controllerType:
 
-  ## HTTPRoute specific configuration
-  HTTPRoute: {}
-    ## List of existing Gateway parent refs to connect the routes to.
-    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-    # existingGateways: {}
+## How all routes should be constructed by default, unless overridden
+routes:
+  ## Annotations to be added to all routes. Will be merged with component specific route annotations
+  annotations: {}
+
+  ## Disable TLS configuration by setting it to false
+  tlsEnabled: true
+
+  ## The name of the Secret containing the TLS certificate and the key that should be used for all routes by default
+  # tlsSecret:
+
+  ## How the Services behind all routes is constructed by default
+  service:
+    type: ClusterIP
+    ## Annotations to be added to all routes services. Will be merged with component specific route services annotations
+    annotations: {}
+    # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    externalTrafficPolicy: Cluster
+    internalTrafficPolicy: Cluster
+
+  ## List of existing Gateway parent refs to connect the routes to.
+  ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+  # existingGateways: {}
 
 ## Common image properties that are applied as defaults to all components.
 image:
@@ -617,11 +628,6 @@ matrixRTC:
     ## What hostname should be used for this Ingress
     # host:
 
-    ## Should we generate this Ingress resource
-    enabled: true
-    ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    # type: Ingress
-
     ## Annotations to be added to this Ingress
     annotations: {}
 
@@ -642,20 +648,40 @@ matrixRTC:
     #   externalIPs: []
     service: {}
 
-    ## Ingress specific configuration
-    Ingress: {}
-      ## What Ingress Class Name that should be used for this Ingress
-      # className:
+    ## What Ingress Class Name that should be used for this Ingress
+    # className:
 
-      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-      ## This can be set to `ingress-nginx`.
-      # controllerType:
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
+  ## How this component's routes should be constructed
+  routes:
+    ## What hostname should be used for this component
+    # host:
 
-    ## HTTPRoute specific configuration
-    HTTPRoute: {}
-      ## List of existing Gateway parent refs to connect the routes to.
-      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-      # existingGateways: {}
+    ## Annotations to be added to this route
+    annotations: {}
+
+    ## Disable TLS configuration by setting it to false
+    tlsEnabled: true
+
+    ## The name of the Secret containing the TLS certificate and the key that should be used for this route
+    # tlsSecret:
+
+    ## How the Service behind this route is constructed
+    # service:
+    #   type: ClusterIP
+    #   annotations: {}
+    #   # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    #   externalTrafficPolicy: Cluster
+    #   internalTrafficPolicy: Cluster
+    #   # External IPs addresses of this service.
+    #   externalIPs: []
+    service: {}
+
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
   # Details of the image to be used
   image:
     ## The host and (optional) port of the container image registry for this component.
@@ -1377,11 +1403,6 @@ elementAdmin:
     ## What hostname should be used for this Ingress
     # host:
 
-    ## Should we generate this Ingress resource
-    enabled: true
-    ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    # type: Ingress
-
     ## Annotations to be added to this Ingress
     annotations: {}
 
@@ -1402,20 +1423,40 @@ elementAdmin:
     #   externalIPs: []
     service: {}
 
-    ## Ingress specific configuration
-    Ingress: {}
-      ## What Ingress Class Name that should be used for this Ingress
-      # className:
+    ## What Ingress Class Name that should be used for this Ingress
+    # className:
 
-      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-      ## This can be set to `ingress-nginx`.
-      # controllerType:
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
+  ## How this component's routes should be constructed
+  routes:
+    ## What hostname should be used for this component
+    # host:
 
-    ## HTTPRoute specific configuration
-    HTTPRoute: {}
-      ## List of existing Gateway parent refs to connect the routes to.
-      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-      # existingGateways: {}
+    ## Annotations to be added to this route
+    annotations: {}
+
+    ## Disable TLS configuration by setting it to false
+    tlsEnabled: true
+
+    ## The name of the Secret containing the TLS certificate and the key that should be used for this route
+    # tlsSecret:
+
+    ## How the Service behind this route is constructed
+    # service:
+    #   type: ClusterIP
+    #   annotations: {}
+    #   # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    #   externalTrafficPolicy: Cluster
+    #   internalTrafficPolicy: Cluster
+    #   # External IPs addresses of this service.
+    #   externalIPs: []
+    service: {}
+
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
   ## Labels to add to all manifest for this component
   labels: {}
   ## Defines the annotations to add to the workload
@@ -1679,11 +1720,6 @@ elementWeb:
     ## What hostname should be used for this Ingress
     # host:
 
-    ## Should we generate this Ingress resource
-    enabled: true
-    ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    # type: Ingress
-
     ## Annotations to be added to this Ingress
     annotations: {}
 
@@ -1704,20 +1740,40 @@ elementWeb:
     #   externalIPs: []
     service: {}
 
-    ## Ingress specific configuration
-    Ingress: {}
-      ## What Ingress Class Name that should be used for this Ingress
-      # className:
+    ## What Ingress Class Name that should be used for this Ingress
+    # className:
 
-      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-      ## This can be set to `ingress-nginx`.
-      # controllerType:
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
+  ## How this component's routes should be constructed
+  routes:
+    ## What hostname should be used for this component
+    # host:
 
-    ## HTTPRoute specific configuration
-    HTTPRoute: {}
-      ## List of existing Gateway parent refs to connect the routes to.
-      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-      # existingGateways: {}
+    ## Annotations to be added to this route
+    annotations: {}
+
+    ## Disable TLS configuration by setting it to false
+    tlsEnabled: true
+
+    ## The name of the Secret containing the TLS certificate and the key that should be used for this route
+    # tlsSecret:
+
+    ## How the Service behind this route is constructed
+    # service:
+    #   type: ClusterIP
+    #   annotations: {}
+    #   # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    #   externalTrafficPolicy: Cluster
+    #   internalTrafficPolicy: Cluster
+    #   # External IPs addresses of this service.
+    #   externalIPs: []
+    service: {}
+
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
   ## Labels to add to all manifest for this component
   labels: {}
   ## Defines the annotations to add to the workload
@@ -2301,11 +2357,6 @@ hookshot:
     ## What hostname should be used for this Ingress
     # host:
 
-    ## Should we generate this Ingress resource
-    enabled: true
-    ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    # type: Ingress
-
     ## Annotations to be added to this Ingress
     annotations: {}
 
@@ -2326,20 +2377,41 @@ hookshot:
     #   externalIPs: []
     service: {}
 
-    ## Ingress specific configuration
-    Ingress: {}
-      ## What Ingress Class Name that should be used for this Ingress
-      # className:
+    ## What Ingress Class Name that should be used for this Ingress
+    # className:
 
-      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-      ## This can be set to `ingress-nginx`.
-      # controllerType:
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
 
-    ## HTTPRoute specific configuration
-    HTTPRoute: {}
-      ## List of existing Gateway parent refs to connect the routes to.
-      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-      # existingGateways: {}
+  ## How this component's routes should be constructed
+  routes:
+    ## What hostname should be used for this component
+    # host:
+
+    ## Annotations to be added to this route
+    annotations: {}
+
+    ## Disable TLS configuration by setting it to false
+    tlsEnabled: true
+
+    ## The name of the Secret containing the TLS certificate and the key that should be used for this route
+    # tlsSecret:
+
+    ## How the Service behind this route is constructed
+    # service:
+    #   type: ClusterIP
+    #   annotations: {}
+    #   # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    #   externalTrafficPolicy: Cluster
+    #   internalTrafficPolicy: Cluster
+    #   # External IPs addresses of this service.
+    #   externalIPs: []
+    service: {}
+
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
 
   ## Additional configuration to provide to Hookshot.
   ## You can, if you whish, override it in the additional config.
@@ -2806,11 +2878,6 @@ matrixAuthenticationService:
     ## What hostname should be used for this Ingress
     # host:
 
-    ## Should we generate this Ingress resource
-    enabled: true
-    ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    # type: Ingress
-
     ## Annotations to be added to this Ingress
     annotations: {}
 
@@ -2831,20 +2898,41 @@ matrixAuthenticationService:
     #   externalIPs: []
     service: {}
 
-    ## Ingress specific configuration
-    Ingress: {}
-      ## What Ingress Class Name that should be used for this Ingress
-      # className:
+    ## What Ingress Class Name that should be used for this Ingress
+    # className:
 
-      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-      ## This can be set to `ingress-nginx`.
-      # controllerType:
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
 
-    ## HTTPRoute specific configuration
-    HTTPRoute: {}
-      ## List of existing Gateway parent refs to connect the routes to.
-      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-      # existingGateways: {}
+  ## How this component's routes should be constructed
+  routes:
+    ## What hostname should be used for this component
+    # host:
+
+    ## Annotations to be added to this route
+    annotations: {}
+
+    ## Disable TLS configuration by setting it to false
+    tlsEnabled: true
+
+    ## The name of the Secret containing the TLS certificate and the key that should be used for this route
+    # tlsSecret:
+
+    ## How the Service behind this route is constructed
+    # service:
+    #   type: ClusterIP
+    #   annotations: {}
+    #   # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    #   externalTrafficPolicy: Cluster
+    #   internalTrafficPolicy: Cluster
+    #   # External IPs addresses of this service.
+    #   externalIPs: []
+    service: {}
+
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
 
   ## Kubernetes resources to allocate to each instance.
   resources:
@@ -5745,11 +5833,6 @@ synapse:
     ## What hostname should be used for this Ingress
     # host:
 
-    ## Should we generate this Ingress resource
-    enabled: true
-    ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    # type: Ingress
-
     ## Annotations to be added to this Ingress
     annotations: {}
 
@@ -5770,20 +5853,40 @@ synapse:
     #   externalIPs: []
     service: {}
 
-    ## Ingress specific configuration
-    Ingress: {}
-      ## What Ingress Class Name that should be used for this Ingress
-      # className:
+    ## What Ingress Class Name that should be used for this Ingress
+    # className:
 
-      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-      ## This can be set to `ingress-nginx`.
-      # controllerType:
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
+  ## How this component's routes should be constructed
+  routes:
+    ## What hostname should be used for this component
+    # host:
 
-    ## HTTPRoute specific configuration
-    HTTPRoute: {}
-      ## List of existing Gateway parent refs to connect the routes to.
-      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-      # existingGateways: {}
+    ## Annotations to be added to this route
+    annotations: {}
+
+    ## Disable TLS configuration by setting it to false
+    tlsEnabled: true
+
+    ## The name of the Secret containing the TLS certificate and the key that should be used for this route
+    # tlsSecret:
+
+    ## How the Service behind this route is constructed
+    # service:
+    #   type: ClusterIP
+    #   annotations: {}
+    #   # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    #   externalTrafficPolicy: Cluster
+    #   internalTrafficPolicy: Cluster
+    #   # External IPs addresses of this service.
+    #   externalIPs: []
+    service: {}
+
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
   ## Labels to add to all manifest for this component
   labels: {}
   ## Defines the annotations to add to the workload
@@ -6032,11 +6135,6 @@ wellKnownDelegation:
     ## What hostname should be used for this Ingress
     # host:
 
-    ## Should we generate this Ingress resource
-    enabled: true
-    ## What type of ingress resource should be used (Ingress, HTTPRoute)
-    # type: Ingress
-
     ## Annotations to be added to this Ingress
     annotations: {}
 
@@ -6057,20 +6155,38 @@ wellKnownDelegation:
     #   externalIPs: []
     service: {}
 
-    ## Ingress specific configuration
-    Ingress: {}
-      ## What Ingress Class Name that should be used for this Ingress
-      # className:
+    ## What Ingress Class Name that should be used for this Ingress
+    # className:
 
-      ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
-      ## This can be set to `ingress-nginx`.
-      # controllerType:
+    ## If set, some tweaks will be applied automatically to ingresses based on the controller type here.
+    ## This can be set to `ingress-nginx`.
+    # controllerType:
 
-    ## HTTPRoute specific configuration
-    HTTPRoute: {}
-      ## List of existing Gateway parent refs to connect the routes to.
-      ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-      # existingGateways: {}
+  ## How this component's routes should be constructed
+  routes:
+    ## Annotations to be added to this route
+    annotations: {}
+
+    ## Disable TLS configuration by setting it to false
+    tlsEnabled: true
+
+    ## The name of the Secret containing the TLS certificate and the key that should be used for this route
+    # tlsSecret:
+
+    ## How the Service behind this route is constructed
+    # service:
+    #   type: ClusterIP
+    #   annotations: {}
+    #   # External traffic policy will be configured on services of type `NodePort` and `LoadBalancer`
+    #   externalTrafficPolicy: Cluster
+    #   internalTrafficPolicy: Cluster
+    #   # External IPs addresses of this service.
+    #   externalIPs: []
+    service: {}
+
+    ## List of existing Gateway parent refs to connect the routes to.
+    ## More info: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    # existingGateways: {}
 
   ## If ElementWeb is deployed, the base domain will redirect to it's ingress host by default
   ## If ElementWeb is not deployed or this is disabled, no base domain URL redirect will be set.

--- a/newsfragments/1050.added.md
+++ b/newsfragments/1050.added.md
@@ -1,0 +1,6 @@
+Add support for Kubernetes v1 Gateway spec as an alternative ingress handler.
+
+This can be enabled globally, or on each component by setting inboundTrafficProvider
+to "routes" (defaults to "ingress"). Gateway creation is managed via the global
+"gateway" key. Route configuration is managed via the new per-component/global
+"routes" section.

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -764,27 +764,8 @@ all_components_details = [
         makes_outbound_requests=False,
         has_workloads=False,
         values_file_path_overrides={
-        #    # Gateway do not have most of the generic paths
-        #    PropertyType.Affinity: ValuesFilePath.not_supported(),
-        #    PropertyType.ContainersSecurityContext: ValuesFilePath.not_supported(),
-        #    PropertyType.Env: ValuesFilePath.not_supported(),
-        #    PropertyType.Image: ValuesFilePath.not_supported(),
-        #    PropertyType.InitContainers: ValuesFilePath.not_supported(),
-        #    PropertyType.LivenessProbe: ValuesFilePath.not_supported(),
-        #    PropertyType.NodeSelector: ValuesFilePath.not_supported(),
-        #    PropertyType.PodSecurityContext: ValuesFilePath.not_supported(),
-        #    PropertyType.PriorityClassName: ValuesFilePath.not_supported(),
-        #    PropertyType.RuntimeClassName: ValuesFilePath.not_supported(),
-        #    PropertyType.SchedulerName: ValuesFilePath.not_supported(),
+            # Gateway do not have replicas
             PropertyType.Replicas: ValuesFilePath.not_supported(),
-        #    PropertyType.ReadinessProbe: ValuesFilePath.not_supported(),
-        #    PropertyType.Resources: ValuesFilePath.not_supported(),
-        #    PropertyType.StartupProbe: ValuesFilePath.not_supported(),
-        #    PropertyType.ServiceAccount: ValuesFilePath.not_supported(),
-        #    PropertyType.Tolerations: ValuesFilePath.not_supported(),
-        #    PropertyType.TopologySpreadConstraints: ValuesFilePath.not_supported(),
-        #    PropertyType.Volumes: ValuesFilePath.not_supported(),
-        #    PropertyType.VolumeMounts: ValuesFilePath.not_supported(),
         },
     ),
 ]

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -764,7 +764,7 @@ all_components_details = [
         makes_outbound_requests=False,
         has_workloads=False,
         values_file_path_overrides={
-            # Gateway do not have replicas
+            # Gateways do not have replicas
             PropertyType.Replicas: ValuesFilePath.not_supported(),
         },
     ),

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -755,6 +755,38 @@ all_components_details = [
         has_credentials=False,
         has_workloads=False,
     ),
+    ComponentDetails(
+        name="gateway",
+        has_additional_config=False,
+        has_credentials=False,
+        has_ingress=False,
+        is_shared_component=True,
+        makes_outbound_requests=False,
+        has_workloads=False,
+        values_file_path_overrides={
+        #    # Gateway do not have most of the generic paths
+        #    PropertyType.Affinity: ValuesFilePath.not_supported(),
+        #    PropertyType.ContainersSecurityContext: ValuesFilePath.not_supported(),
+        #    PropertyType.Env: ValuesFilePath.not_supported(),
+        #    PropertyType.Image: ValuesFilePath.not_supported(),
+        #    PropertyType.InitContainers: ValuesFilePath.not_supported(),
+        #    PropertyType.LivenessProbe: ValuesFilePath.not_supported(),
+        #    PropertyType.NodeSelector: ValuesFilePath.not_supported(),
+        #    PropertyType.PodSecurityContext: ValuesFilePath.not_supported(),
+        #    PropertyType.PriorityClassName: ValuesFilePath.not_supported(),
+        #    PropertyType.RuntimeClassName: ValuesFilePath.not_supported(),
+        #    PropertyType.SchedulerName: ValuesFilePath.not_supported(),
+            PropertyType.Replicas: ValuesFilePath.not_supported(),
+        #    PropertyType.ReadinessProbe: ValuesFilePath.not_supported(),
+        #    PropertyType.Resources: ValuesFilePath.not_supported(),
+        #    PropertyType.StartupProbe: ValuesFilePath.not_supported(),
+        #    PropertyType.ServiceAccount: ValuesFilePath.not_supported(),
+        #    PropertyType.Tolerations: ValuesFilePath.not_supported(),
+        #    PropertyType.TopologySpreadConstraints: ValuesFilePath.not_supported(),
+        #    PropertyType.Volumes: ValuesFilePath.not_supported(),
+        #    PropertyType.VolumeMounts: ValuesFilePath.not_supported(),
+        },
+    ),
 ]
 
 


### PR DESCRIPTION
This adds support for the Kubernetes v1 Gateway spec as an alternative to the traditional Ingress resources. This logic supports using Ingresses as they are now, using HTTPRoutes only, or a mix. HTTPRoutes can be connected to an existing gateway, or a new gateway can be generated for the user. I tried to unify the template logic and reuse existing code wherever possible. Currently using this in production on my home server, and I have run what tests I could figure out how to locally :slightly_smiling_face: 

A few key notes:
- The change does reorganize a few keys under the "ingress" config and is therefore technically a "breaking" change. I could restore these without affecting the HTTPRoute logic. Edit: I see you have deprication logic already so that is probably the way to handle any moving keys
- defaults to ingress resources
- Added an option to disable ingress altogether since I was writing the conditional logic anyway. This can be removed, but it is a common feature on Helm charts as an escape hatch for complex deployments.
- I have intentionally not handled routing SFU via TCP/UDP Routes in this PR. I can add them, but they have mixed support within gateway controllers, and this PR was already getting long as is.

As an outside contributor, how should I handle the copyright notices? I don't see a CLA, but all the files are currently copyrighted by Element.
I am not sure what test fragments you may want me to add, since I intentionally tried to make it pass without changing the minimum config.

Thanks for all the work making ess-comunity possible, and I look forward to your review!