### PR TITLE
Migration: Fail prompt if running in quiet mode

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1153.misc.md
+++ b/packages/ess-migration-tool/newsfragments/1153.misc.md
@@ -1,0 +1,1 @@
+Fail the migration process if running in quiet mode and secrets or extra files could not be discovered automatically.

--- a/packages/ess-migration-tool/src/ess_migration_tool/extra_files.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/extra_files.py
@@ -15,6 +15,7 @@ from urllib.parse import urlparse
 
 from .interfaces import ExtraFilesDiscoveryStrategy, SecretDiscoveryStrategy
 from .models import DiscoveredExtraFile, DiscoveredPath, SecretConfig
+from .utils import is_quiet_mode
 
 logger = logging.getLogger("migration")
 
@@ -219,6 +220,14 @@ class ExtraFilesDiscovery:
         """
         Prompt user for alternative paths when files are missing.
         """
+        # Check if quiet mode is enabled
+        if is_quiet_mode(self.pretty_logger) and self.missing_file_paths:
+            missing_files = [str(fp.source_path) for fp in self.missing_file_paths]
+            raise ExtraFilesError(
+                f"Missing extra files in quiet mode: {', '.join(missing_files)}. "
+                "Cannot prompt for files when --quiet is enabled."
+            )
+
         self.pretty_logger.info("\n" + "=" * 60)
         self.pretty_logger.info("📁 EXTRA FILES DISCOVERY")
         self.pretty_logger.info("=" * 60)

--- a/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 
 from .interfaces import SecretDiscoveryStrategy
 from .models import DiscoveredSecret
-from .utils import get_nested_value
+from .utils import get_nested_value, is_quiet_mode
 
 logger = logging.getLogger("migration")
 
@@ -117,6 +117,15 @@ class SecretDiscovery:
         """Prompt user to provide missing required secrets."""
         if not self.missing_required_secrets:
             return
+
+        # Check if quiet mode is enabled
+        if is_quiet_mode(self.pretty_logger):
+            missing_list = ", ".join(self.missing_required_secrets)
+            raise SecretsError(
+                f"Missing required {self.strategy.component_name} secrets in quiet mode: {missing_list}. "
+                "Cannot prompt for secrets when --quiet is enabled."
+            )
+
         component_name = self.strategy.component_name.upper()
         self.pretty_logger.info("\n" + "=" * 60)
         self.pretty_logger.info(f"🔐 {component_name} SECRETS REQUIRED FOR MIGRATION")

--- a/packages/ess-migration-tool/src/ess_migration_tool/utils.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/utils.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 
+import logging
 import urllib.parse
 from typing import Any
 
@@ -225,3 +226,19 @@ def detect_key_type(content: bytes) -> str:
     except Exception:
         # Any other error (invalid format, corrupted data, etc.)
         return "unknown"
+
+
+def is_quiet_mode(pretty_logger: logging.Logger) -> bool:
+    """
+    Check if quiet mode is enabled by examining the logger level.
+
+    In the migration tool, quiet mode is indicated by setting the pretty_logger
+    level to logging.CRITICAL, which suppresses all summary output.
+
+    Args:
+        pretty_logger: The pretty logger instance to check
+
+    Returns:
+        True if quiet mode is enabled (logger level is CRITICAL), False otherwise
+    """
+    return pretty_logger.level == logging.CRITICAL

--- a/packages/ess-migration-tool/tests/test_prompts.py
+++ b/packages/ess-migration-tool/tests/test_prompts.py
@@ -15,7 +15,9 @@ from io import StringIO
 
 import pytest
 from ess_migration_tool.engine import MigrationEngine
+from ess_migration_tool.extra_files import ExtraFilesError
 from ess_migration_tool.inputs import InputProcessor
+from ess_migration_tool.secrets import SecretsError
 
 
 def test_migration_with_missing_secrets_prompt(
@@ -101,6 +103,76 @@ def test_migration_with_missing_secrets_prompt(
             raise
     finally:
         log_capture_string.close()
+
+
+def test_quiet_mode_fails_on_missing_secrets(tmp_path, synapse_config_with_signing_key, write_synapse_config):
+    """Test that migration fails in quiet mode when secrets are missing."""
+    # Create Synapse configuration with missing secrets
+    synapse_config = synapse_config_with_signing_key.copy()
+    # Remove password to simulate missing secret
+    del synapse_config["database"]["args"]["password"]
+    del synapse_config["macaroon_secret_key"]
+
+    # Write Synapse config
+    synapse_config_file = write_synapse_config(synapse_config)
+
+    # Load migration input
+    input_processor = InputProcessor()
+    input_processor.load_migration_input(
+        config_path=str(synapse_config_file),
+        name="synapse",
+    )
+
+    # Create logger in quiet mode (CRITICAL level)
+    pretty_logger = logging.getLogger(test_quiet_mode_fails_on_missing_secrets.__name__)
+    pretty_logger.propagate = False
+    pretty_logger.setLevel(logging.CRITICAL)  # This simulates --quiet mode
+    pretty_logger.addHandler(logging.StreamHandler())
+
+    engine = MigrationEngine(input_processor, pretty_logger=pretty_logger)
+
+    # Test that it raises SecretsError in quiet mode
+    with pytest.raises(SecretsError) as exc_info:
+        engine.run_migration()
+
+    # Verify the error message
+    assert "quiet mode" in str(exc_info.value)
+    assert "Cannot prompt for secrets when --quiet is enabled" in str(exc_info.value)
+    assert "synapse.postgres.password" in str(exc_info.value)
+
+
+def test_quiet_mode_fails_on_missing_extra_files(
+    tmp_path, synapse_config_with_signing_key, synapse_config_with_email_templates, write_synapse_config
+):
+    """Test that migration fails in quiet mode when extra files are missing."""
+    # Write Synapse config
+    synapse_config_file = write_synapse_config(synapse_config_with_signing_key | synapse_config_with_email_templates)
+
+    # Remove the email templates directory to simulate missing files
+    shutil.rmtree(tmp_path / "email_templates")
+
+    # Load migration input
+    input_processor = InputProcessor()
+    input_processor.load_migration_input(
+        config_path=str(synapse_config_file),
+        name="synapse",
+    )
+
+    # Create logger in quiet mode (CRITICAL level)
+    pretty_logger = logging.getLogger(test_quiet_mode_fails_on_missing_extra_files.__name__)
+    pretty_logger.propagate = False
+    pretty_logger.setLevel(logging.CRITICAL)  # This simulates --quiet mode
+    pretty_logger.addHandler(logging.StreamHandler())
+
+    engine = MigrationEngine(input_processor, pretty_logger=pretty_logger)
+
+    # Test that it raises ExtraFilesError in quiet mode
+    with pytest.raises(ExtraFilesError) as exc_info:
+        engine.run_migration()
+
+    # Verify the error message
+    assert "quiet mode" in str(exc_info.value)
+    assert "Cannot prompt for files when --quiet is enabled" in str(exc_info.value)
 
 
 def test_migration_with_unknown_workers_prompt(


### PR DESCRIPTION
When running in quiet mode, we cannot prompt the user - we must fail prompting