### PR TITLE
Allow specification of more options to k3d

### DIFF
--- a/newsfragments/1064.internal.md
+++ b/newsfragments/1064.internal.md
@@ -1,0 +1,1 @@
+Allow passing of additional options when creating the `k3d` cluster.

--- a/tests/integration/fixtures/cluster.py
+++ b/tests/integration/fixtures/cluster.py
@@ -100,7 +100,8 @@ async def cluster():
     # Both these names must match what `setup_test_cluster.sh` would create
     this_cluster = PotentiallyExistingK3dCluster("ess-helm")
     this_cluster.create(
-        ClusterOptions(cluster_name="ess-helm", provider_config=Path(__file__).parent / Path("files/clusters/k3d.yml"))
+        ClusterOptions(cluster_name="ess-helm", provider_config=Path(__file__).parent / Path("files/clusters/k3d.yml")),
+        options=os.environ.get("K3D_EXTRA_OPTIONS", "").split(" "),
     )
 
     yield this_cluster


### PR DESCRIPTION
Allows me to do `K3D_EXTRA_OPTIONS='--volume=/dev/mapper:/dev/mapper'` locally to resolve https://k3d.io/stable/faq/faq/?h=kubelet#issues-with-btrfs