### PR TITLE
ESS Migration: Rename "component_root_key" to strategy name

### DIFF
--- a/packages/ess-migration-tool/src/ess_migration_tool/__main__.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/__main__.py
@@ -14,9 +14,10 @@ from dataclasses import dataclass, field
 
 from .engine import MigrationEngine
 from .inputs import InputProcessor, ValidationError
-from .mas import parse_postgres_uri
+from .mas import MAS_STRATEGY_NAME, parse_postgres_uri
 from .models import MigrationError
 from .outputs import generate_helm_values, write_outputs
+from .synapse import SYNAPSE_STRATEGY_NAME
 from .utils import delay_next_steps, prompt_for_database_choice
 
 LOADING_STEP = "Loading and validating input files"
@@ -179,13 +180,13 @@ Examples:
         reporter.report_step(LOADING_STEP)
         input_processor = InputProcessor()
         input_processor.load_migration_input(
-            name="synapse",
+            name=SYNAPSE_STRATEGY_NAME,
             config_path=args.synapse_config,
         )
 
         if args.mas_config:
             input_processor.load_migration_input(
-                name="matrixAuthenticationService",
+                name=MAS_STRATEGY_NAME,
                 config_path=args.mas_config,
             )
 
@@ -228,7 +229,7 @@ Examples:
 
         # Process migrations
         for migrator in engine.migrators:
-            migration_input = engine.input_processor.input_for_component(migrator.component_root_key)
+            migration_input = engine.input_processor.input_for_strategy(migrator.name)
             # Migrators are created according to discovered input for components, we do not expect NoneTypes here
             assert migration_input
             source_file = migration_input.config_path
@@ -331,7 +332,7 @@ Examples:
         delay_next_steps(pretty_logger)
 
         # Get the original media path from Synapse configuration
-        synapse_input = engine.input_processor.input_for_component("synapse")
+        synapse_input = engine.input_processor.input_for_strategy(SYNAPSE_STRATEGY_NAME)
         original_media_path = None
         if synapse_input and synapse_input.config.get("media_store_path"):
             original_media_path = synapse_input.config["media_store_path"]
@@ -353,8 +354,8 @@ Examples:
             delay_next_steps(pretty_logger)
 
             # Get source database configuration from input files
-            synapse_input = engine.input_processor.input_for_component("synapse")
-            mas_input = engine.input_processor.input_for_component("matrixAuthenticationService")
+            synapse_input = engine.input_processor.input_for_strategy(SYNAPSE_STRATEGY_NAME)
+            mas_input = engine.input_processor.input_for_strategy(MAS_STRATEGY_NAME)
 
             # Extract source database info from Synapse configuration
             assert synapse_input

--- a/packages/ess-migration-tool/src/ess_migration_tool/engine.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/engine.py
@@ -45,7 +45,7 @@ class MigrationEngine:
             ),
             (MASMigration(self.global_options), MASSecretDiscovery(self.global_options), MASExtraFileDiscovery()),
         ]:
