### PR TITLE
ci: fix matrix-tools release being flaky

### DIFF
--- a/.github/workflows/matrix-tools.yml
+++ b/.github/workflows/matrix-tools.yml
@@ -126,7 +126,6 @@ jobs:
           cwd://${{ steps.meta.outputs.bake-file }}
         targets: matrix-tools
         set: |
-          *.output=type=image
           *.platform=linux/amd64,linux/arm64
         # https://docs.zizmor.sh/audits/#cache-poisoning
         # This is not catched by zizmor but arguably we need to disable cache for docker builds

--- a/newsfragments/1142.internal.md
+++ b/newsfragments/1142.internal.md
@@ -1,0 +1,1 @@
+CI: Fix an issue with `matrix-tools` image sometimes not being pushed until we retry the job.


### PR DESCRIPTION
I think this is what have been causing flakes with pushing images to the registry.

https://docs.docker.com/reference/cli/docker/buildx/build/#registry

> The registry exporter is a shortcut for type=image,push=true.

https://github.com/docker/bake-action

> push Bool Push is a shorthand for --set=*.output=type=registry (default false)

So according to this, I think we should not set output type in our docker bake action.