### PR TITLE
Display where the secret can be read when having permission errors

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1161.misc.md
+++ b/packages/ess-migration-tool/newsfragments/1161.misc.md
@@ -1,0 +1,1 @@
+Display the secret path for the user to use a privileged session to access them.

--- a/packages/ess-migration-tool/src/ess_migration_tool/__main__.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/__main__.py
@@ -267,6 +267,7 @@ Examples:
 
         # Show next steps for deployment
         pretty_logger.info("🚀 NEXT STEPS TO DEPLOY ELEMENT SERVER SUITE:")
+        pretty_logger.info("=" * 60)
         pretty_logger.info("")
 
         # Use incremental step numbering

--- a/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
@@ -33,6 +33,7 @@ class SecretDiscovery:
     discovered_secrets: dict[str, DiscoveredSecret] = field(default_factory=dict)  # Secrets with source tracking
     init_by_ess_secrets: list[str] = field(default_factory=list)  # Secrets to be initialized by ESS
     missing_required_secrets: list[str] = field(default_factory=list)  # Secrets missing from configuration
+    secret_discovery_failures: dict[str, str] = field(default_factory=dict)  # secret_key -> failure_reason
 
     def discover_secrets(self, config_data: dict) -> None:
         """Discover secrets from configuration data."""
@@ -76,8 +77,10 @@ class SecretDiscovery:
                         logging.info(f"Found file value for {secret_key}")
                     except FileNotFoundError:
                         logger.warning(f"File not found: {file_path}")
+                        self.secret_discovery_failures[secret_key] = f"File not found: {file_path}"
                     except PermissionError:
                         logger.warning(f"Permission denied when reading file: {file_path}")
+                        self.secret_discovery_failures[secret_key] = f"Permission denied reading file: {file_path}"
 
             # Apply transformer if available and we have a value
             if discovered_value is not None and secret_config.transformer is not None:
@@ -141,6 +144,12 @@ class SecretDiscovery:
 
             self.pretty_logger.info(f"📝 {secret_info.description}")
             self.pretty_logger.info(f"   Secret path: {secret_key}")
+
+            # Add failure reason if available
+            if secret_key in self.secret_discovery_failures:
+                self.pretty_logger.info(f"   ⚠️  {self.secret_discovery_failures[secret_key]}")
+                if "Permission denied" in self.secret_discovery_failures[secret_key]:
+                    self.pretty_logger.info("   💡 Use elevated privileges to read this file")
 
             # The config key that will be injected in the configuration is preferably the path to the secret
             # But we fallback to the config_inline in needed

--- a/packages/ess-migration-tool/tests/test_synapse_secrets.py
+++ b/packages/ess-migration-tool/tests/test_synapse_secrets.py
@@ -72,6 +72,11 @@ def test_permission_error_handling_for_secrets(tmp_path, basic_synapse_config):
     # Signing key should be in missing required secrets due to permission error
     assert "synapse.signingKey" in discovery.missing_required_secrets
 
+    # Check that the failure information is stored
+    assert "synapse.signingKey" in discovery.secret_discovery_failures
+    assert "Permission denied reading file:" in discovery.secret_discovery_failures["synapse.signingKey"]
+    assert str(restricted_key) in discovery.secret_discovery_failures["synapse.signingKey"]
+
     # Other secrets should be discovered normally
     assert "synapse.postgres.password" in discovery.discovered_secrets
     assert "synapse.macaroon" in discovery.discovered_secrets


### PR DESCRIPTION
When using the script against a Synapse installed using system package, we expect the script not to be allowed to read the signing key. It will be helpful to give tips to the user to figure out where to read the secret.