### PR TITLE
Do not escape strings automatically in our jinja files

### DIFF
--- a/.github/element-docs-words.txt
+++ b/.github/element-docs-words.txt
@@ -17,6 +17,7 @@ homeserver
 Homeserver
 homeservers
 Jetstack
+Jinja
 kubeconform
 kubernetes
 linters

--- a/newsfragments/1097.internal.md
+++ b/newsfragments/1097.internal.md
@@ -1,0 +1,1 @@
+Scripts: Do not escape strings automatically in our Jinja files.

--- a/scripts/construct_helm_values.py
+++ b/scripts/construct_helm_values.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 
 # Copyright 2024 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
 from pathlib import Path
 
 import typer
-from jinja2 import Environment, FileSystemLoader, select_autoescape
+from jinja2 import Environment, FileSystemLoader
 
 
 def find_sub_dirs(root_dir):
@@ -31,7 +31,7 @@ def construct_values_file(source_values_template_path: Path, destination_values_
                 *find_sub_dirs(charts_path),
             ]
         ),
-        autoescape=select_autoescape,
+        autoescape=False,
         keep_trailing_newline=True,
     )
     template = env.get_template(source_values_template_path.name)


### PR DESCRIPTION
This is causing Jinja to render `<foo>` as `&lt;foo&gt;`