### PR TITLE
Improve k3s docs and tests around X-Forwarded-For

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,19 +211,50 @@ chown "$USER:$USER" "$KUBECONFIG"
 
 3. Add `export KUBECONFIG=~/.kube/config` to `~/.bashrc` to make it persistent
 
-4. Install Helm, the Kubernetes Package Manager. You can use your [OS repository](https://helm.sh/docs/intro/install/) or call the following command:
+4. Customise Traefik by creating the file `traefik-config.yaml` in `/var/lib/rancher/k3s/server/manifests`
+
+```yaml
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    ports:
+      web:
+        forwardedHeaders:
+          trustedIPs:
+            - "10.42.0.0/16"
+            - "2001:db8:42::/56"
+        http:
+          encodedCharacters:
+            allowEncodedHash: true
+            allowEncodedSlash: true
+      websecure
+        forwardedHeaders:
+          trustedIPs:
+            - "10.42.0.0/16"
+            - "2001:db8:42::/56"
+        http:
+          encodedCharacters:
+            allowEncodedHash: true
+            allowEncodedSlash: true
+```
+
+5. Install Helm, the Kubernetes Package Manager. You can use your [OS repository](https://helm.sh/docs/intro/install/) or call the following command:
 
 ```
 curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 ```
 
-5. Create your Kubernetes namespace where you will deploy the Element Server Suite Community:
+6. Create your Kubernetes namespace where you will deploy the Element Server Suite Community:
 
 ```
 kubectl create namespace ess
 ```
 
-6. Create a directory containing your Element Server Suite configuration values:
+7. Create a directory containing your Element Server Suite configuration values:
 
 ```
 mkdir ~/ess-config-values

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -57,7 +57,7 @@ If the goal is to have a drive dedicated to K3s one may also mount an external d
 
 ## Configuring Traefik ingress timeouts when using K3s
 
-If you are experiencing timeouts when uploading large files to ESS, you will want to customize Traefik timeouts creating the file `traefik-config.yaml` in `/var/lib/rancher/k3s/server/manifests`. If the file already exists because you have configured custom ports for Traefik, add the example below to the existing file.
+If you are experiencing timeouts when uploading large files to ESS, you will want to customize Traefik timeouts creating the file `traefik-config.yaml` in `/var/lib/rancher/k3s/server/manifests`. If the file already exists because you have configured custom ports or trusted IPs as per the [README](../README.md#kubernetes-single-node-setup-with-k3s) for Traefik, add the example below to the existing file.
 
 ```yml
 apiVersion: helm.cattle.io/v1

--- a/newsfragments/1242.doc.md
+++ b/newsfragments/1242.doc.md
@@ -1,0 +1,1 @@
+Update `k3s` installation docs to trust the `X-Forwarded-For` header correctly.

--- a/newsfragments/1242.internal.md
+++ b/newsfragments/1242.internal.md
@@ -1,0 +1,1 @@
+Configure the Traefik instance in `k3d` closer to how we document it.

--- a/tests/integration/fixtures/cluster.py
+++ b/tests/integration/fixtures/cluster.py
@@ -146,12 +146,6 @@ async def ingress(cluster, kube_client: AsyncClient):
             assert service
             assert service.spec
             assert service.spec.clusterIP
-
-            # So that we see the real connecting IP
-            # As per https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
-            service.spec.externalTrafficPolicy = "Local"
-            await kube_client.patch(Service, name="traefik", namespace="kube-system", obj=service)
-
             return service.spec.clusterIP
         except ApiError:
             await asyncio.sleep(1)

--- a/tests/integration/fixtures/files/clusters/k3d.yml
+++ b/tests/integration/fixtures/files/clusters/k3d.yml
@@ -49,6 +49,9 @@ files:
 - source: audit-policy.yml
   destination: /etc/kubernetes/policies/audit-policy.yaml
   nodeFilters: [servers:*]
+- source: traefik.yml
+  destination: /var/lib/rancher/k3s/server/manifests/traefik-config.yaml
+  nodeFilters: [servers:*]
 registries:
   create:
     name: k3d-ess-helm-registry

--- a/tests/integration/fixtures/files/clusters/traefik.yml
+++ b/tests/integration/fixtures/files/clusters/traefik.yml
@@ -1,0 +1,39 @@
+# Copyright 2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    service:
+      spec:
+        # So that we see the real connecting IP
+        # As per https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+        externalTrafficPolicy: Local
+    ports:
+      web:
+        forwardedHeaders:
+          trustedIPs:
+            - "10.42.0.0/16"
+            - "2001:db8:42::/56"
+        http:
+          # These don't do anything at present as k3d embeds Traefik Helm 37.1.1
+          # Will be needed on Traefik Helm >=38.0.0
+          encodedCharacters:
+            allowEncodedHash: true
+            allowEncodedSlash: true
+      websecure:
+        forwardedHeaders:
+          trustedIPs:
+            - "10.42.0.0/16"
+            - "2001:db8:42::/56"
+        http:
+          # These don't do anything at present as k3d embeds Traefik Helm 37.1.1
+          # Will be needed on Traefik Helm >=38.0.0
+          encodedCharacters:
+            allowEncodedHash: true
+            allowEncodedSlash: true

--- a/tests/integration/test_synapse.py
+++ b/tests/integration/test_synapse.py
@@ -5,6 +5,8 @@
 
 import asyncio
 import hashlib
+import ipaddress
+import re
 import uuid
 from pathlib import Path
 
@@ -55,10 +57,7 @@ async def test_synapse_exposes_chart_version_edition(
 @pytest.mark.skipif(value_file_has("synapse.enabled", False), reason="Synapse not deployed")
 @pytest.mark.asyncio_cooperative
 async def test_synapse_can_access_client_api(
-    ingress_ready,
-    ssl_context,
-    generated_data: ESSData,
-    helm_client: pyhelm3.Client,
+    ingress_ready, ssl_context, generated_data: ESSData, kube_client: AsyncClient
 ):
     await ingress_ready("synapse")
 
@@ -72,6 +71,27 @@ async def test_synapse_can_access_client_api(
 
     # Push notifications for encrypted messages
     assert json_content["unstable_features"]["org.matrix.msc4028"]
+
+    # Validate that Traefik -> HAProxy -> Synapse is honouring the external IP address and
+    # not overwriting it with a cluster-internal IP address
+    async for line in kube_client.log(
+        f"{generated_data.release_name}-synapse-main-0", namespace=generated_data.ess_namespace, newlines=False
+    ):
+        versions_log_line = re.search(r"INFO - GET-\d+ - ([^\s]+) - .*\"GET /_matrix/client/versions ", line)
+        if versions_log_line is None:
+            continue
+        client_ip_address = ipaddress.ip_address(versions_log_line.group(1))
+        assert client_ip_address, f"{versions_log_line} did not have a client IP address"
+        # These CIDRs are k3s' default as per https://docs.k3s.io/networking/basic-network-options
+        assert client_ip_address not in ipaddress.IPv4Network("10.42.0.0/16"), (
+            f"{versions_log_line} showed request was inside the k3s IPv4 CIDR not external"
+        )
+        assert client_ip_address not in ipaddress.IPv6Network("2001:db8:42::/56"), (
+            f"{versions_log_line} showed request was inside the k3s IPv6 CIDR not external"
+        )
+        break
+    else:
+        raise AssertionError("Couldn't find a /_matrix/client_versions log line to test")
 
 
 @pytest.mark.skipif(value_file_has("synapse.enabled", False), reason="Synapse not deployed")


### PR DESCRIPTION
Fixes #1216

The Trusted IP CIDRs come from https://docs.k3s.io/networking/basic-network-options. We don't technically need for this Traefik in k3d in CI as we use `externalTrafficPolicy: Local` but it doesn't hurt either