### PR TITLE
synapse: replace the deprecate database arg with dbname

### DIFF
--- a/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
@@ -48,14 +48,14 @@ https://github.com/kubernetes/kubernetes/issues/129043 / https://github.com/kube
 {{- if .postgres }}
     user: {{ .postgres.user }}
     password: ${SYNAPSE_POSTGRES_PASSWORD}
-    database: {{ .postgres.database }}
+    dbname: {{ .postgres.database }}
     host: {{ (tpl .postgres.host $root) }}
     port: {{ .postgres.port | default 5432 }}
     sslmode: {{ .postgres.sslMode | default "prefer" }}
 {{- else if $root.Values.postgres.enabled }}
     user: "synapse_user"
     password: ${SYNAPSE_POSTGRES_PASSWORD}
-    database: "synapse"
+    dbname: "synapse"
     host: "{{ $root.Release.Name }}-postgres.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}"
     port: 5432
     sslmode: prefer

--- a/newsfragments/1151.changed.md
+++ b/newsfragments/1151.changed.md
@@ -1,0 +1,1 @@
+Synapse: Change `database.args.database` and replace with `database.args.dbname`.

--- a/packages/ess-migration-tool/src/ess_migration_tool/synapse.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/synapse.py
@@ -107,6 +107,17 @@ def extract_workers_from_instance_map(pretty_logger: logging.Logger, instance_ma
     return selected_workers
 
 
+def extract_database_name(pretty_logger: logging.Logger, database_args: dict[str, Any]) -> str:
+    """Extract database name from the database arguments."""
+    database_name = database_args.get("dbname")
+    if not database_name:
+        database_name = database_args.get("database")
+    if not database_name:
+        pretty_logger.info("   ❌ Synapse database name could not be found")
+        raise MigrationError("No synapse database name found")
+    return database_name
+
+
 @dataclass
 class SynapseMigration(MigrationStrategy):
     """Synapse-specific migration implementation."""
@@ -156,15 +167,15 @@ class SynapseMigration(MigrationStrategy):
     @property
     def transformations(self) -> list[TransformationSpec]:
         return [
-            TransformationSpec(src_key="server_name", target_key="serverName"),  # Required by default
-            TransformationSpec(src_key="database.args.host", target_key="synapse.postgres.host"),  # Required by default
+            TransformationSpec(src_key="server_name", target_key="serverName"),
+            TransformationSpec(src_key="database.args.host", target_key="synapse.postgres.host"),
             TransformationSpec(
                 src_key="database.args.port", target_key="synapse.postgres.port", required=False
             ),  # Optional - defaults to 5432
-            TransformationSpec(src_key="database.args.user", target_key="synapse.postgres.user"),  # Required by default
+            TransformationSpec(src_key="database.args.user", target_key="synapse.postgres.user"),
             TransformationSpec(
-                src_key="database.args.database", target_key="synapse.postgres.database"
-            ),  # Required by default
+                src_key="database.args", target_key="synapse.postgres.database", transformer=extract_database_name
+            ),
             TransformationSpec(
                 src_key="database.args.sslmode", target_key="synapse.postgres.sslMode", required=False
             ),  # Optional security feature


### PR DESCRIPTION
The attribute has changed in Synapse 1.97, we should be using the new configuration value.

https://github.com/matrix-org/synapse/pull/16618