### PR TITLE
CI: Fix integration tests release

### DIFF
--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -46,8 +46,44 @@ jobs:
           uv version --directory tests/ --bump "dev=$GITHUB_RUN_ID"
         fi
 
+    # We have to go through some hoops to build the package
+    # because the pyhelm3 package we use is a git ref
+    # and Pypi rejects packages with git refs dependencies
     - name: Build
-      run: uv build --package ess-community-integration-tests
+      run: |
+      # Step 1: Build the ess-community-integration-tests package
+      uv build --sdist --package ess-community-integration-tests
+      TARBALL=$(ls dist/ess_community_integration_tests-*.tar.gz)
+      echo "Built tarball: $TARBALL"
+
+      # Step 2: Clone and checkout the specific commit of pyhelm3
+      git clone https://github.com/element-hq/pyhelm3.git
+      cd pyhelm3
+      git checkout efa509e7501edeb9d04f2a9e688f6e0088305954
+      cd ..
+
+      # Step 3: Extract the ess-community-integration-tests tarball
+      mkdir extracted
+      tar -xzf "$TARBALL" -C extracted
+      EXTRACTED_DIR=$(ls extracted)
+      echo "Extracted to: $EXTRACTED_DIR"
+
+      # Step 4: Patch pyproject.toml to remove pyhelm3 dependency
+      sed -i '/pyhelm3 @ git+https:\/\/github.com\/element-hq\/pyhelm3.git@efa509e7501edeb9d04f2a9e688f6e0088305954/d' "extracted/$EXTRACTED_DIR/pyproject.toml"
+
+      # Step 5: Copy the pyhelm3 source into the extracted package
+      cp -r pyhelm3 "extracted/$EXTRACTED_DIR/"
+
+      # Step 6: Repack the tarball
+      cd extracted
+      PATCHED_TARBALL="patched_$(basename "$TARBALL")"
+      tar -czf "../dist/$PATCHED_TARBALL" *
+      cd ..
+      mv "dist/$PATCHED_TARBALL" "dist/$(basename "$TARBALL")"
+
+      # Step 7: Clean up
+      rm -rf extracted pyhelm3
+
     # Check that basic features work and we didn't miss to include crucial files
     - name: Smoke test (wheel)
       run: uv run --isolated --no-project --with dist/*.whl pytest-ess --test-suite synapse -- --setup-plan

--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -83,6 +83,9 @@ jobs:
         # Copy the pyhelm3 source into the extracted package
         mv pyhelm3/pyhelm3 "extracted/$EXTRACTED_DIR/"
 
+        # Step 6: Remove the Requires-Dist line from PKG-INFO
+        sed -i "/Requires-Dist: pyhelm3 @ git+https:\/\/github.com\/element-hq\/pyhelm3.git@$PYHELM_GIT_REF/d" "extracted/$EXTRACTED_DIR/PKG-INFO"
+
         # Repack the tarball
         cd extracted
         PATCHED_TARBALL="patched_$(basename "$TARBALL")"

--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -53,7 +53,7 @@ jobs:
       shell: bash
       run: |
         # Build the ess-community-integration-tests package
-        uv build --package ess-community-integration-tests
+        uv build --package ess-community-integration-tests --sdist
         TARBALL=$(ls dist/ess_community_integration_tests-*.tar.gz)
         echo "Built tarball: $TARBALL"
 

--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -68,7 +68,7 @@ jobs:
         git clone https://github.com/element-hq/pyhelm3.git
         cd pyhelm3
         git checkout "$PYHELM_GIT_REF"
-        cd ..
+        cd -
 
         # Extract the ess-community-integration-tests tarball
         mkdir extracted
@@ -86,8 +86,8 @@ jobs:
         # Repack the tarball
         cd extracted
         PATCHED_TARBALL="patched_$(basename "$TARBALL")"
-        tar -czf "../dist/$PATCHED_TARBALL  " -- .
-        cd ..
+        tar -czf "../dist/$PATCHED_TARBALL" -- .
+        cd -
         mv "dist/$PATCHED_TARBALL" "dist/$(basename "$TARBALL")"
 
         # Clean up

--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -46,17 +46,10 @@ jobs:
           uv version --directory tests/ --bump "dev=$GITHUB_RUN_ID"
         fi
 
-    # We have to go through some hoops to build the package
-    # because the pyhelm3 package we use is a git ref
-    # and Pypi rejects packages with git refs dependencies
-    - name: Build
-      shell: bash
+    # Because pyhelm3 is a git ref, the package cannot use it as direct dependencies when pushing to Pypi
+    # Instead we manually vendor pyhelm3 in the package when releasing it in CI
+    - name: Fetch pyhelm3
       run: |
-        # Build the ess-community-integration-tests package
-        uv build --package ess-community-integration-tests --sdist
-        TARBALL=$(ls dist/ess_community_integration_tests-*.tar.gz)
-        echo "Built tarball: $TARBALL"
-
         # Extract the Git reference for pyhelm3 from pyproject.toml
         PYHELM_GIT_REF=$(grep -oP 'pyhelm3 @ git\+https://github.com/element-hq/pyhelm3.git@\K[^"]+' tests/pyproject.toml)
         if [ -z "$PYHELM_GIT_REF" ]; then
@@ -70,32 +63,15 @@ jobs:
         cd pyhelm3
         git checkout "$PYHELM_GIT_REF"
         cd -
-
-        # Extract the ess-community-integration-tests tarball
-        mkdir extracted
-        tar -xzf "$TARBALL" -C extracted
-        EXTRACTED_DIR=$(ls extracted)
-        echo "Extracted to: $EXTRACTED_DIR"
+        mv pyhelm3/pyhelm3 tests/pyhelm3
+        rm -rf pyhelm3
 
         # Patch pyproject.toml to remove pyhelm3 dependency
-        sed -i '/pyhelm3 @ git+https:\/\/github.com\/element-hq\/pyhelm3.git@efa509e7501edeb9d04f2a9e688f6e0088305954/d' "extracted/$EXTRACTED_DIR/pyproject.toml"
-        sed -i 's/\(module-name = "integration"\)/module-name = ["pyhelm3", "integration"]/' "extracted/$EXTRACTED_DIR/pyproject.toml"
+        sed -i '/pyhelm3 @ git+https:\/\/github.com\/element-hq\/pyhelm3.git@'"$PYHELM_GIT_REF/d" "tests/pyproject.toml"
+        sed -i 's/\(module-name = "integration"\)/module-name = ["pyhelm3", "integration"]/' "tests/pyproject.toml"
 
-        # Copy the pyhelm3 source into the extracted package
-        mv pyhelm3/pyhelm3 "extracted/$EXTRACTED_DIR/"
-
-        # Step 6: Remove the Requires-Dist line from PKG-INFO
-        sed -i "/Requires-Dist: pyhelm3 @ git+https:\/\/github.com\/element-hq\/pyhelm3.git@$PYHELM_GIT_REF/d" "extracted/$EXTRACTED_DIR/PKG-INFO"
-
-        # Repack the tarball
-        cd extracted
-        PATCHED_TARBALL="patched_$(basename "$TARBALL")"
-        tar -czf "../dist/$PATCHED_TARBALL" -- .
-        cd -
-        mv "dist/$PATCHED_TARBALL" "dist/$(basename "$TARBALL")"
-
-        # Clean up
-        rm -rf extracted pyhelm3
+    - name: Build
+      run: uv build --package ess-community-integration-tests
 
     # Check that basic features work and we didn't miss to include crucial files
     - name: Smoke test (source distribution)

--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -78,9 +78,10 @@ jobs:
 
         # Patch pyproject.toml to remove pyhelm3 dependency
         sed -i '/pyhelm3 @ git+https:\/\/github.com\/element-hq\/pyhelm3.git@efa509e7501edeb9d04f2a9e688f6e0088305954/d' "extracted/$EXTRACTED_DIR/pyproject.toml"
+        sed -i 's/\(module-name = "integration"\)/module-name = ["pyhelm3", "integration"]/' "extracted/$EXTRACTED_DIR/pyproject.toml"
 
         # Copy the pyhelm3 source into the extracted package
-        cp -r pyhelm3 "extracted/$EXTRACTED_DIR/"
+        mv pyhelm3/pyhelm3 "extracted/$EXTRACTED_DIR/"
 
         # Repack the tarball
         cd extracted

--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -51,42 +51,48 @@ jobs:
     # and Pypi rejects packages with git refs dependencies
     - name: Build
       run: |
-      # Step 1: Build the ess-community-integration-tests package
-      uv build --sdist --package ess-community-integration-tests
-      TARBALL=$(ls dist/ess_community_integration_tests-*.tar.gz)
-      echo "Built tarball: $TARBALL"
+        # Build the ess-community-integration-tests package
+        uv build --package ess-community-integration-tests
+        TARBALL=$(ls dist/ess_community_integration_tests-*.tar.gz)
+        echo "Built tarball: $TARBALL"
 
-      # Step 2: Clone and checkout the specific commit of pyhelm3
-      git clone https://github.com/element-hq/pyhelm3.git
-      cd pyhelm3
-      git checkout efa509e7501edeb9d04f2a9e688f6e0088305954
-      cd ..
+        # Extract the Git reference for pyhelm3 from pyproject.toml
+        PYHELM_GIT_REF=$(grep -oP 'pyhelm3 @ git\+https://github.com/element-hq/pyhelm3.git@\K[^"]+' tests/pyproject.toml)
+        if [ -z "$PYHELM_GIT_REF" ]; then
+            echo "Error: Could not extract pyhelm3 Git reference from pyproject.toml."
+            exit 1
+        fi
+        echo "Extracted pyhelm3 Git reference: $PYHELM_GIT_REF"
 
-      # Step 3: Extract the ess-community-integration-tests tarball
-      mkdir extracted
-      tar -xzf "$TARBALL" -C extracted
-      EXTRACTED_DIR=$(ls extracted)
-      echo "Extracted to: $EXTRACTED_DIR"
+        # Clone and checkout the specific commit of pyhelm3
+        git clone https://github.com/element-hq/pyhelm3.git
+        cd pyhelm3
+        git checkout "$PYHELM_GIT_REF"
+        cd ..
 
-      # Step 4: Patch pyproject.toml to remove pyhelm3 dependency
-      sed -i '/pyhelm3 @ git+https:\/\/github.com\/element-hq\/pyhelm3.git@efa509e7501edeb9d04f2a9e688f6e0088305954/d' "extracted/$EXTRACTED_DIR/pyproject.toml"
+        # Extract the ess-community-integration-tests tarball
+        mkdir extracted
+        tar -xzf "$TARBALL" -C extracted
+        EXTRACTED_DIR=$(ls extracted)
+        echo "Extracted to: $EXTRACTED_DIR"
 
-      # Step 5: Copy the pyhelm3 source into the extracted package
-      cp -r pyhelm3 "extracted/$EXTRACTED_DIR/"
+        # Patch pyproject.toml to remove pyhelm3 dependency
+        sed -i '/pyhelm3 @ git+https:\/\/github.com\/element-hq\/pyhelm3.git@efa509e7501edeb9d04f2a9e688f6e0088305954/d' "extracted/$EXTRACTED_DIR/pyproject.toml"
 
-      # Step 6: Repack the tarball
-      cd extracted
-      PATCHED_TARBALL="patched_$(basename "$TARBALL")"
-      tar -czf "../dist/$PATCHED_TARBALL" *
-      cd ..
-      mv "dist/$PATCHED_TARBALL" "dist/$(basename "$TARBALL")"
+        # Copy the pyhelm3 source into the extracted package
+        cp -r pyhelm3 "extracted/$EXTRACTED_DIR/"
 
-      # Step 7: Clean up
-      rm -rf extracted pyhelm3
+        # Repack the tarball
+        cd extracted
+        PATCHED_TARBALL="patched_$(basename "$TARBALL")"
+        tar -czf "../dist/$PATCHED_TARBALL" *
+        cd ..
+        mv "dist/$PATCHED_TARBALL" "dist/$(basename "$TARBALL")"
+
+        # Clean up
+        rm -rf extracted pyhelm3
 
     # Check that basic features work and we didn't miss to include crucial files
-    - name: Smoke test (wheel)
-      run: uv run --isolated --no-project --with dist/*.whl pytest-ess --test-suite synapse -- --setup-plan
     - name: Smoke test (source distribution)
       run: uv run --isolated --no-project --with dist/*.tar.gz pytest-ess --test-suite synapse -- --setup-plan
 

--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -50,6 +50,7 @@ jobs:
     # because the pyhelm3 package we use is a git ref
     # and Pypi rejects packages with git refs dependencies
     - name: Build
+      shell: bash
       run: |
         # Build the ess-community-integration-tests package
         uv build --package ess-community-integration-tests

--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -86,7 +86,7 @@ jobs:
         # Repack the tarball
         cd extracted
         PATCHED_TARBALL="patched_$(basename "$TARBALL")"
-        tar -czf "../dist/$PATCHED_TARBALL" *
+        tar -czf "../dist/$PATCHED_TARBALL  " -- .
         cd ..
         mv "dist/$PATCHED_TARBALL" "dist/$(basename "$TARBALL")"
 

--- a/newsfragments/1241.internal.md
+++ b/newsfragments/1241.internal.md
@@ -1,0 +1,1 @@
+CI: Fix releasing of integration test suite.


### PR DESCRIPTION
We are currently using a pyhelm3 git ref as our dependency, and this gets rejected by pypi : https://github.com/element-hq/ess-helm/actions/runs/24390056991/job/71234261799

```
error: Failed to publish `dist/ess_community_integration_tests-26.4.0.tar.gz` to https://upload.pypi.org/legacy/
  Caused by: Server returned status code 400 Bad Request. Server says: 400 Can't have direct dependency: pyhelm3 @ git+https://github.com/element-hq/pyhelm3.git@efa509e7501edeb9d04f2a9e688f6e0088305954. See https://packaging.python.org/specifications/core-metadata for more information.
```

This tries to workaround this issue by "vendoring" pyhelm3 directly in the sdist package.