### PR TITLE
Don't construct test resources YAML files with .txt in the filename

### DIFF
--- a/newsfragments/1220.internal.md
+++ b/newsfragments/1220.internal.md
@@ -1,0 +1,1 @@
+CI: output the YAML of resources into `.yaml` files rather than `.txt.yaml` files.

--- a/tests/integration/scripts.py
+++ b/tests/integration/scripts.py
@@ -92,10 +92,12 @@ def collect_ess_logs():
 
             # Get resources
             for resource in resources:
-                output_file = f"{destination}/{ns}/{resource}.txt"
-                run_command_to_file(f"kubectl --context=k3d-ess-helm get {resource} -n {ns}", output_file)
+                output_file_prefix = f"{destination}/{ns}/{resource}"
                 run_command_to_file(
-                    f"kubectl --context=k3d-ess-helm get {resource} -o yaml -n {ns}", f"{output_file}.yaml"
+                    f"kubectl --context=k3d-ess-helm get {resource} -n {ns}", f"{output_file_prefix}.txt"
+                )
+                run_command_to_file(
+                    f"kubectl --context=k3d-ess-helm get {resource} -o yaml -n {ns}", f"{output_file_prefix}.yaml"
                 )
 
             # Get events


### PR DESCRIPTION
Noticed while debugging some CI flakes