### PR TITLE
ci: retry setting up prometheus operator crds

### DIFF
--- a/.github/element-docs-words.txt
+++ b/.github/element-docs-words.txt
@@ -26,6 +26,7 @@ Muxed
 newsfragment
 newsfragments
 passthrough
+prometheus
 postgres
 PostgreSQL
 pytest

--- a/newsfragments/1072.internal.md
+++ b/newsfragments/1072.internal.md
@@ -1,0 +1,1 @@
+CI: Retry setting up prometheus operator CRDs to kill flakes.


### PR DESCRIPTION
In CI, during setup, k3d API can become a bit slow. This is causing Helm to fail to properly refresh the status of the resources its setting up we are going to early-kill the deployment of the prometheus-operator chart. We will retry 5 times, each time for a maximum of 60s. 

This should be reverted once https://github.com/helm/helm/issues/31824 is resolved.