### PR TITLE
Upgrade MatrixRTC SFU to 1.9.12

### DIFF
--- a/charts/matrix-stack/source/matrix-rtc.yaml.j2
+++ b/charts/matrix-stack/source/matrix-rtc.yaml.j2
@@ -78,7 +78,7 @@ sfu:
     {{- sub_schema_values.exposedServicePort('turn', 30004, 'NodePort', defaultEnabled=False, nodePortTemplate="{{ .context.port }}") | indent(4) }}
 
 
-{{- sub_schema_values.image(registry='docker.io', repository='livekit/livekit-server', tag='v1.9.1') | indent(2) }}
+{{- sub_schema_values.image(registry='docker.io', repository='livekit/livekit-server', tag='v1.9.12') | indent(2) }}
 {{- sub_schema_values.extraEnv() | indent(2) }}
 {{- sub_schema_values.extraVolumes("Matrix RTC SFU") | indent(2) }}
 {{- sub_schema_values.extraVolumeMounts("Matrix RTC SFU") | indent(2) }}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -897,7 +897,7 @@ matrixRTC:
 
       ## The tag of the container image to use.
       ## One of tag or digest must be provided.
-      tag: "v1.9.1"
+      tag: "v1.9.12"
 
       ## Container digest to use. Used to pull the image instead of the image tag if set
       ## The tag will still be set as the app.kubernetes.io/version label

--- a/newsfragments/1127.changed.md
+++ b/newsfragments/1127.changed.md
@@ -1,0 +1,14 @@
+Upgrade Matrix RTC SFU to 1.9.12.
+
+Full Changelogs:
+- [v1.9.2](https://github.com/livekit/livekit/releases/tag/v1.9.2)
+- [v1.9.3](https://github.com/livekit/livekit/releases/tag/v1.9.3)
+- [v1.9.4](https://github.com/livekit/livekit/releases/tag/v1.9.4)
+- [v1.9.5](https://github.com/livekit/livekit/releases/tag/v1.9.5)
+- [v1.9.6](https://github.com/livekit/livekit/releases/tag/v1.9.6)
+- [v1.9.7](https://github.com/livekit/livekit/releases/tag/v1.9.7)
+- [v1.9.8](https://github.com/livekit/livekit/releases/tag/v1.9.8)
+- [v1.9.9](https://github.com/livekit/livekit/releases/tag/v1.9.9)
+- [v1.9.10](https://github.com/livekit/livekit/releases/tag/v1.9.10)
+- [v1.9.11](https://github.com/livekit/livekit/releases/tag/v1.9.11)
+- [v1.9.12](https://github.com/livekit/livekit/releases/tag/v1.9.12)


### PR DESCRIPTION
Now that https://github.com/element-hq/lk-jwt-service/issues/136 is resolved we can upgrade again.

There doesn't appear to be a v1.9.5 tag