### PR TITLE
Configure `web_client_location` in Synapse with the URL of the Element Web.

### DIFF
--- a/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
@@ -6,6 +6,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 
 {{- $root := .root -}}
+{{- if $root.Values.elementWeb.enabled }}
+web_client_location: https://{{ $root.Values.elementWeb.ingress.host }}/
+{{- end }}
+
 report_stats: false
 
 require_auth_for_profile_requests: true

--- a/newsfragments/1226.changed.md
+++ b/newsfragments/1226.changed.md
@@ -1,0 +1,1 @@
+Configure `web_client_location` in Synapse with the URL of the Element Web.


### PR DESCRIPTION
[`web_client_location`](https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#web_client_location) is mostly about redirecting `<synapse domain>/` to this location. That's not applicable here as `/` isn't on the Synapse `Ingress` (only `/_matrix` & `/synapse`). However it is used for other things, e.g. providing a hint to Identity Servers and there's no harm in configuring this I can see