### PR TITLE
CI: Run matrix-rtc upgrade idempotency integration tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -119,7 +119,7 @@ jobs:
         PYTEST_CI_FIRST_STEP: "1"
       # Drop me after releasing next 26.3.x
       # We are changing the k3d ports range, so we cannot setup matrix-rtc with the old values
-      if: ${{ !contains(env.MATRIX_TEST_COMPONENT, 'matrix-rtc') }}
+      if: ${{ env.MATRIX_TEST_FROM_REF == '26.2.3' && !contains(env.MATRIX_TEST_COMPONENT, 'matrix-rtc') || env.MATRIX_TEST_FROM_REF != '26.2.3' }}
       run: |
         if [ -f "tests/integration/env/${MATRIX_TEST_COMPONENT}.rc" ]; then
           # shellcheck source=/dev/null

--- a/newsfragments/1123.removed.md
+++ b/newsfragments/1123.removed.md
@@ -1,0 +1,23 @@
+Matrix RTC: Change the default ports to move them to the proper default Kubernetes static range.
+
+Kubernetes default static range contains ports 30000-30085. The new Matrix RTC exposed services have been moved to :
+- Matrix RTC TCP : 30001
+- Matrix RTC UDP : 30002
+- Matrix RTC Turn TLS: 30003
+- Matrix RTC Turn: 30004
+
+If you want to keep using the previously set static ports, you can do so by adding the following to your values files :
+
+```yml
+matrixRTC:
+  sfu:
+    exposedServices:
+      rtcTcp:
+        port: 30881
+      rtcMuxedUdp:
+        port: 30882
+      turnTLS:
+        port: 31443
+      turn:
+        port: 31748
+```


### PR DESCRIPTION
Allows to run the upgrade test from main that was disabled in https://github.com/element-hq/ess-helm/pull/1118
We should be able to run matrix-rtc now that the main branch has the proper k3d configuration.