### PR TITLE
Synapse: make the DB keepalive settings configurable

### DIFF
--- a/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
@@ -31,6 +31,11 @@ database:
     sslrootcert: system
 {{- end }}
 {{- end }}
+    keepalives: 1
+    keepalives_idle: 10
+    keepalives_interval: 10
+    keepalives_count: 3
+
     # Synapse has no defaults, so up from Twisted's defaults of 3-5
     cp_min: 5
     cp_max: 10

--- a/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
@@ -62,10 +62,6 @@ https://github.com/kubernetes/kubernetes/issues/129043 / https://github.com/kube
 {{ end }}
 
     application_name: ${APPLICATION_NAME}
-    keepalives: 1
-    keepalives_idle: 10
-    keepalives_interval: 10
-    keepalives_count: 3
 
 # The default as of 1.27.0
 ip_range_blacklist:

--- a/newsfragments/1239.changed.md
+++ b/newsfragments/1239.changed.md
@@ -1,0 +1,1 @@
+Allow changing of the Synapse database `keepalive` settings that the chart configures.


### PR DESCRIPTION
While the chart sets sensible defaults, I see no reason that chart users shouldn't be able to change these