### PR TITLE
Migration: Fix an issue where tracked values would be logged

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1160.misc.md
+++ b/packages/ess-migration-tool/newsfragments/1160.misc.md
@@ -1,0 +1,1 @@
+Display the config keys which are being passed as `additional` settings, and warn the user when ESS will override them.

--- a/packages/ess-migration-tool/src/ess_migration_tool/migration.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/migration.py
@@ -164,7 +164,6 @@ class ConfigValueTransformer:
         updated_config = copy.deepcopy(source_config)
         for discovered_path in extra_files_discovery.discovered_file_paths:
             if discovered_path.skipped_reason:
-                self.tracked_values.append(discovered_path.config_key)
                 continue
             # If it is a directory, files will be mounted as child of the directory name
             # If it is a file, files will be mounted as child of the `extra` folder
@@ -259,6 +258,11 @@ class ConfigValueTransformer:
 
         configmap = ConfigMap(name=configmap_name, data=configmap_data)
 
+        # Add skipped paths to tracked_values for override detection
+        for discovered_path in extra_files_discovery.discovered_file_paths:
+            if discovered_path.skipped_reason:
+                self.tracked_values.append(discovered_path.config_key)
+
         for extra_file in extra_files_discovery.discovered_extra_files.values():
             for discovered_path in extra_file.discovered_source_paths:
                 if discovered_path.skipped_reason:
@@ -320,7 +324,7 @@ class MigrationService:
         self.component_root_key = self.migration.component_root_key
         self.override_configs = self.migration.override_configs
 
-    def _check_overrides(self, config: dict[str, Any]) -> None:
+    def _check_overrides(self, config: dict[str, Any], config_to_ess_transformer: ConfigValueTransformer) -> None:
         """
         Check if the configuration contains any override configurations
         that are managed by ESS and cannot be overridden.
@@ -330,6 +334,7 @@ class MigrationService:
 
         Args:
             config: Configuration to check
+            config_to_ess_transformer: Transformer containing tracked values for filtering
         """
         override_warnings = []
 
@@ -337,8 +342,6 @@ class MigrationService:
         transformed_configs = set()
         for transformation in self.migration.transformations:
             transformed_configs.add(transformation.src_key)
-
-        config_to_ess_transformer = ConfigValueTransformer(self.pretty_logger, self.ess_config)
 
         # Use the filtered configuration (with migrated values removed) for override detection
         # This automatically excludes values that are tracked by the transformer,
@@ -424,7 +427,7 @@ class MigrationService:
         )
 
         # Step 7: Check for override configurations and warn user
-        self._check_overrides(self.input.config)
+        self._check_overrides(self.input.config, config_to_ess_transformer)
 
         # Step 8: Add filtered additional configurations
         config_to_ess_transformer.add_additional_config_to_component(

--- a/packages/ess-migration-tool/tests/conftest.py
+++ b/packages/ess-migration-tool/tests/conftest.py
@@ -21,6 +21,20 @@ def basic_synapse_config():
     return {
         "server_name": "test.example.com",
         "public_baseurl": "https://matrix.example.com",
+        "listeners": [
+            {
+                "port": 8008,
+                "tls": False,
+                "type": "http",
+                "x_forwarded": False,
+                "resources": [
+                    {
+                        "names": ["client", "federation"],
+                        "compression": False,
+                    }
+                ],
+            }
+        ],
         "database": {
             "args": {"database": "synapse", "user": "synapse", "host": "postgres", "port": 5432, "password": "test"}
         },

--- a/packages/ess-migration-tool/tests/test_config_value_tracker.py
+++ b/packages/ess-migration-tool/tests/test_config_value_tracker.py
@@ -291,10 +291,9 @@ def test_update_paths_in_config_with_skipped_paths():
     assert updated_config["templates"]["password_reset"] == "/path/to/password_reset.html"  # Unchanged
     assert updated_config["templates"]["registration"] == "/etc/synapse/extra/registration.html"  # Updated
 
-    # Verify tracked values (only skipped paths are tracked)
-    assert "templates.password_reset" in transformer.tracked_values
+    assert "templates.password_reset" not in transformer.tracked_values
     assert "templates.registration" not in transformer.tracked_values
-    assert len(transformer.tracked_values) == 1
+    assert len(transformer.tracked_values) == 0
 
 
 def test_update_paths_in_config_empty_discovery():

--- a/packages/ess-migration-tool/tests/test_main_e2e.py
+++ b/packages/ess-migration-tool/tests/test_main_e2e.py
@@ -24,6 +24,7 @@ def test_main_e2e_synapse_only(
     synapse_config_with_ca_federation_list,
     synapse_config_without_public_baseurl,
     write_synapse_config,
+    capsys,
 ):
     """Test the complete end-to-end migration workflow with Synapse only."""
 
@@ -63,6 +64,18 @@ def test_main_e2e_synapse_only(
 
     # Verify successful execution
     assert exit_code == 0
+
+    # Get captured stderr output (where logging goes)
+    captured = capsys.readouterr()
+    log_output = captured.err
+
+    # Verify override detection behavior
+    # listeners should be detected as override for Synapse
+    assert "'listeners' found in synapse.additional[\"00-imported.yaml\"].config" in log_output
+    # signing_key_path should NOT be detected (filtered out)
+    assert "'signing_key_path' found in synapse.additional[\"00-imported.yaml\"].config" not in log_output
+    # database.args.password should NOT be detected (filtered out as it's a secret)
+    assert "'database.args.password' found in synapse.additional[\"00-imported.yaml\"].config" not in log_output
 
     # Check that output files were created
     values_file = output_dir / "values.yaml"
@@ -188,6 +201,7 @@ def test_main_e2e_synapse_with_mas(
     basic_mas_config_with_keys,
     write_synapse_config,
     write_mas_config,
+    capsys,
 ):
     """Test the complete end-to-end migration workflow with Synapse and MAS."""
     # Write configuration files
@@ -215,6 +229,20 @@ def test_main_e2e_synapse_with_mas(
 
     # Verify successful execution
     assert exit_code == 0
+
+    # Get captured stderr output (where logging goes)
+    captured = capsys.readouterr()
+    log_output = captured.err
+
+    # Verify override detection behavior for MAS
+    # http should be detected as override for MAS
+    assert "'http' found in matrixAuthenticationService.additional[\"00-imported.yaml\"].config" in log_output
+    # listeners should be detected as override for Synapse
+    assert "'listeners' found in synapse.additional[\"00-imported.yaml\"].config" in log_output
+    # signing_key_path should NOT be detected (filtered out)
+    assert "'signing_key_path' found in synapse.additional[\"00-imported.yaml\"].config" not in log_output
+    # database.args.password should NOT be detected (filtered out as it's a secret)
+    assert "'database.args.password' found in synapse.additional[\"00-imported.yaml\"].config" not in log_output
 
     # Check that output files were created
     values_file = output_dir / "values.yaml"


### PR DESCRIPTION
When trying the script manually I realized that a regression happened while refactoring this week : 


```
⚠  ESS-MANAGED CONFIGURATIONS FOUND:
   These settings are managed by ESS and will be overridden:

   • ⚠  'signing_key_path' found in synapse.additional["00-imported.yaml"].config
   • ⚠  'listeners' found in synapse.additional["00-imported.yaml"].config
   • ⚠  'log_config' found in synapse.additional["00-imported.yaml"].config
   • ⚠  'database.args.password' found in synapse.additional["00-imported.yaml"].config
```

`signing_key_path` being imported to `synapse.signingKey`, it is dropped from `synapse.additional` values. It should not be logged out as settings that are going to be overridden.