### PR TITLE
Migration Tool : Support PermissionError

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1149.misc.md
+++ b/packages/ess-migration-tool/newsfragments/1149.misc.md
@@ -1,0 +1,1 @@
+Prepare `ess-migration-tool` for pypi publishing.

--- a/packages/ess-migration-tool/src/ess_migration_tool/extra_files.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/extra_files.py
@@ -406,6 +406,9 @@ class ExtraFilesDiscovery:
         if self._is_binary_file(file_path):
             extra_file.cleartext = False
 
-        with open(file_path):
-            extra_file.content = file_path.read_bytes()
+        try:
+            with open(file_path):
+                extra_file.content = file_path.read_bytes()
+        except PermissionError as err:
+            raise ExtraFilesError(f"Permission denied when reading file: {file_path}") from err
         return extra_file

--- a/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
@@ -76,6 +76,8 @@ class SecretDiscovery:
                         logging.info(f"Found file value for {secret_key}")
                     except FileNotFoundError:
                         logger.warning(f"File not found: {file_path}")
+                    except PermissionError:
+                        logger.warning(f"Permission denied when reading file: {file_path}")
 
             # Apply transformer if available and we have a value
             if discovered_value is not None and secret_config.transformer is not None:

--- a/packages/ess-migration-tool/tests/test_extra_files.py
+++ b/packages/ess-migration-tool/tests/test_extra_files.py
@@ -412,3 +412,46 @@ def test_ignored_config_keys():
         assert expected_skipped_file not in discovered_files, (
             f"Ignored file {expected_skipped_file} should not be in discovered files"
         )
+
+
+def test_permission_error_handling(tmp_path):
+    """Test that permission errors are handled gracefully for extra files."""
+    # Create a file with no read permissions
+    restricted_file = tmp_path / "restricted.txt"
+    restricted_file.write_text("restricted content")
+    restricted_file.chmod(0o200)  # Write-only for owner
+
+    @dataclass
+    class TestStrategy(ExtraFilesDiscoveryStrategy):
+        @property
+        def ignored_config_keys(self):
+            return []
+
+    @dataclass
+    class TestSecretStrategy(SecretDiscoveryStrategy):
+        @property
+        def ess_secret_schema(self):
+            return {}
+
+    # Create discovery instance
+    discovery = ExtraFilesDiscovery(
+        strategy=TestStrategy(),
+        pretty_logger=logging.getLogger(),
+        secrets_strategy=TestSecretStrategy(),
+        source_file="test.yaml",
+    )
+
+    # Discover file paths
+    config_data = {"restricted_file_path": str(restricted_file)}
+    discovery.discover_extra_files_from_config(config_data)
+
+    # File should be in missing file paths due to permission error
+    assert len(discovery.missing_file_paths) == 1
+    missing_path = discovery.missing_file_paths[0]
+    assert missing_path.source_path == restricted_file
+
+    # File should not be in discovered extra files
+    assert len(discovery.discovered_extra_files) == 0
+
+    # Clean up: restore permissions for cleanup
+    restricted_file.chmod(0o644)

--- a/packages/ess-migration-tool/tests/test_synapse_secrets.py
+++ b/packages/ess-migration-tool/tests/test_synapse_secrets.py
@@ -49,3 +49,32 @@ def test_discover_extra_files_from_synapse_config(tmp_path, synapse_config_with_
     assert tmp_path / "email_templates" / "password_reset.html" in discovery.discovered_extra_files
     assert tmp_path / "email_templates" / "registration.html" in discovery.discovered_extra_files
     assert len(discovery.discovered_extra_files) == 2
+
+
+def test_permission_error_handling_for_secrets(tmp_path, basic_synapse_config):
+    """Test that permission errors are handled gracefully for secret files."""
+    # Create a restricted signing key file
+    restricted_key = tmp_path / "signing.key"
+    restricted_key.write_text("restricted_signing_key_content")
+    restricted_key.chmod(0o200)  # Write-only for owner
+
+    # Create config with restricted file reference
+    synapse_config = basic_synapse_config.copy()
+    synapse_config["signing_key_path"] = str(restricted_key)
+    synapse_config["database"]["args"]["password"] = "test_password"
+    synapse_config["macaroon_secret_key"] = "test_macaroon_key"
+
+    # Test secret discovery
+    synapse_secrets = SynapseSecretDiscovery()
+    discovery = SecretDiscovery(synapse_secrets, logging.getLogger(), "synapse.yaml")
+    discovery.discover_secrets(synapse_config)
+
+    # Signing key should be in missing required secrets due to permission error
+    assert "synapse.signingKey" in discovery.missing_required_secrets
+
+    # Other secrets should be discovered normally
+    assert "synapse.postgres.password" in discovery.discovered_secrets
+    assert "synapse.macaroon" in discovery.discovered_secrets
+
+    # Clean up: restore permissions for cleanup
+    restricted_key.chmod(0o644)


### PR DESCRIPTION
Fixes : 

```
ess-migration-tool --synapse-config /etc/synapse/homeserver.yaml 
🚀 Starting Matrix Stack to ESS Migration
📦 Step 0/4 (0%): Loading and validating input files
📦 Step 1/4 (25%): Migrating configuration to ESS values
❌ Migration failed!
💥 Error: [Errno 13] Permission denied: '/etc/synapse/legacy.localhost.signing.key'
📚 Check logs for details and try again.
ERROR:root:Migration failed: [Errno 13] Permission denied: '/etc/synapse/legacy.localhost.signing.key'

```