### PR TITLE
pytest: log ingress_ready last exception if it still fails after 30s

### DIFF
--- a/newsfragments/1078.internal.md
+++ b/newsfragments/1078.internal.md
@@ -1,0 +1,1 @@
+CI: Log the last exception happening when waiting for an ingress to become ready.


### PR DESCRIPTION
We are seeing flakes in this area, but we do not have enough logs to figure out what's going on.

https://github.com/element-hq/ess-helm/actions/runs/22444354709/job/64994700885