### PR TITLE
Migration: Disable components not handled by the migration tool

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1162.misc.md
+++ b/packages/ess-migration-tool/newsfragments/1162.misc.md
@@ -1,0 +1,1 @@
+The migration tool sets up the chart without Element Web, Matrix RTC and Element Admin by default.

--- a/packages/ess-migration-tool/src/ess_migration_tool/engine.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/engine.py
@@ -73,5 +73,17 @@ class MigrationEngine:
             self.discovered_secrets.extend(migrator.discovered_secrets)
             self.init_by_ess_secrets.extend(migrator.init_by_ess_secrets)
 
+        # Handle component-specific relationships after migration
+        migrated_components = {migrator.component_root_key for migrator in self.migrators}
+
+        # Define all known ESS components
+        # These are components that can be managed by ESS Helm chart
+        ALL_ESS_COMPONENTS = {"synapse", "matrixAuthenticationService", "elementWeb", "elementAdmin", "matrixRTC"}
+
+        # Disable any ESS component that was not migrated
+        for component in ALL_ESS_COMPONENTS:
+            if component not in migrated_components:
+                self.ess_config.setdefault(component, {})["enabled"] = False
+
         logger.info("Migration process completed successfully")
         return self.ess_config

--- a/packages/ess-migration-tool/tests/test_main_e2e.py
+++ b/packages/ess-migration-tool/tests/test_main_e2e.py
@@ -90,9 +90,15 @@ def test_main_e2e_synapse_only(
     assert "serverName" in generated_values
     assert generated_values["serverName"] == "test.example.com"
 
-    # Verify Synapse configuration was migrated
+    # Verify Synapse configuration was migrated and is explicitly enabled
     synapse_config = generated_values["synapse"]
-    assert synapse_config["enabled"] is True
+    assert synapse_config["enabled"] is True, "synapse.enabled should be True"
+
+    # Verify all other components are explicitly disabled when only Synapse is configured
+    other_components = ["matrixAuthenticationService", "elementWeb", "elementAdmin", "matrixRTC"]
+    for component in other_components:
+        assert component in generated_values, f"{component} should be present in generated values"
+        assert generated_values[component]["enabled"] is False, f"{component}.enabled should be False"
 
     # Verify ingress host was set from prompt (not from public_baseurl)
     assert "ingress" in synapse_config
@@ -252,15 +258,21 @@ def test_main_e2e_synapse_with_mas(
     with open(values_file) as f:
         generated_values = yaml.safe_load(f)
 
-    # Verify Synapse configuration was migrated
+    # Verify Synapse configuration was migrated and is explicitly enabled
     assert "synapse" in generated_values
     synapse_config = generated_values["synapse"]
-    assert synapse_config["enabled"] is True
+    assert synapse_config["enabled"] is True, "synapse.enabled should be True"
 
-    # Verify MAS configuration was migrated
+    # Verify MAS configuration was migrated and is explicitly enabled
     assert "matrixAuthenticationService" in generated_values
     mas_config = generated_values["matrixAuthenticationService"]
-    assert mas_config["enabled"] is True
+    assert mas_config["enabled"] is True, "matrixAuthenticationService.enabled should be True"
+
+    # Verify other components are explicitly disabled when not migrated
+    other_components = ["elementWeb", "elementAdmin", "matrixRTC"]
+    for component in other_components:
+        assert component in generated_values, f"{component} should be present in generated values"
+        assert generated_values[component]["enabled"] is False, f"{component}.enabled should be False"
 
     # Verify MAS secrets were handled (using credential schema)
     assert "synapseSharedSecret" in mas_config


### PR DESCRIPTION
When testing the script I ended up with the following helm error : 

```
$ helm upgrade --install --namespace "ess" ess oci://ghcr.io/element-hq/ess-helm/matrix-stack -f output/values.yaml --wait
Release "ess" does not exist. Installing it now.
Pulled: ghcr.io/element-hq/ess-helm/matrix-stack:26.3.0
Digest: sha256:26a826958083d34056f6e8e73f8ebbdc8e712a1def3898f4e0af164644a75d09
Error: execution error at (matrix-stack/templates/z_validation/validation.txt:55:3): 
- elementAdmin.ingress.host is required when elementAdmin.enabled=true
- elementWeb.ingress.host is required when elementWeb.enabled=true
- matrixAuthenticationService.ingress.host is required when matrixAuthenticationService.enabled=true
- matrixRTC.ingress.host is required when matrixRTC.enabled=true
```

I dont think the import script should enable them by default. Let's make the migration path as short as possible.

The user can enable them later on using the chart instructions

