### PR TITLE
Migration: fix test_prompts being unreliable

### DIFF
--- a/newsfragments/1106.changed.md
+++ b/newsfragments/1106.changed.md
@@ -1,0 +1,1 @@
+Add support for Synapse workers discovery in migration script.

--- a/scripts/migration/synapse.py
+++ b/scripts/migration/synapse.py
@@ -50,8 +50,6 @@ worker_types = [
 def prompt_user_for_worker(
     pretty_logger: logging.Logger, instance_name: str, instance_props: Any, matched_worker_types: list[str]
 ) -> str:
-    pretty_logger = logging.getLogger("migration:summary")
-
     if not matched_worker_types:
         matched_worker_types = worker_types
 

--- a/scripts/migration/tests/test_prompts.py
+++ b/scripts/migration/tests/test_prompts.py
@@ -10,8 +10,8 @@ Tests for missing secrets and extra files handling.
 import asyncio
 import base64
 import logging
-
 from io import StringIO
+
 import pytest
 
 from ..engine import MigrationEngine


### PR DESCRIPTION
- It used to silently pass for workers prompt if all tests were called
due to side effect in main testing. It successfully captured the string
in the base logger, but not the prompt logger.