### PR TITLE
Turn TLS: Retry on SSLEOFError

### DIFF
--- a/newsfragments/1073.internal.md
+++ b/newsfragments/1073.internal.md
@@ -1,0 +1,1 @@
+CI: Retry Turn TLS connectivity in case of unexpected EOF Errors.


### PR DESCRIPTION
This will hopefully make the test more reliable.