### PR TITLE
Turn TLS tests: open socket against 127.0.0.1

### DIFF
--- a/newsfragments/1074.internal.md
+++ b/newsfragments/1074.internal.md
@@ -1,0 +1,1 @@
+CI: Retry Turn TLS connectivity in case of unexpected EOF Errors.

--- a/tests/integration/test_element_call.py
+++ b/tests/integration/test_element_call.py
@@ -60,7 +60,7 @@ async def test_matrix_rtc_turn_tls(ingress_ready, generated_data: ESSData, ssl_c
 
     async def _assert_tls_socket():
         reader, writer = await asyncio.open_connection(
-            host=f"turn.{generated_data.server_name}",
+            host="127.0.0.1",
             port=31443,
             ssl=ssl_context,
             server_hostname=f"turn.{generated_data.server_name}",
@@ -78,5 +78,5 @@ async def test_matrix_rtc_turn_tls(ingress_ready, generated_data: ESSData, ssl_c
     # The TLS socket can somewhat expect to fail while the stack boots
     await async_retry_with_timeout(
         _assert_tls_socket,
-        should_retry=lambda e: type(e) is ssl.SSLEOFError,
+        should_retry=lambda e: type(e) in [ssl.SSLEOFError, ConnectionResetError],
     )


### PR DESCRIPTION
On some tests setup, the hostname cannot be resolved - this should rely on 127.0.0.1 directly instead. `server_hostname` will be used to verify the actual certificate.