### PR TITLE
Fix HAProxy backend IP address flapping

### DIFF
--- a/charts/matrix-stack/configs/haproxy/haproxy.cfg.tpl
+++ b/charts/matrix-stack/configs/haproxy/haproxy.cfg.tpl
@@ -1,6 +1,6 @@
 {{- /*
 Copyright 2024-2025 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -17,6 +17,19 @@ global
 
   # Allow HAProxy Stats sockets
   stats socket ipv4@127.0.0.1:1999 level admin
+
+  # In a dual-stack cluster, HAProxy will receive both the A and AAAA records for each backing Pod.
+  # This is either in the additional section of the response or when directly querying the hostname in the SRV response.
+  # As a backend server can only have a single IP address and `resolve-prefer` doesn't appear to impact SRV results,
+  # we end up having the IP for each backend server flapping between IPv4, IPv6.
+  # This also appears to cause a memory leak in HAProxy.
+  # The default (`ipv4,ipv6`) and `auto` (IPv4 + IPv6 if there's an IPv6 gateway) are both problematic and so we must set one.
+  # In the dual-stack case, we pick IPv4 only as that's most likely to work, however this means that IPv6 only clusters
+  # needs to adjust network.ipFamily to `ipv6` rather than leaving it at `dual-stack`.
+  #
+  # The only alternative found is to tweak `hold obsolete` up from the default of 0s in the `resolvers` section.
+  # This has the undesirable behaviour of making HAProxy slower to respond to Pod restarts
+  dns-accept-family {{ has $root.Values.networking.ipFamily (list "ipv4" "dual-stack") | ternary "ipv4" "ipv6" }}
 
 defaults
   mode http

--- a/newsfragments/1124.fixed.md
+++ b/newsfragments/1124.fixed.md
@@ -1,0 +1,8 @@
+Fix HAProxy memory leak in dual-stack clusters.
+
+In dual-stack clusters the IP of the backend server for each Synapse `Pod`
+flaps between the IPv4 & IPv6 address every second or so. This causes a memory leak.
+
+Configure HAProxy to only use the IPv4 or IPv6 address based on the value of
+`networking.ipFamily`. In the case of `dual-stack` (the default value), the IPv4
+address is used. As such IPv6 only clusters must now set `networking.ipFamily: ipv6`.


### PR DESCRIPTION
Fixes #1088 

This is not a satisfying fix. It prevents HAProxy working in IPv6 only clusters with the default config (`networking.ipFamily: dual-stack`) as there's no IPv4 address being returned to HAProxy. But allowing HAProxy to see/use more than 1 IP Family causes the bug.

I experimented with setting `hold obsolete` in `resolvers kubedns`. With a value of 5s/6s it made the issue much less frequent but delayed HAProxy seeing new IPs after `Pod` restarts, so wasn't acceptable.

Having `resolve-prefer` on the `server-template` line would be ideal but it didn't seem to take effect at all. This might be possible if we moved away from `server-template` to adding a list of `server` but that would mean that lots of backend servers would appear down.