-            migration_input = self.input_processor.input_for_component(migration.component_root_key)
+            migration_input = self.input_processor.input_for_strategy(migration.name)
             if migration_input:
                 self.migrators.append(
                     MigrationService(
@@ -77,16 +77,13 @@ class MigrationEngine:
             self.discovered_secrets.extend(migrator.discovered_secrets)
             self.init_by_ess_secrets.extend(migrator.init_by_ess_secrets)
 
-        # Handle component-specific relationships after migration
-        migrated_components = {migrator.component_root_key for migrator in self.migrators}
-
         # Define all known ESS components
         # These are components that can be managed by ESS Helm chart
         ALL_ESS_COMPONENTS = {"synapse", "matrixAuthenticationService", "elementWeb", "elementAdmin", "matrixRTC"}
 
         # Disable any ESS component that was not migrated
         for component in ALL_ESS_COMPONENTS:
-            if component not in migrated_components:
+            if component not in self.ess_config:
                 self.ess_config.setdefault(component, {})["enabled"] = False
 
         logger.info("Migration process completed successfully")

--- a/packages/ess-migration-tool/src/ess_migration_tool/inputs.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/inputs.py
@@ -32,12 +32,12 @@ class InputProcessor:
 
     inputs: list[MigrationInput] = field(default_factory=list)
 
-    def input_for_component(self, component_root_key: str) -> MigrationInput | None:
+    def input_for_strategy(self, strategy_name: str) -> MigrationInput | None:
         """
-        Return the migration input for a component.
+        Return the migration input for a strategy name.
         """
         for _input in self.inputs:
-            if _input.name == component_root_key:
+            if _input.name == strategy_name:
                 return _input
         return None
 

--- a/packages/ess-migration-tool/src/ess_migration_tool/interfaces.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/interfaces.py
@@ -21,8 +21,8 @@ class MigrationStrategy(Protocol):
         ...
 
     @property
-    def component_root_key(self) -> str:
-        """Get the component root key (e.g., 'synapse', 'matrixAuthenticationService')."""
+    def name(self) -> str:
+        """Get the strategy name (e.g., 'synapse', 'matrixAuthenticationService')."""
         ...
 
     @property
@@ -50,8 +50,8 @@ class SecretDiscoveryStrategy(Protocol):
         ...
 
     @property
-    def component_name(self) -> str:
-        """Get the component name for user-facing messages."""
+    def name(self) -> str:
+        """Get the strategy name for user-facing messages."""
         ...
 
     def discover_component_specific_secrets(self, config_data: dict) -> dict[str, DiscoveredSecret]:
@@ -82,6 +82,6 @@ class ExtraFilesDiscoveryStrategy(Protocol):
         ...
 
     @property
-    def component_name(self) -> str:
-        """Get the component name for user-facing messages."""
+    def name(self) -> str:
+        """Get the strategy name for user-facing messages."""
         ...

--- a/packages/ess-migration-tool/src/ess_migration_tool/mas.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/mas.py
@@ -20,6 +20,9 @@ from .utils import detect_key_type, extract_hostname_from_url, yaml_dump_with_pi
 logger = logging.getLogger("migration")
 
 
+MAS_STRATEGY_NAME = "Matrix Authentication Service"
+
+
 def parse_postgres_uri(uri: str) -> dict[str, Any]:
     """
     Parse a PostgreSQL connection URI and extract database configuration.
@@ -208,8 +211,8 @@ class MASMigration(MigrationStrategy):
         self.global_options = global_options
 
     @property
-    def component_root_key(self) -> str:
-        return "matrixAuthenticationService"
+    def name(self) -> str:
+        return MAS_STRATEGY_NAME
 
     @property
     def override_configs(self) -> set[str]:
@@ -289,8 +292,8 @@ class MASSecretDiscovery(SecretDiscoveryStrategy):
         self.global_options = global_options
 
     @property
-    def component_name(self) -> str:
-        return "Matrix Authentication Service"
+    def name(self) -> str:
+        return MAS_STRATEGY_NAME
 
     @property
     def ess_secret_schema(self) -> dict[str, SecretConfig]:
@@ -482,8 +485,8 @@ class MASSecretDiscovery(SecretDiscoveryStrategy):
 
 class MASExtraFileDiscovery(ExtraFilesDiscoveryStrategy):
     @property
-    def component_name(self) -> str:
-        return "Matrix Authentication Service"
+    def name(self) -> str:
+        return MAS_STRATEGY_NAME
 
     @property
     def ignored_config_keys(self) -> list[str]:

--- a/packages/ess-migration-tool/src/ess_migration_tool/migration.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/migration.py
@@ -171,10 +171,10 @@ class ConfigValueTransformer:
         self,
         source_config: dict[str, Any],
         extra_files_discovery: ExtraFilesDiscovery,
-        component_root_key: str,
+        name: str,
     ):
         # Get the base mount path for the component
-        base_mount_path = f"/etc/{component_root_key}/extra"
+        base_mount_path = f"/etc/{name}/extra"
         updated_config = copy.deepcopy(source_config)
         for discovered_path in extra_files_discovery.discovered_file_paths:
             if discovered_path.skipped_reason:
@@ -190,7 +190,7 @@ class ConfigValueTransformer:
     def handle_secrets(
         self,
         secret_discovery: SecretDiscovery,
-        component_root_key: str,
+        name: str,
         secrets_list: list[Secret],
     ) -> None:
         """
@@ -199,7 +199,7 @@ class ConfigValueTransformer:
         Args:
             config: Configuration to analyze for secrets
             secret_service: SecretDiscoveryService instance
-            component_root_key: Name of the component (synapse or mas)
+            name: Name of the component (synapse or mas)
             secrets_list: List to append created secrets to
 
         Returns:
@@ -210,9 +210,9 @@ class ConfigValueTransformer:
             return
 
         # Create a Kubernetes Secret containing all discovered secrets
-        # Convert component_root_key to kebab-case for the secret name
+        # Convert name to kebab-case for the secret name
         # Replace camelCase with kebab-case (e.g., "matrixAuthenticationService" -> "matrix-authentication-service")
-        kebab_case_name = component_root_key
+        kebab_case_name = name
         # Insert hyphens before uppercase letters and convert to lowercase
         kebab_case_name = "".join(["-" + c.lower() if c.isupper() else c for c in kebab_case_name]).lstrip("-")
 
@@ -226,10 +226,7 @@ class ConfigValueTransformer:
 
         secret = Secret(name=secret_name, data=secret_data)
         secrets_list.append(secret)
-        logging.info(
-            f"Created Kubernetes Secret with {len(secret_discovery.discovered_secrets)}"
-            f" secrets for {component_root_key}"
-        )
+        logging.info(f"Created Kubernetes Secret with {len(secret_discovery.discovered_secrets)} secrets for {name}")
 
         # Update ESS values to use credential schema instead of direct values
         # Use the ess_secret_schema to map secret keys to ESS configuration paths
@@ -253,14 +250,14 @@ class ConfigValueTransformer:
     def handle_extra_files_mounts(
         self,
         extra_files_discovery: ExtraFilesDiscovery,
-        component_root_key: str,
+        name: str,
         config_maps: list[ConfigMap],
     ):
-        config = self.get_component_config(component_root_key)
+        config = self.get_component_config(name)
         # Get the base mount path for the component
-        base_mount_path = f"/etc/{component_root_key}/extra"
+        base_mount_path = f"/etc/{name}/extra"
 
-        configmap_name = f"imported-{to_kebab_case(component_root_key)}"
+        configmap_name = f"imported-{to_kebab_case(name)}"
         extra_volume_mounts: list[dict[str, Any]] = []
         extra_volumes: list[dict[str, Any]] = []
 
@@ -331,12 +328,12 @@ class MigrationService:
     secrets: list[Secret] = field(default_factory=list)  # List of created Secrets
     configmaps: list[ConfigMap] = field(default_factory=list)  # List of created ConfigMaps
     override_configs: set[str] = field(default_factory=set)  # Set of configurations that are managed by ESS
-    component_root_key: str = field(init=False)  # Root key for the component (e.g., 'synapse')
+    name: str = field(init=False)  # Root key for the component (e.g., 'synapse')
     results: list[TransformationResult] = field(default_factory=list)  # List of transformation results
     global_options: GlobalOptions = field(default_factory=GlobalOptions)  # Global migration options
 
     def __post_init__(self):
-        self.component_root_key = self.migration.component_root_key
+        self.name = self.migration.name
         self.override_configs = self.migration.override_configs
 
     def _check_overrides(self, config: dict[str, Any], config_to_ess_transformer: ConfigValueTransformer) -> None:
@@ -371,12 +368,12 @@ class MigrationService:
                 and override_config not in transformed_configs
             ):
                 override_warnings.append(
-                    f"⚠️  '{override_config}' found in {self.component_root_key}.additional[\"00-imported.yaml\"].config"
+                    f"⚠️  '{override_config}' found in {self.name}.additional[\"00-imported.yaml\"].config"
                 )
 
         if override_warnings:
             self.override_warnings.extend(override_warnings)
-            logger.warning(f"{self.component_root_key} configuration contains ESS-managed overrides:")
+            logger.warning(f"{self.name} configuration contains ESS-managed overrides:")
             for warning in override_warnings:
                 logger.warning(warning)
 
@@ -420,7 +417,7 @@ class MigrationService:
         self.missing_file_paths = extra_files_discovery.missing_file_paths
 
         # Step 3: Enable component
-        self.ess_config.setdefault(self.component_root_key, {})["enabled"] = True
+        self.ess_config.setdefault(self.name, {})["enabled"] = True
 
         config_to_ess_transformer = ConfigValueTransformer(self.pretty_logger, self.ess_config)
         # Step 4: Apply component transformations
@@ -430,7 +427,7 @@ class MigrationService:
         # This will update the root ESS config directly and create Kubernetes Secrets
         config_to_ess_transformer.handle_secrets(
             secret_discovery,
-            self.component_root_key,
+            self.name,
             self.secrets,
         )
 
@@ -438,7 +435,7 @@ class MigrationService:
         # This will update the root ESS config directly and create Kubernetes ConfigMaps
         config_to_ess_transformer.handle_extra_files_mounts(
             extra_files_discovery,
-            self.component_root_key,
+            self.name,
             self.configmaps,
         )
 
@@ -447,7 +444,7 @@ class MigrationService:
 
         # Step 8: Add filtered additional configurations
         config_to_ess_transformer.add_additional_config_to_component(
-            self.component_root_key, self.input.config, extra_files_discovery
+            self.name, self.input.config, extra_files_discovery
         )
 
         # Step 9: Store results

--- a/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
@@ -38,7 +38,7 @@ class SecretDiscovery:
 
     def discover_secrets(self, config_data: dict) -> None:
         """Discover secrets from configuration data."""
-        logging.info(f"Discovering {self.strategy.component_name} secrets from configuration")
+        logging.info(f"Discovering {self.strategy.name} secrets from configuration")
 
         # Common discovery using strategy's schema
         self._discover_secrets_from_schema(config_data)
@@ -116,8 +116,8 @@ class SecretDiscovery:
         """Validate that all required secrets are present."""
         if self.missing_required_secrets:
             missing_list = ", ".join(self.missing_required_secrets)
-            raise SecretsError(f"Missing required {self.strategy.component_name} secrets: {missing_list}")
-        logging.info(f"All required {self.strategy.component_name} secrets are present")
+            raise SecretsError(f"Missing required {self.strategy.name} secrets: {missing_list}")
+        logging.info(f"All required {self.strategy.name} secrets are present")
 
     def prompt_for_missing_secrets(self) -> None:
         """Prompt user to provide missing required secrets."""
@@ -128,15 +128,15 @@ class SecretDiscovery:
         if is_quiet_mode(self.pretty_logger):
             missing_list = ", ".join(self.missing_required_secrets)
             raise SecretsError(
-                f"Missing required {self.strategy.component_name} secrets in quiet mode: {missing_list}. "
+                f"Missing required {self.strategy.name} secrets in quiet mode: {missing_list}. "
                 "Cannot prompt for secrets when --quiet is enabled."
             )
 
-        component_name = self.strategy.component_name.upper()
+        name = self.strategy.name.upper()
         self.pretty_logger.info("\n" + "=" * 60)
-        self.pretty_logger.info(f"🔐 {component_name} SECRETS REQUIRED FOR MIGRATION")
+        self.pretty_logger.info(f"🔐 {name} SECRETS REQUIRED FOR MIGRATION")
         self.pretty_logger.info("=" * 60)
-        self.pretty_logger.info(f"The following {component_name} secrets are required but could not be automatically")
+        self.pretty_logger.info(f"The following {name} secrets are required but could not be automatically")
         self.pretty_logger.info("discovered from your configuration files. Please provide them:")
 
         for secret_key in self.missing_required_secrets[:]:
@@ -182,5 +182,5 @@ class SecretDiscovery:
                     self.pretty_logger.info("\n   ❌ End of input reached")
                     raise SecretsError("End of input reached during secret prompt") from err
 
-        self.pretty_logger.info(f"\n✅ All required {component_name} secrets have been provided")
+        self.pretty_logger.info(f"\n✅ All required {name} secrets have been provided")
         self.pretty_logger.info("=" * 60)

--- a/packages/ess-migration-tool/src/ess_migration_tool/synapse.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/synapse.py
@@ -46,6 +46,8 @@ worker_types = [
     "user-dir",
 ]
 
+SYNAPSE_STRATEGY_NAME = "Synapse"
+
 
 def prompt_user_for_worker(
     pretty_logger: logging.Logger, instance_name: str, instance_props: Any, matched_worker_types: list[str]
@@ -240,8 +242,8 @@ class SynapseMigration(MigrationStrategy):
         self.global_options = global_options
 
     @property
-    def component_root_key(self) -> str:
-        return "synapse"
+    def name(self) -> str:
+        return SYNAPSE_STRATEGY_NAME
 
     @property
     def override_configs(self) -> set[str]:
@@ -331,10 +333,6 @@ class SynapseMigration(MigrationStrategy):
                 )
             ]
 
-    @property
-    def component_config_extras(self) -> dict[str, Any]:
-        return {"enabled": True}
-
 
 class SynapseSecretDiscovery(SecretDiscoveryStrategy):
     """Synapse-specific secret discovery implementation."""
@@ -386,8 +384,8 @@ class SynapseSecretDiscovery(SecretDiscoveryStrategy):
         return schema
 
     @property
-    def component_name(self) -> str:
-        return "Synapse"
+    def name(self) -> str:
+        return SYNAPSE_STRATEGY_NAME
 
     def discover_component_specific_secrets(self, config_data: dict) -> dict[str, DiscoveredSecret]:
         """
@@ -406,8 +404,8 @@ class SynapseSecretDiscovery(SecretDiscoveryStrategy):
 
 class SynapseExtraFileDiscovery(ExtraFilesDiscoveryStrategy):
     @property
-    def component_name(self) -> str:
-        return "Synapse"
+    def name(self) -> str:
+        return SYNAPSE_STRATEGY_NAME
 
     @property
     def ignored_config_keys(self) -> list[str]:


### PR DESCRIPTION
- A strategy does not necessarily manage only 1 component root key so the attribute name is misleading
- In the future we are going to have strategies managing multiple values of the chart