### PR TITLE
Hookshot: correct Redis password handling

### DIFF
--- a/charts/matrix-stack/configs/hookshot/config-override.yaml.tpl
+++ b/charts/matrix-stack/configs/hookshot/config-override.yaml.tpl
@@ -34,10 +34,7 @@ encryption:
 
 cache:
 {{- if .redis }}
-  redisUri: "redis{{ if .redis.tls }}s{{ end }}://{{ tpl .redis.host $root }}:{{ .redis.port | default 6379 }}/{{ .redis.db | default 0 }}"
-{{- if .redis.password }}
-  redisPassword: ${HOOKSHOT_REDIS_PASSWORD}
-{{- end }}
+  redisUri: "redis{{ if .redis.tls }}s{{ end }}://{{ if .redis.password }}:${HOOKSHOT_REDIS_PASSWORD}@{{ end }}{{ tpl .redis.host $root }}:{{ .redis.port | default 6379 }}/{{ .redis.db | default 0 }}"
 {{- else }}
   redisUri: "redis://{{ $root.Release.Name }}-redis.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}:6379"
 {{- end }}

--- a/charts/matrix-stack/templates/hookshot/_helpers.tpl
+++ b/charts/matrix-stack/templates/hookshot/_helpers.tpl
@@ -105,7 +105,7 @@ env:
 - name: HOOKSHOT_REDIS_PASSWORD
   value: >-
     {{
-      printf "{{ readfile \"/secrets/%s\" | quote }}"
+      printf "{{ readfile \"/secrets/%s\" | urlencode }}"
         (
           include "element-io.ess-library.provided-secret-path" (
             dict "root" $root

--- a/newsfragments/1236.fixed.md
+++ b/newsfragments/1236.fixed.md
@@ -1,0 +1,1 @@
+Correctly set the external Redis password in Hookshot if configured.


### PR DESCRIPTION
Fixes #1235

Builds on #1222. Broken since external Redis support was introduced in #1143 

Unlike with Synapse where the Redis password is a distinct field, it is part of a connection string in Hookshot. Therefore escaping quotes is incorrect and the password should be urlencoded instead (e.g. how MAS does Postgres)

cc @wolbernd