### PR TITLE
Load our custom nginx config so that Element Admin starts in an IPv6 only cluster

### DIFF
--- a/charts/matrix-stack/templates/element-admin/deployment.yaml
+++ b/charts/matrix-stack/templates/element-admin/deployment.yaml
@@ -67,12 +67,28 @@ spec:
           {{- toYaml . | nindent 10 }}
 {{- end }}
         volumeMounts:
+        - mountPath: /etc/nginx/conf.d/default.conf
+          name: nginx-config
+          readOnly: true
+          subPath: default.conf
+        - mountPath: /etc/nginx/conf.d/http_customisations.conf
+          name: nginx-config
+          readOnly: true
+          subPath: http_customisations.conf
+        - mountPath: /etc/nginx/security_headers.conf
+          name: nginx-config
+          readOnly: true
+          subPath: security_headers.conf
         - mountPath: /tmp
           name: nginx-tmp
 {{- range .extraVolumeMounts }}
         - {{ (. | toYaml) | nindent 10 }}
 {{- end }}
       volumes:
+      - configMap:
+          defaultMode: 420
+          name: {{ $.Release.Name }}-element-admin
+        name: nginx-config
       - emptyDir:
           medium: Memory
         name: nginx-tmp

--- a/newsfragments/1125.fixed.md
+++ b/newsfragments/1125.fixed.md
@@ -1,0 +1,1 @@
+Fix Element Admin not starting in an IPv6 only cluster.

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -551,8 +551,24 @@ all_components_details = [
         has_credentials=False,
         has_service_monitor=False,
         makes_outbound_requests=False,
+        ignore_paths_mismatches={
+            "element-admin": (
+                # Various paths / path prefixes in the nginx config for adjusting headers.
+                # Files provided by the base image
+                "/50x.html",
+                "/health",
+                "/index.html",
+                "/index.runtime.html",
+                "/assets",
+            )
+        },
         ignore_unreferenced_mounts={
-            "element-admin": ("/tmp",),
+            "element-admin": (
+                # Explicitly mounted but wildcard included by the base-image
+                "/etc/nginx/conf.d/default.conf",
+                "/etc/nginx/conf.d/http_customisations.conf",
+                "/tmp",
+            )
         },
     ),
     ComponentDetails(


### PR DESCRIPTION
Discovered whilst testing #1124.

The security & cache headers still look in sync with https://github.com/element-hq/element-admin/blob/main/docker/nginx.conf