### PR TITLE
CI: Persist credentials when releasing

### DIFF
--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -105,7 +105,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       with:
-        persist-credentials: false
+        # We are creating a commit changing the chart version for the next version PR
+        persist-credentials: true
 
     - name: Grab packaged chart
       uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # v8.0.0

--- a/newsfragments/1119.internal.md
+++ b/newsfragments/1119.internal.md
@@ -1,0 +1,1 @@
+CI: Run zizmor security scan against ess-helm github action workflows.


### PR DESCRIPTION
We are creating a commit to change the next chart version with a PR. We have to persist git credentials to make it work.