### PR TITLE
Upgrade MatrixRTC authoriser to v0.4.3

### DIFF
--- a/charts/matrix-stack/source/matrix-rtc.yaml.j2
+++ b/charts/matrix-stack/source/matrix-rtc.yaml.j2
@@ -24,7 +24,7 @@ restrictRoomCreationToLocalUsers: true
 
 replicas: 1
 {{- sub_schema_values.ingress() }}
-{{- sub_schema_values.image(registry='oci.element.io', repository='lk-jwt-service', tag='0.4.2') }}
+{{- sub_schema_values.image(registry='oci.element.io', repository='lk-jwt-service', tag='0.4.3') }}
 {{- sub_schema_values.labels() }}
 {{- sub_schema_values.workloadAnnotations() }}
 {{- sub_schema_values.containersSecurityContext() }}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -525,7 +525,7 @@ matrixRTC:
 
     ## The tag of the container image to use.
     ## One of tag or digest must be provided.
-    tag: "0.4.2"
+    tag: "0.4.3"
 
     ## Container digest to use. Used to pull the image instead of the image tag if set
     ## The tag will still be set as the app.kubernetes.io/version label

--- a/newsfragments/1237.changed.md
+++ b/newsfragments/1237.changed.md
@@ -1,0 +1,8 @@
+Upgrade MatrixRTC Authoriser to v0.4.3.
+
+Highlights:
+- Update [MSC4195](https://github.com/matrix-org/matrix-spec-proposals/pull/4195) identity hash to latest update
+- Update dependencies for security updates
+
+Full Changelogs
+- [v0.4.3](https://github.com/element-hq/lk-jwt-service/releases/tag/v0.4.3)


### PR DESCRIPTION
https://github.com/element-hq/lk-jwt-service/releases/tag/v0.4.3

The experimental modes aren't default enabled anywhere. People need to mess around in developer settings to do so, so they're on their own if they do