### PR TITLE
Upgrade Synapse to v1.152.0

### DIFF
--- a/charts/matrix-stack/source/synapse.yaml.j2
+++ b/charts/matrix-stack/source/synapse.yaml.j2
@@ -87,7 +87,7 @@ logging:
   ## levelOverrides:
   ##   synapse.util.caches.lrucache: WARNING
   levelOverrides: {}
-{{- sub_schema_values.image(registry='oci.element.io', repository='synapse', tag='v1.151.0-ess.1') }}
+{{- sub_schema_values.image(registry='oci.element.io', repository='synapse', tag='v1.152.0') }}
 {{- sub_schema_values.extraVolumes("Synapse", with_context=true) }}
 {{- sub_schema_values.extraVolumeMounts("Synapse", with_context=true) }}
 {{- sub_schema_values.extraInitContainers("Synapse") }}

--- a/charts/matrix-stack/templates/synapse/_synapse_details.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_details.tpl
@@ -96,6 +96,8 @@ responsibleForMedia
 {{ list "to_device" | toJson }}
 {{- else if eq . "event-persister" }}
 {{ list "events" | toJson }}
+{{- else if eq . "media-repository" }}
+{{ list "quarantined_media_changes" | toJson }}
 {{- else if eq . "presence-writer" }}
 {{ list "presence" | toJson }}
 {{- else if eq . "push-rules" }}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -4935,7 +4935,7 @@ synapse:
 
     ## The tag of the container image to use.
     ## One of tag or digest must be provided.
-    tag: "v1.151.0-ess.1"
+    tag: "v1.152.0"
 
     ## Container digest to use. Used to pull the image instead of the image tag if set
     ## The tag will still be set as the app.kubernetes.io/version label

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -13,6 +13,8 @@ SPDX-License-Identifier: AGPL-3.0-only
   - [Backup](#backup)
   - [Restore](#restore)
 - [Installation State](#installation-state)
+- [Fixing CVE-2025-24044 manually](#fixing-cve-2026-24044elementsec-2025-1670-manually)
+  - [Manually running the event resigning background job](#manually-running-the-event-resigning-background-job)
 
 ## Upgrading
 
@@ -130,6 +132,8 @@ The deployment markers functionality can be turned off by setting `deploymentMar
 
 If you initially deployed ESS Community with the chart secrets initialization hook enabled (`initSecrets.enabled` not set to `false`), your Synapse signing key will be vulnerable if it was not set explicitly in `synapse.signingKey`. If you later specified its content in `synapse.signingKey` in the values files, the chart will not be able to generate a new key automatically. You will be using the vulnerable signing key until you change it manually.
 
+Even if the above doesn't apply, if you never ran a version of ESS Community between 25.12.2 and 26.4.0 (inclusive), you will still need to [manually trigger the event resigning background job](#manually-running-the-event-resigning-background-job).
+
 1. Install `signedjson` and `pyyaml` using `pip` : `pip install signedjson pyyaml`
 2. Generate your new signing key with the key id `ed25519:1` using the following command :
 
@@ -205,3 +209,19 @@ If you initially deployed ESS Community with the chart secrets initialization ho
   }
 
   ```
+
+### Manually running the event resigning background job
+
+If you are upgrading from 25.12.1 or earlier to ESS Community 26.4.1 or later then the event resigning background job needs to be manually run.
+This applies if `initSecrets` was enabled (the default), regardless of whether you hard-coded the generated Synapse signing key into `synapse.signingKey` or not.
+
+If your deployment ever ran 25.12.2 to 26.4.0, and either generated the Synapse signing key externally or didn't hard-code the chart generated signing key, then this process does not need to run.
+
+The event resigning background job is triggered with
+
+```json
+curl -s https://<your synapse host>/_synapse/admin/v1/background_updates/start_job -H 'Authorization: Bearer <admin access token>' -H 'Content-type: application/json' -d '{"job_name": "event_resign"}'
+```
+
+The background job optionally takes `old_key` and `before_ts` JSON fields.
+Full documentation can be found in the [Synapse Admin API documentation](https://element-hq.github.io/synapse/latest/usage/administration/admin_api/background_updates.html#run)

--- a/newsfragments/1259.changed.md
+++ b/newsfragments/1259.changed.md
@@ -1,0 +1,13 @@
+Upgrade Synapse to v1.152.0.
+
+If upgrading directly from ESS Community 25.12.1 or earlier, the [`event_resign` background update](https://element-hq.github.io/synapse/latest/usage/administration/admin_api/background_updates.html) will need to be manually run.
+If ESS Community 25.12.2 to 26.4.0 have been run on a deployment with `initSecrets` enabled (the default), this background update does not need to be manually run.
+If upgrading from ESS Community 25.12.1 or earlier or `initSecrets` was later disabled, full [instructions are available](https://github.com/element-hq/ess-helm/blob/main/docs/maintenance.md#fixing-cve-2026-24044elementsec-2025-1670-manually)
+
+Highlights:
+- Add a ["Listing quarantined media changes" Admin API](https://element-hq.github.io/synapse/latest/admin_api/media_admin_api.html#listing-quarantined-media-changes) for retrieving a paginated record of when media became (un)quarantined
+- Add a way to re-sign local events with a new signing key
+- Reduce database disk space usage by pruning old rows from `device_lists_changes_in_room`
+
+Full Changelogs:
+- [v1.152.0](https://github.com/element-hq/synapse/releases/tag/v1.152.0)


### PR DESCRIPTION
Draft as RC. Deliberately moving away from the `-ess.n` variant given https://github.com/element-hq/synapse/pull/19668 is now merged