### PR TITLE
Postgres: Replace env-var helper with helm standard functions

### DIFF
--- a/charts/matrix-stack/templates/ess-library/_postgres.tpl
+++ b/charts/matrix-stack/templates/ess-library/_postgres.tpl
@@ -1,7 +1,7 @@
 
 {{- /*
 Copyright 2025 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -24,14 +24,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- define "element-io.ess-library.postgres-env-var" -}}
 {{- $root := .root -}}
 {{- with required "element-io.ess-library.postgres-env-var requires context" .context -}}
-{{- $input := . -}}
-{{- $output := list -}}
-{{- range $input | splitList "" -}}
-{{- if (. | regexMatch "[A-Z]") -}}
-{{- $output = append $output "_" -}}
-{{- end -}}
-{{- $output = append $output . -}}
-{{- end -}}
-{{- printf "POSTGRES_%s_PASSWORD" (upper ($output | join "")) -}}
+{{- printf "POSTGRES_%s_PASSWORD" (. | snakecase | upper) -}}
 {{- end -}}
 {{- end -}}

--- a/newsfragments/1094.internal.md
+++ b/newsfragments/1094.internal.md
@@ -1,0 +1,1 @@
+Use helm standard function to transform string to env var name.


### PR DESCRIPTION
Unsure when those methods were added to helm, but it's way more reliable than our currently limited algorithm.