### PR TITLE
Simplify the `maxUnavailable` calculation for `Deployments`

### DIFF
--- a/charts/matrix-stack/templates/ess-library/_workloads.tpl
+++ b/charts/matrix-stack/templates/ess-library/_workloads.tpl
@@ -22,11 +22,7 @@ strategy:
   type: RollingUpdate
   rollingUpdate:
     maxSurge: 2
-{{- if hasKey . "replicas" }}
-    maxUnavailable: {{ min (max 0 (sub .replicas 1)) 1 }}
-{{- else }}
-    maxUnavailable: 0
-{{- end }}
+    maxUnavailable: {{ min (max 0 (sub (.replicas | default 1) 1)) 1 }}
 {{- else }}
 serviceName: {{ $root.Release.Name }}-{{ $serviceNameSuffix }}
 updateStrategy:

--- a/newsfragments/1225.changed.md
+++ b/newsfragments/1225.changed.md
@@ -1,0 +1,1 @@
+Simplify the `maxUnavailable` calculation for `Deployments`.


### PR DESCRIPTION
Aligns with line 16 as well.

Should be a no-op on the manifests