### PR TITLE
Matrix RTC: Hardcode Turn ports in internal kubernetes traffic

### DIFF
--- a/charts/matrix-stack/configs/matrix-rtc/sfu/config-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/matrix-rtc/sfu/config-overrides.yaml.tpl
@@ -65,7 +65,11 @@ turn:
   enabled: true
 {{- with .exposedServices.turnTLS }}
 {{ if .enabled }}
+{{- if eq .portType "HostPort" }}
   tls_port: {{ .port }}
+{{- else }}
+  tls_port: 5349
+{{- end }}
   domain: {{ tpl .domain $root }}
 {{- if .tlsTerminationOnPod }}
   cert_file: /turn-tls/tls.crt

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
@@ -93,11 +93,13 @@ spec:
 {{- with .exposedServices }}
   {{- with .turnTLS }}
   {{- if .enabled }}
-        - containerPort: {{ .port }}
+        - name: turn-tls-tcp
     {{- if eq .portType "HostPort" }}
           hostPort: {{ .port }}
+          containerPort: {{ .port }}
+    {{- else }}
+          containerPort: 5349
     {{- end }}
-          name: turn-tls-tcp
           protocol: TCP
   {{- end }}
   {{- end }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_tcp_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_tcp_service.yaml
@@ -31,6 +31,7 @@ spec:
   ports:
   - name: "rtc-tcp"
     protocol: "TCP"
+  {{- /* port and targetPort must be the same for RTC traffic as LiveKit advertises the local port its listening on as the access port*/}}
     port: {{ .exposedServices.rtcTcp.port }}
     targetPort: {{ .exposedServices.rtcTcp.port }}
     {{- with .exposedServices.rtcTcp.nodePort }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_muxer_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_muxer_service.yaml
@@ -31,6 +31,7 @@ spec:
   ports:
   - name: "rtc-muxed-udp"
     protocol: "UDP"
+  {{- /* port and targetPort must be the same for RTC traffic as LiveKit advertises the local port its listening on as the access port*/}}
     port: {{ .exposedServices.rtcMuxedUdp.port }}
     targetPort: {{ .exposedServices.rtcMuxedUdp.port }}
     {{- with .exposedServices.rtcMuxedUdp.nodePort }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_range_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_range_service.yaml
@@ -39,6 +39,7 @@ spec:
 {{- $segment_end := ((min (add $range_end 1) (add $segment_start 250)) | int) }}
 {{- range $port := untilStep $segment_start $segment_end 1 }}
   - name: rtc-udp-{{ $port }}
+  {{- /* port and targetPort must be the same for RTC traffic as LiveKit advertises the local port its listening on as the access port*/}}
     port: {{ $port }}
     targetPort: {{ $port }}
     {{- with $.Values.matrixRTC.sfu.exposedServices.rtcUdp.portRange.nodePort }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_turn_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_turn_service.yaml
@@ -31,6 +31,7 @@ spec:
   ports:
   - name: "turn-udp"
     protocol: "UDP"
+  {{- /* port and targetPort must be the same for Turn UDP traffic as LiveKit advertises the local port its listening on as the access port*/}}
     port: {{ .exposedServices.turn.port }}
     targetPort: {{ .exposedServices.turn.port }}
     {{- with .exposedServices.turn.nodePort }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_turn_tls_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_turn_tls_service.yaml
@@ -32,7 +32,9 @@ spec:
   - name: "turn-tls-tcp"
     protocol: "TCP"
     port: {{ .exposedServices.turnTLS.port }}
-    targetPort: {{ .exposedServices.turnTLS.port }}
+  {{- /* LiveKit will advertise the port 443 regardless of the port configured.
+    We hardcode it to 5349 and rely on Kubernetes routing to expose a port of 443 using a LoadBalancer service */}}
+    targetPort: 5349
     {{- with .exposedServices.turnTLS.nodePort }}
     nodePort: {{ tpl . (dict "context" $.Values.matrixRTC.sfu.exposedServices.turnTLS "root" $) }}
     {{- end }}

--- a/newsfragments/1079.fixed.md
+++ b/newsfragments/1079.fixed.md
@@ -1,0 +1,1 @@
+Matrix RTC: Fix an issue where LiveKit would crash if setting `exposedServices.turnTLS.port` to `443` when not using `HostPort` `portType`.


### PR DESCRIPTION
When Turn is exposed as port `443` on the LoadBalancer, this is causing the SFU to crash as it is trying to listen on the same port without having enough permissions. 

This PR changes the port and hardcodes it to the standard `5349`. This works because Livekit does not consider `turn.tls_port` value to advertise the remote access endpoint, it will always advertise `443` for Turn.

The same logic does not apply to RTC Ports : Those must be strictly the same between remote and local, as they are advertised as-is to remote clients.