### PR TITLE
Migration: Simplify failures handling further

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1260.misc.md
+++ b/packages/ess-migration-tool/newsfragments/1260.misc.md
@@ -1,0 +1,1 @@
+Adjust handling of failures in dynamically discovered secrets.

--- a/packages/ess-migration-tool/src/ess_migration_tool/extra_files.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/extra_files.py
@@ -89,6 +89,10 @@ class ExtraFilesDiscovery:
             # Build the full key path
             if not parent_key:
                 raise RuntimeError("ESS Migration does not handle source file with only a single list at root")
+            # Skip if parent_key is in ignored config keys
+            # This prevents discovery of file paths in ignored sections (e.g., secrets.keys)
+            if parent_key in self.strategy.ignored_config_keys:
+                return
             for i, value in enumerate(config_data):
                 full_key = f"{parent_key}.{i}"
                 if isinstance(value, str) and self._is_file_path(value):

--- a/packages/ess-migration-tool/src/ess_migration_tool/interfaces.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/interfaces.py
@@ -55,19 +55,21 @@ class SecretDiscoveryStrategy(Protocol):
         ...
 
     def discover_component_specific_secrets(
-        self, config_data: dict
-    ) -> tuple[dict[str, DiscoveredSecret], dict[str, str]]:
+        self, source_file: str, config_data: dict
+    ) -> tuple[dict[str, DiscoveredSecret], list[tuple[DiscoveredSecret, str]]]:
         """
         Discover component-specific secrets from configuration.
 
         Args:
+            source_file: Source configuration file name
             config_data: Component configuration data
 
         Returns:
             Tuple of (discovered_secrets, failed_secrets) where:
             - discovered_secrets: Dictionary mapping ESS secret keys to DiscoveredSecret objects
-            - failed_secrets: Dictionary mapping ESS secret keys to error messages for
-              secrets that were discovered but could not be read
+            - failed_secrets: List of (DiscoveredSecret, error_message) tuples for secrets
+              that were discovered but could not be read. DiscoveredSecret includes config_key
+              (the original configuration path from the source config).
         """
         ...
 

--- a/packages/ess-migration-tool/src/ess_migration_tool/mas.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/mas.py
@@ -393,55 +393,60 @@ class MASSecretDiscovery(SecretDiscoveryStrategy):
         return schema
 
     def discover_component_specific_secrets(
-        self, config_data: dict
-    ) -> tuple[dict[str, DiscoveredSecret], dict[str, str]]:
+        self, source_file: str, config_data: dict
+    ) -> tuple[dict[str, DiscoveredSecret], list[tuple[DiscoveredSecret, str]]]:
         """
         Discover component-specific secrets from MAS configuration.
 
         Args:
+            source_file: Source configuration file name
             config_data: MAS configuration data
 
         Returns:
             Tuple of (discovered_secrets, failed_secrets) where:
             - discovered_secrets: Dictionary mapping ESS secret keys to DiscoveredSecret objects
-            - failed_secrets: Dictionary mapping failed ESS secret keys to error messages
+            - failed_secrets: List of (DiscoveredSecret, error_message) tuples for secrets
+              that failed to be read. DiscoveredSecret includes config_key from the source config.
         """
         discovered_secrets: dict[str, DiscoveredSecret] = {}
-        failed_secrets: dict[str, str] = {}
+        failed_secrets: list[tuple[DiscoveredSecret, str]] = []
 
         # Handle keys_dir (directory scanning)
         keys_dir = config_data.get("secrets", {}).get("keys_dir")
         if keys_dir:
-            dir_secrets, dir_failures = self._process_keys_directory(keys_dir)
+            dir_secrets, dir_failures = self._process_keys_directory(source_file, keys_dir)
             discovered_secrets.update(dir_secrets)
-            failed_secrets.update(dir_failures)
+            # Directory failures are logged but not returned for prompting
 
         # Handle individual keys
         keys_config = config_data.get("secrets", {}).get("keys", [])
         if keys_config:
-            individual_secrets, individual_failures = self._process_individual_keys(keys_config)
+            individual_secrets, individual_failures = self._process_individual_keys(source_file, keys_config)
             # Individual keys take precedence over directory keys
             discovered_secrets.update(individual_secrets)
-            failed_secrets.update(individual_failures)
+            failed_secrets.extend(individual_failures)
 
         return (discovered_secrets, failed_secrets)
 
-    def _process_keys_directory(self, keys_dir: str) -> tuple[dict[str, DiscoveredSecret], dict[str, str]]:
+    def _process_keys_directory(
+        self, source_file: str, keys_dir: str
+    ) -> tuple[dict[str, DiscoveredSecret], list[tuple[DiscoveredSecret, str]]]:
         """
         Process all key files in a directory.
 
         Args:
+            source_file: Source configuration file name
             keys_dir: Path to directory containing key files
 
         Returns:
             Tuple of (discovered_secrets, failed_secrets)
+            Note: failed_secrets is always empty list as directory scan failures are only logged
         """
         discovered_secrets: dict[str, DiscoveredSecret] = {}
-        failed_secrets: dict[str, str] = {}
         try:
             if not os.path.isdir(keys_dir):
                 logger.warning(f"Keys directory does not exist: {keys_dir}")
-                return (discovered_secrets, failed_secrets)
+                return (discovered_secrets, [])
 
             for filename in os.listdir(keys_dir):
                 filepath = os.path.join(keys_dir, filename)
@@ -451,77 +456,86 @@ class MASSecretDiscovery(SecretDiscoveryStrategy):
                             content = f.read()
                         key_type = detect_key_type(content)
                         if key_type in ["rsa", "ecdsaPrime256v1", "ecdsaSecp256k1", "ecdsaSecp384r1"]:
-                            secret_key = f"matrixAuthenticationService.privateKeys.{key_type}"
+                            ess_secret_key = f"matrixAuthenticationService.privateKeys.{key_type}"
+                            source_config_key = "secrets.keys_dir"
                             # Only set if not already discovered (prefer individual keys over directory)
-                            if secret_key not in discovered_secrets:
+                            if ess_secret_key not in discovered_secrets:
                                 discovered_secret = DiscoveredSecret(
-                                    source_file="mas.yaml",
-                                    secret_key=secret_key,
-                                    config_key="secrets.keys_dir",
+                                    source_file=source_file,
+                                    secret_key=ess_secret_key,
+                                    config_key=source_config_key,
                                     value=content.decode("utf-8"),
                                 )
-                                discovered_secrets[secret_key] = discovered_secret
+                                discovered_secrets[ess_secret_key] = discovered_secret
                                 logger.info(f"Discovered {key_type} key from file: {filepath}")
                     except Exception as e:
-                        # For unrecognized key types, we don't add to discovered, but we also don't fail
-                        # This is expected behavior (non-key files in directory)
-                        logger.debug(f"Skipping non-key file {filepath}: {e}")
+                        # Only log failures for directory scanning; directory scan failures cannot be prompted
+                        logger.warning(f"Failed to process key file {filepath}: {e}")
         except Exception as e:
             logger.warning(f"Failed to process keys directory {keys_dir}: {e}")
 
-        return (discovered_secrets, failed_secrets)
+        return (discovered_secrets, [])
 
-    def _process_individual_keys(self, keys_config: list) -> tuple[dict[str, DiscoveredSecret], dict[str, str]]:
+    def _process_individual_keys(
+        self, source_file: str, keys_config: list
+    ) -> tuple[dict[str, DiscoveredSecret], list[tuple[DiscoveredSecret, str]]]:
         """
         Process individual key configurations.
 
         Args:
+            source_file: Source configuration file name
             keys_config: List of key configuration dictionaries
 
         Returns:
             Tuple of (discovered_secrets, failed_secrets)
         """
         discovered_secrets: dict[str, DiscoveredSecret] = {}
-        failed_secrets: dict[str, str] = {}
+        failed_secrets: list[tuple[DiscoveredSecret, str]] = []
 
         for index, key_config in enumerate(keys_config):
             content = None
-            config_key = None
+            source_config_key = None
 
             # Try key_file first
             if "key_file" in key_config:
+                source_config_key = f"secrets.keys.{index}"
                 try:
                     with open(key_config["key_file"], "rb") as f:
                         content = f.read()
-                    config_key = f"secrets.privateKeys.{index}"
                     logger.info(f"Read key from file: {key_config['key_file']}")
                 except Exception as e:
                     # Track failure for prompting
-                    secret_key = f"matrixAuthenticationService.privateKeys.{index}"
+                    ess_secret_key = f"matrixAuthenticationService.privateKeys.{index}"
                     error_msg = f"Failed to read key file {key_config['key_file']}: {e}"
-                    failed_secrets[secret_key] = error_msg
+                    failed_secret = DiscoveredSecret(
+                        source_file=source_file,
+                        secret_key=ess_secret_key,
+                        config_key=source_config_key,
+                        value="",
+                    )
+                    failed_secrets.append((failed_secret, error_msg))
                     logger.warning(error_msg)
                     continue
 
             # Try inline key content
             elif "key" in key_config:
                 content = key_config["key"].encode("utf-8")
-                config_key = f"secrets.privateKeys.{index}"
+                source_config_key = f"secrets.keys.{index}"
                 logger.info("Read key from inline content")
 
-            if content and config_key:
+            if content and source_config_key:
                 key_type = detect_key_type(content)
                 if key_type in ["rsa", "ecdsaPrime256v1", "ecdsaSecp256k1", "ecdsaSecp384r1"]:
-                    secret_key = f"matrixAuthenticationService.privateKeys.{key_type}"
+                    ess_secret_key = f"matrixAuthenticationService.privateKeys.{key_type}"
                     # Only set if not already discovered (prefer individual keys over directory)
-                    if secret_key not in discovered_secrets:
+                    if ess_secret_key not in discovered_secrets:
                         discovered_secret = DiscoveredSecret(
-                            source_file="mas.yaml",
-                            secret_key=secret_key,
-                            config_key=config_key,
+                            source_file=source_file,
+                            secret_key=ess_secret_key,
+                            config_key=source_config_key,
                             value=content.decode("utf-8"),
                         )
-                        discovered_secrets[secret_key] = discovered_secret
+                        discovered_secrets[ess_secret_key] = discovered_secret
                         logger.info(f"Discovered {key_type} key from individual configuration")
 
         return (discovered_secrets, failed_secrets)

--- a/packages/ess-migration-tool/src/ess_migration_tool/mas.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/mas.py
@@ -552,9 +552,9 @@ class MASExtraFileDiscovery(ExtraFilesDiscoveryStrategy):
 
     @property
     def ignored_config_keys(self) -> list[str]:
-        # Keep secrets.keys_dir in ignored keys for extra files discovery
-        # as it's processed by specialized key discovery logic
-        return ["secrets.keys_dir"]
+        # Keep secrets.keys_dir and secrets.keys in ignored keys for extra files discovery
+        # as they are processed by specialized key discovery logic
+        return ["secrets.keys_dir", "secrets.keys"]
 
     @property
     def ignored_file_paths(self) -> list[str]:

--- a/packages/ess-migration-tool/src/ess_migration_tool/migration.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/migration.py
@@ -30,6 +30,7 @@ from .utils import (
     get_nested_value,
     remove_nested_value,
     set_nested_value,
+    sort_tracked_values_for_filtering,
     to_kebab_case,
     yaml_dump_with_pipe_for_multiline,
 )
@@ -66,7 +67,9 @@ def additional_config_transformer(
     filtered_config = copy.deepcopy(source_config)
 
     # Filter out values already processed by other transformations
-    for source_path in config_value_transformer.tracked_values:
+    # Sort tracked values so list indices are removed in descending order to avoid shifting
+    sorted_tracked = sort_tracked_values_for_filtering(config_value_transformer.tracked_values)
+    for source_path in sorted_tracked:
         remove_nested_value(filtered_config, source_path)
 
     # Note: This runs after filtering so we check the remaining config
@@ -212,7 +215,9 @@ class ConfigValueTransformer:
         """
         filtered_config = copy.deepcopy(config)
 
-        for source_path in self.tracked_values:
+        # Sort tracked values so list indices are removed in descending order to avoid shifting
+        sorted_tracked = sort_tracked_values_for_filtering(self.tracked_values)
+        for source_path in sorted_tracked:
             remove_nested_value(filtered_config, source_path)
 
         return filtered_config

--- a/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
@@ -33,8 +33,9 @@ class SecretDiscovery:
 
     discovered_secrets: dict[str, DiscoveredSecret] = field(default_factory=dict)  # Secrets with source tracking
     init_by_ess_secrets: list[str] = field(default_factory=list)  # Secrets to be initialized by ESS
-    missing_required_secrets: list[str] = field(default_factory=list)  # Secrets missing from configuration
-    secret_discovery_failures: dict[str, str] = field(default_factory=dict)  # secret_key -> failure_reason
+    missing_required_secrets: list[tuple[DiscoveredSecret, str | None]] = field(
+        default_factory=list
+    )  # (DiscoveredSecret, error_message) for required but missing/failed secrets
 
     def discover_secrets(self, config_data: dict) -> None:
         """Discover secrets from configuration data."""
@@ -44,7 +45,9 @@ class SecretDiscovery:
         self._discover_secrets_from_schema(config_data)
 
         # Component-specific secret discovery (e.g., for MAS keys)
-        component_secrets, component_failures = self.strategy.discover_component_specific_secrets(config_data)
+        component_secrets, component_failures = self.strategy.discover_component_specific_secrets(
+            self.source_file, config_data
+        )
         for secret_key, discovered_secret in component_secrets.items():
             # Check for exact match or wildcard pattern match
             matching_schema_key = find_matching_schema_key(secret_key, self.strategy.ess_secret_schema)
@@ -54,9 +57,8 @@ class SecretDiscovery:
             self.discovered_secrets[secret_key] = discovered_secret
 
         # Process component-specific discovery failures
-        for secret_key, error_message in component_failures.items():
-            # Track the failure
-            self.secret_discovery_failures[secret_key] = error_message
+        for discovered_secret, error_message in component_failures:
+            secret_key = discovered_secret.secret_key
 
             # Find matching schema key (could be wildcard pattern)
             matching_schema_key = find_matching_schema_key(secret_key, self.strategy.ess_secret_schema)
@@ -72,7 +74,7 @@ class SecretDiscovery:
             elif secret_config.init_if_missing_from_source_cfg:
                 self.init_by_ess_secrets.append(secret_key)
             else:
-                self.missing_required_secrets.append(secret_key)
+                self.missing_required_secrets.append((discovered_secret, error_message))
 
     def _discover_secrets_from_schema(self, config_data: dict) -> None:
         """Common discovery logic using the strategy's ess_secret_schema."""
@@ -81,6 +83,7 @@ class SecretDiscovery:
             if is_wildcard_pattern(secret_key):
                 continue
             discovered_value = None
+            error_msg: str | None = None
 
             if secret_config.config_inline:
                 # Direct value
@@ -100,10 +103,10 @@ class SecretDiscovery:
                         logging.info(f"Found file value for {secret_key}")
                     except FileNotFoundError:
                         logger.warning(f"File not found: {file_path}")
-                        self.secret_discovery_failures[secret_key] = f"File not found: {file_path}"
+                        error_msg = f"File not found: {file_path}"
                     except PermissionError:
                         logger.warning(f"Permission denied when reading file: {file_path}")
-                        self.secret_discovery_failures[secret_key] = f"Permission denied reading file: {file_path}"
+                        error_msg = f"Permission denied reading file: {file_path}"
 
             # Apply transformer if available and we have a value
             if discovered_value is not None and secret_config.transformer is not None:
@@ -129,15 +132,29 @@ class SecretDiscovery:
                 if secret_config.optional:
                     # Optional secrets are ignored if not found
                     continue
-                elif secret_config.init_if_missing_from_source_cfg:
+
+                # Build DiscoveredSecret with config_key from schema
+                # If there was an error reading from config_path, use that; otherwise prefer config_inline
+                config_key_for_missing = (
+                    secret_config.config_path if error_msg else secret_config.config_inline or secret_config.config_path
+                )
+                assert config_key_for_missing is not None
+                discovered_secret_still_missing = DiscoveredSecret(
+                    source_file=self.source_file,
+                    secret_key=secret_key,
+                    config_key=config_key_for_missing,
+                    value="",
+                )
+
+                if secret_config.init_if_missing_from_source_cfg:
                     self.init_by_ess_secrets.append(secret_key)
                 else:
-                    self.missing_required_secrets.append(secret_key)
+                    self.missing_required_secrets.append((discovered_secret_still_missing, error_msg))
 
     def validate_required_secrets(self) -> None:
         """Validate that all required secrets are present."""
         if self.missing_required_secrets:
-            missing_list = ", ".join(self.missing_required_secrets)
+            missing_list = ", ".join(ds.secret_key for ds, _ in self.missing_required_secrets)
             raise SecretsError(f"Missing required {self.strategy.secret_name} secrets: {missing_list}")
         logging.info(f"All required {self.strategy.secret_name} secrets are present")
 
@@ -146,9 +163,10 @@ class SecretDiscovery:
         if not self.missing_required_secrets:
             return
 
+        still_missing_secrets = []
         # Check if quiet mode is enabled
         if is_quiet_mode(self.pretty_logger):
-            missing_list = ", ".join(self.missing_required_secrets)
+            missing_list = ", ".join(ds.secret_key for ds, _ in self.missing_required_secrets)
             raise SecretsError(
                 f"Missing required {self.strategy.secret_name} secrets in quiet mode: {missing_list}. "
                 "Cannot prompt for secrets when --quiet is enabled."
@@ -161,7 +179,10 @@ class SecretDiscovery:
         self.pretty_logger.info(f"The following {component_name} secrets are required but could not be automatically")
         self.pretty_logger.info("discovered from your configuration files. Please provide them:")
 
-        for secret_key in self.missing_required_secrets[:]:
+        for discovered_secret, error_message in self.missing_required_secrets[:]:
+            secret_key = discovered_secret.secret_key
+            config_key = discovered_secret.config_key
+
             # Find matching schema key (supports wildcard patterns)
             matching_schema_key = find_matching_schema_key(secret_key, self.strategy.ess_secret_schema)
             assert matching_schema_key is not None
@@ -171,16 +192,11 @@ class SecretDiscovery:
             self.pretty_logger.info(f"   Secret path: {secret_key}")
 
             # Add failure reason if available
-            if secret_key in self.secret_discovery_failures:
-                self.pretty_logger.info(f"   ⚠️  {self.secret_discovery_failures[secret_key]}")
-                if "Permission denied" in self.secret_discovery_failures[secret_key]:
+            if error_message:
+                self.pretty_logger.info(f"   ⚠️  {error_message}")
+                if "Permission denied" in error_message:
                     self.pretty_logger.info("   💡 Use elevated privileges to read this file")
 
-            # The config key that will be injected in the configuration is preferably the path to the secret
-            # But we fallback to the config_inline in needed
-            config_key = secret_info.config_path
-            if not config_key:
-                config_key = secret_info.config_inline
             if not config_key:
                 raise RuntimeError(f"Missing configuration path for {secret_key}")
 
@@ -194,7 +210,6 @@ class SecretDiscovery:
                             config_key=config_key,
                             value=value,
                         )
-                        self.missing_required_secrets.remove(secret_key)
                         self.pretty_logger.info(f"   ✅ Secret stored for {secret_key}")
                         break
                     else:

--- a/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
@@ -138,7 +138,18 @@ class SecretDiscovery:
                 config_key_for_missing = (
                     secret_config.config_path if error_msg else secret_config.config_inline or secret_config.config_path
                 )
-                assert config_key_for_missing is not None
+
+                # If there's no way to discover this secret from the config (no config_inline or config_path),
+                # handle it specially:
+                # - If init_if_missing_from_source_cfg is True, add to init_by_ess_secrets
+                # - Otherwise, it will be discovered via component-specific discovery
+                if config_key_for_missing is None:
+                    if secret_config.init_if_missing_from_source_cfg:
+                        self.init_by_ess_secrets.append(secret_key)
+                    # In either case, we don't add to missing_required_secrets
+                    # because component-specific discovery will handle these
+                    continue
+
                 discovered_secret_still_missing = DiscoveredSecret(
                     source_file=self.source_file,
                     secret_key=secret_key,
@@ -163,7 +174,6 @@ class SecretDiscovery:
         if not self.missing_required_secrets:
             return
 
-        still_missing_secrets = []
         # Check if quiet mode is enabled
         if is_quiet_mode(self.pretty_logger):
             missing_list = ", ".join(ds.secret_key for ds, _ in self.missing_required_secrets)

--- a/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
@@ -220,6 +220,8 @@ class SecretDiscovery:
                             config_key=config_key,
                             value=value,
                         )
+                        # Remove from missing_required_secrets after successful prompt
+                        self.missing_required_secrets.remove((discovered_secret, error_message))
                         self.pretty_logger.info(f"   ✅ Secret stored for {secret_key}")
                         break
                     else:

--- a/packages/ess-migration-tool/src/ess_migration_tool/synapse.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/synapse.py
@@ -435,20 +435,21 @@ class SynapseSecretDiscovery(SecretDiscoveryStrategy):
         return "synapse"
 
     def discover_component_specific_secrets(
-        self, config_data: dict
-    ) -> tuple[dict[str, DiscoveredSecret], dict[str, str]]:
+        self, source_file: str, config_data: dict
+    ) -> tuple[dict[str, DiscoveredSecret], list[tuple[DiscoveredSecret, str]]]:
         """
         Discover component-specific secrets from configuration.
 
-        Synapse doesn't have specialized secret discovery, so this returns empty dicts.
+        Synapse doesn't have specialized secret discovery, so this returns empty dict/list.
 
         Args:
+            source_file: Source configuration file name
             config_data: Synapse configuration data
 
         Returns:
-            Tuple of (empty dict, empty dict) - no specialized secret discovery for Synapse
+            Tuple of (empty dict, empty list) - no specialized secret discovery for Synapse
         """
-        return ({}, {})
+        return ({}, [])
 
 
 class SynapseExtraFileDiscovery(ExtraFilesDiscoveryStrategy):

--- a/packages/ess-migration-tool/src/ess_migration_tool/utils.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/utils.py
@@ -8,6 +8,7 @@ import os
 import random
 import time
 import urllib.parse
+from collections import defaultdict
 from typing import Any
 
 import yaml
@@ -332,6 +333,43 @@ def is_quiet_mode(pretty_logger: logging.Logger) -> bool:
         True if quiet mode is enabled (logger level is CRITICAL), False otherwise
     """
     return pretty_logger.level == logging.CRITICAL
+
+
+def sort_tracked_values_for_filtering(tracked_values: list[str]) -> list[str]:
+    """
+    Sort tracked values so that list indices are processed in descending order.
+    This prevents the list shifting problem when removing indices sequentially.
+
+    For example: ['secrets.keys.0', 'secrets.keys.1', 'secrets.keys.2'] ->
+    ['secrets.keys.2', 'secrets.keys.1', 'secrets.keys.0']
+
+    Args:
+        tracked_values: List of dot-separated config paths
+
+    Returns:
+        Sorted list of paths with list indices in descending order within each parent
+    """
+    # Separate paths: regular paths and paths ending with numeric indices
+    regular_paths = []
+    indexed_paths_by_parent: dict[str, list] = defaultdict(list)
+
+    for path in tracked_values:
+        parts = path.rsplit(".", 1)
+        if len(parts) == 2 and parts[1].isdigit():
+            # This is a list index path like 'secrets.keys.2'
+            parent, index = parts
+            indexed_paths_by_parent[parent].append((int(index), path))
+        else:
+            regular_paths.append(path)
+
+    # Sort indexed paths by parent (sorted for determinism), then by index descending
+    sorted_indexed: list[str] = []
+    for parent in sorted(indexed_paths_by_parent.keys()):
+        sorted_indexed.extend(
+            path for _, path in sorted(indexed_paths_by_parent[parent], key=lambda x: x[0], reverse=True)
+        )
+
+    return regular_paths + sorted_indexed
 
 
 def prompt_for_database_choice(pretty_logger) -> bool:

--- a/packages/ess-migration-tool/tests/conftest.py
+++ b/packages/ess-migration-tool/tests/conftest.py
@@ -12,7 +12,7 @@ import pytest
 import yaml
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
 
 from .helm_validation import validate_helm_template
 
@@ -214,12 +214,18 @@ def write_mas_config(tmp_path):
 
 @pytest.fixture
 def basic_mas_config_with_individual_keys(tmp_path):
-    """MAS configuration with individual keys in the secrets.keys array for testing config_key fix."""
+    """MAS configuration with individual keys in the secrets.keys array for testing.
+
+    This fixture creates three key files:
+    - RSA key (index 0): Recognized format, will be imported as secret
+    - DSA key (index 1): Unrecognized format, will NOT be imported as secret
+    - ECDSA key (index 2): Recognized format, will be imported as secret
+    """
     # Create key files in tmp_path (which persists for the test duration)
     tmpdir_path = tmp_path / "mas_keys"
     tmpdir_path.mkdir(parents=True)
 
-    # Generate and save RSA key
+    # Generate and save RSA key (recognized format)
     rsa_key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
     rsa_pem = rsa_key.private_bytes(
         encoding=serialization.Encoding.PEM,
@@ -229,7 +235,17 @@ def basic_mas_config_with_individual_keys(tmp_path):
     rsa_key_file = tmpdir_path / "rsa_key.pem"
     rsa_key_file.write_bytes(rsa_pem)
 
-    # Generate and save ECDSA key
+    # Generate and save DSA key (unrecognized format - DSA is not supported by ESS)
+    dsa_key = dsa.generate_private_key(key_size=2048, backend=default_backend())
+    dsa_pem = dsa_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    dsa_key_file = tmpdir_path / "dsa_key.pem"
+    dsa_key_file.write_bytes(dsa_pem)
+
+    # Generate and save ECDSA key (recognized format)
     ecdsa_key = ec.generate_private_key(ec.SECP256R1(), backend=default_backend())
     ecdsa_pem = ecdsa_key.private_bytes(
         encoding=serialization.Encoding.PEM,
@@ -239,9 +255,6 @@ def basic_mas_config_with_individual_keys(tmp_path):
     ecdsa_key_file = tmpdir_path / "ecdsa_key.pem"
     ecdsa_key_file.write_bytes(ecdsa_pem)
 
-    # Create a non-existent key file path for testing failure handling
-    missing_key_file = tmpdir_path / "missing_key.pem"
-
     # Create MAS config with individual keys
     config = {
         "http": {"public_base": "https://auth.example.com", "bind": {"address": "0.0.0.0", "port": 8080}},
@@ -249,9 +262,9 @@ def basic_mas_config_with_individual_keys(tmp_path):
         "secrets": {
             "encryption": "my_encryption_key",
             "keys": [
-                {"key_file": str(rsa_key_file)},
-                {"key_file": str(missing_key_file)},  # This will fail
-                {"key_file": str(ecdsa_key_file)},
+                {"key_file": str(rsa_key_file)},  # Recognized: RSA
+                {"key_file": str(dsa_key_file)},  # Unrecognized: DSA - should NOT be imported
+                {"key_file": str(ecdsa_key_file)},  # Recognized: ECDSA with secp256r1
             ],
         },
         "matrix": {

--- a/packages/ess-migration-tool/tests/conftest.py
+++ b/packages/ess-migration-tool/tests/conftest.py
@@ -213,6 +213,57 @@ def write_mas_config(tmp_path):
 
 
 @pytest.fixture
+def basic_mas_config_with_individual_keys(tmp_path):
+    """MAS configuration with individual keys in the secrets.keys array for testing config_key fix."""
+    # Create key files in tmp_path (which persists for the test duration)
+    tmpdir_path = tmp_path / "mas_keys"
+    tmpdir_path.mkdir(parents=True)
+
+    # Generate and save RSA key
+    rsa_key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+    rsa_pem = rsa_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    rsa_key_file = tmpdir_path / "rsa_key.pem"
+    rsa_key_file.write_bytes(rsa_pem)
+
+    # Generate and save ECDSA key
+    ecdsa_key = ec.generate_private_key(ec.SECP256R1(), backend=default_backend())
+    ecdsa_pem = ecdsa_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    ecdsa_key_file = tmpdir_path / "ecdsa_key.pem"
+    ecdsa_key_file.write_bytes(ecdsa_pem)
+
+    # Create a non-existent key file path for testing failure handling
+    missing_key_file = tmpdir_path / "missing_key.pem"
+
+    # Create MAS config with individual keys
+    config = {
+        "http": {"public_base": "https://auth.example.com", "bind": {"address": "0.0.0.0", "port": 8080}},
+        "database": {"uri": "postgresql://mas:mas_password@postgres:5432/mas?sslmode=prefer"},
+        "secrets": {
+            "encryption": "my_encryption_key",
+            "keys": [
+                {"key_file": str(rsa_key_file)},
+                {"key_file": str(missing_key_file)},  # This will fail
+                {"key_file": str(ecdsa_key_file)},
+            ],
+        },
+        "matrix": {
+            "homeserver": "test.example.com",
+            "secret": "synapse_shared_secret_abcdef",
+            "endpoint": "http://synapse:8008",
+        },
+    }
+    return config
+
+
+@pytest.fixture
 def rsa_key_pem():
     """Generate a sample RSA private key in PEM format using PKCS1."""
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())

--- a/packages/ess-migration-tool/tests/test_main_e2e.py
+++ b/packages/ess-migration-tool/tests/test_main_e2e.py
@@ -695,3 +695,97 @@ def test_main_e2e_synapse_listeners_with_custom_listeners(
     listeners = listeners_config_content["listeners"]
     assert len(listeners) == 1, "Should have exactly one custom listener"
     assert listeners[0]["resources"][0]["names"] == ["custom_api"], "Should preserve custom_api resource"
+
+
+def test_main_e2e_mas_with_individual_keys(
+    monkeypatch,
+    tmp_path,
+    synapse_config_with_signing_key,
+    basic_mas_config_with_individual_keys,
+    write_synapse_config,
+    write_mas_config,
+    capsys,
+    helm_validator,
+):
+    """Test MAS migration with individual keys in secrets.keys array.
+
+    This test verifies that:
+    1. Individual keys are discovered and processed correctly
+    2. Failed individual keys have config_key set to secrets.keys.{index}
+    """
+    # Write Synapse config
+    synapse_config_file = write_synapse_config(synapse_config_with_signing_key)
+
+    # Write MAS config with individual keys (including one that will fail)
+    mas_config_file = write_mas_config(basic_mas_config_with_individual_keys)
+
+    # Create output directory
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    # Mock sys.argv to simulate CLI arguments
+    test_args = [
+        "migration",
+        "--synapse-config",
+        str(synapse_config_file),
+        "--mas-config",
+        str(mas_config_file),
+        "--output-dir",
+        str(output_dir),
+    ]
+
+    # Mock user input for database choice (select option 1 - existing database, default)
+    # We also need to provide input for the missing secret prompt
+    # The fixture has 3 keys: [rsa_key_file, missing_key_file, ecdsa_key_file]
+    # The missing_key_file will fail, so we need to provide input for secrets.keys.1
+    side_effect = (n for n in ("", "test_missing_key_value"))  # database choice, then missing key value
+    monkeypatch.setattr(sys, "argv", test_args)
+    monkeypatch.setattr("builtins.input", lambda _: next(side_effect))
+    exit_code = __main__.main()
+
+    # Verify successful execution
+    assert exit_code == 0
+
+    # Check that output files were created
+    values_file = output_dir / "values.yaml"
+    assert values_file.exists(), "values.yaml should be created"
+
+    # Load and verify the generated values
+    with open(values_file) as f:
+        generated_values = yaml.safe_load(f)
+
+    # Validate generated values against Helm templates
+    success, message = helm_validator(generated_values)
+    assert success, f"Helm template validation failed: {message}"
+
+    # Verify MAS configuration was migrated and is explicitly enabled
+    assert "matrixAuthenticationService" in generated_values
+    mas_config = generated_values["matrixAuthenticationService"]
+    assert mas_config["enabled"] is True, "matrixAuthenticationService.enabled should be True"
+
+    # Check for Secret files
+    secret_files = list(output_dir.glob("*secret.yaml"))
+    # Should have secret files for both Synapse and MAS
+    assert len(secret_files) >= 2, "Secret files should be created for both Synapse and MAS secrets"
+
+    # Verify MAS secrets were imported
+    mas_secret_file = next((sf for sf in secret_files if "matrix-authentication-service" in sf.name), None)
+    assert mas_secret_file is not None, "MAS secret file should be created"
+
+    with open(mas_secret_file) as f:
+        mas_secret_content = yaml.safe_load(f)
+
+    # Verify the RSA and ECDSA keys were imported (index 0 and 2 succeed)
+    assert "matrixAuthenticationService.privateKeys.rsa" in mas_secret_content["data"]
+    assert "matrixAuthenticationService.privateKeys.ecdsaPrime256v1" in mas_secret_content["data"]
+
+    # Verify the missing key (index 1) is NOT in the secret data (since it wasn't in the config_file)
+    # But the key should have been prompted for and stored
+    # The secret file should have data for the provided missing key value
+    assert len(mas_secret_content["data"]) >= 5  # encryption, synapseSharedSecret, postgres.password, rsa, ecdsa
+
+    # Verify that the additional config doesn't contain keys_dir
+    mas_additional_config = yaml.safe_load(mas_config["additional"]["00-imported.yaml"]["config"])
+    assert "keys_dir" not in mas_additional_config.get("secrets", {})
+    # Verify that keys array is not in additional config (as it's processed as secrets)
+    assert "keys" not in mas_additional_config.get("secrets", {})

--- a/packages/ess-migration-tool/tests/test_main_e2e.py
+++ b/packages/ess-migration-tool/tests/test_main_e2e.py
@@ -710,13 +710,18 @@ def test_main_e2e_mas_with_individual_keys(
     """Test MAS migration with individual keys in secrets.keys array.
 
     This test verifies that:
-    1. Individual keys are discovered and processed correctly
-    2. Failed individual keys have config_key set to secrets.keys.{index}
+    1. Recognized key formats (RSA, ECDSA with supported curves) are imported into secrets
+    2. Unrecognized key formats (e.g., DSA) are NOT imported and remain in the additional config
+    3. Failed individual keys have config_key set to secrets.keys.{index}
     """
+    # Get the DSA key file path from the fixture for assertion later
+    # The fixture creates files: dsa_key.pem (index 1), ecdsa_key.pem (index 2), rsa_key.pem (index 0)
+    dsa_key_file = tmp_path / "mas_keys" / "dsa_key.pem"
+
     # Write Synapse config
     synapse_config_file = write_synapse_config(synapse_config_with_signing_key)
 
-    # Write MAS config with individual keys (including one that will fail)
+    # Write MAS config with individual keys (using the fixture)
     mas_config_file = write_mas_config(basic_mas_config_with_individual_keys)
 
     # Create output directory
@@ -735,10 +740,8 @@ def test_main_e2e_mas_with_individual_keys(
     ]
 
     # Mock user input for database choice (select option 1 - existing database, default)
-    # We also need to provide input for the missing secret prompt
-    # The fixture has 3 keys: [rsa_key_file, missing_key_file, ecdsa_key_file]
-    # The missing_key_file will fail, so we need to provide input for secrets.keys.1
-    side_effect = (n for n in ("", "test_missing_key_value"))  # database choice, then missing key value
+    # No missing key prompts needed since all key files exist
+    side_effect = (n for n in ("",))  # database choice only
     monkeypatch.setattr(sys, "argv", test_args)
     monkeypatch.setattr("builtins.input", lambda _: next(side_effect))
     exit_code = __main__.main()
@@ -775,17 +778,22 @@ def test_main_e2e_mas_with_individual_keys(
     with open(mas_secret_file) as f:
         mas_secret_content = yaml.safe_load(f)
 
-    # Verify the RSA and ECDSA keys were imported (index 0 and 2 succeed)
+    # Verify the RSA and ECDSA keys were imported (recognized formats at index 0 and 2)
     assert "matrixAuthenticationService.privateKeys.rsa" in mas_secret_content["data"]
     assert "matrixAuthenticationService.privateKeys.ecdsaPrime256v1" in mas_secret_content["data"]
 
-    # Verify the missing key (index 1) is NOT in the secret data (since it wasn't in the config_file)
-    # But the key should have been prompted for and stored
-    # The secret file should have data for the provided missing key value
-    assert len(mas_secret_content["data"]) >= 5  # encryption, synapseSharedSecret, postgres.password, rsa, ecdsa
+    # Verify the DSA key (unrecognized format at index 1) is NOT in the secret data
+    assert "matrixAuthenticationService.privateKeys.dsa" not in mas_secret_content["data"]
+    # Should have: encryption, synapseSharedSecret, postgres.password, rsa, ecdsaPrime256v1
+    assert len(mas_secret_content["data"]) == 5
 
     # Verify that the additional config doesn't contain keys_dir
     mas_additional_config = yaml.safe_load(mas_config["additional"]["00-imported.yaml"]["config"])
     assert "keys_dir" not in mas_additional_config.get("secrets", {})
-    # Verify that keys array is properly filtered out (all individual keys were imported as secrets)
-    assert mas_additional_config.get("secrets", {}).get("keys", []) == []
+
+    # Verify that the DSA key (unrecognized format, index 1) remains in the additional config
+    # Only recognized keys (index 0 and 2) should be filtered out, leaving index 1
+    secrets_keys = mas_additional_config.get("secrets", {}).get("keys", [])
+    assert len(secrets_keys) == 1, "Unrecognized key (DSA) should remain in additional config"
+    # The remaining key should be the DSA key at index 1
+    assert secrets_keys[0]["key_file"] == str(dsa_key_file)

--- a/packages/ess-migration-tool/tests/test_main_e2e.py
+++ b/packages/ess-migration-tool/tests/test_main_e2e.py
@@ -787,5 +787,5 @@ def test_main_e2e_mas_with_individual_keys(
     # Verify that the additional config doesn't contain keys_dir
     mas_additional_config = yaml.safe_load(mas_config["additional"]["00-imported.yaml"]["config"])
     assert "keys_dir" not in mas_additional_config.get("secrets", {})
-    # Verify that keys array is not in additional config (as it's processed as secrets)
-    assert "keys" not in mas_additional_config.get("secrets", {})
+    # Verify that keys array is properly filtered out (all individual keys were imported as secrets)
+    assert mas_additional_config.get("secrets", {}).get("keys", []) == []

--- a/packages/ess-migration-tool/tests/test_mas_secrets.py
+++ b/packages/ess-migration-tool/tests/test_mas_secrets.py
@@ -166,16 +166,13 @@ def test_individual_keys_discovery(tmp_path, rsa_key_pem, ecdsa_key_pem):
     assert discovery.discovered_secrets["matrixAuthenticationService.privateKeys.rsa"].value == rsa_key_pem.decode(
         "utf-8"
     )
-    assert (
-        discovery.discovered_secrets["matrixAuthenticationService.privateKeys.rsa"].config_key
-        == "secrets.privateKeys.0"
-    )
+    assert discovery.discovered_secrets["matrixAuthenticationService.privateKeys.rsa"].config_key == "secrets.keys.0"
 
     # Verify ECDSA key was discovered from inline content
     ecdsa_secret = discovery.discovered_secrets["matrixAuthenticationService.privateKeys.ecdsaPrime256v1"]
     assert "matrixAuthenticationService.privateKeys.ecdsaPrime256v1" in discovery.discovered_secrets
     assert ecdsa_secret.value == ecdsa_key_pem.decode("utf-8")
-    assert ecdsa_secret.config_key == "secrets.privateKeys.1"
+    assert ecdsa_secret.config_key == "secrets.keys.1"
 
 
 def test_mixed_key_sources(tmp_path, rsa_key_pem, ecdsa_key_pem):
@@ -220,10 +217,7 @@ def test_mixed_key_sources(tmp_path, rsa_key_pem, ecdsa_key_pem):
     assert discovery.discovered_secrets["matrixAuthenticationService.privateKeys.rsa"].value == rsa_key_pem.decode(
         "utf-8"
     )
-    assert (
-        discovery.discovered_secrets["matrixAuthenticationService.privateKeys.rsa"].config_key
-        == "secrets.privateKeys.0"
-    )
+    assert discovery.discovered_secrets["matrixAuthenticationService.privateKeys.rsa"].config_key == "secrets.keys.0"
     ecdsa_secret = discovery.discovered_secrets["matrixAuthenticationService.privateKeys.ecdsaPrime256v1"]
     assert ecdsa_secret.value == ecdsa_key_pem.decode("utf-8")
     assert ecdsa_secret.config_key == "secrets.keys_dir"

--- a/packages/ess-migration-tool/tests/test_nested_values.py
+++ b/packages/ess-migration-tool/tests/test_nested_values.py
@@ -11,6 +11,7 @@ from ess_migration_tool.utils import (
     path_matches_pattern,
     remove_nested_value,
     set_nested_value,
+    sort_tracked_values_for_filtering,
 )
 
 
@@ -240,3 +241,68 @@ def test_find_matching_schema_key_multiple_patterns():
     assert find_matching_schema_key("a.5.c", schema) == "a.*.c"
     assert find_matching_schema_key("x.5.y", schema) == "x.*.y"
     assert find_matching_schema_key("z.5.y", schema) is None
+
+
+# Tests for sort_tracked_values_for_filtering
+
+
+def test_sort_tracked_values_basic():
+    """Test basic sorting of list indices in descending order."""
+    tracked = ["a", "b.0", "b.1", "b.2"]
+    result = sort_tracked_values_for_filtering(tracked)
+    # Regular paths first (in their original order), then indexed paths sorted descending
+    assert result == ["a", "b.2", "b.1", "b.0"]
+
+
+def test_sort_tracked_values_multiple_parents():
+    """Test sorting with multiple parent groups."""
+    tracked = ["secrets.keys.0", "secrets.encryption", "secrets.keys.1", "other.value", "secrets.keys.2"]
+    result = sort_tracked_values_for_filtering(tracked)
+    # Regular paths first, then each parent's indices in descending order
+    assert result == ["secrets.encryption", "other.value", "secrets.keys.2", "secrets.keys.1", "secrets.keys.0"]
+
+
+def test_sort_tracked_values_no_indices():
+    """Test with no list indices."""
+    tracked = ["a", "b.c", "d.e.f"]
+    result = sort_tracked_values_for_filtering(tracked)
+    assert result == ["a", "b.c", "d.e.f"]
+
+
+def test_sort_tracked_values_nested_list_indices():
+    """Test with deeply nested paths where last part is an index."""
+    tracked = ["a.b.c.0", "a.b.c.1", "a.b.c.2"]
+    result = sort_tracked_values_for_filtering(tracked)
+    assert result == ["a.b.c.2", "a.b.c.1", "a.b.c.0"]
+
+
+def test_sort_tracked_values_mixed_numeric_non_numeric():
+    """Test with mixed paths - some ending in numbers, some not."""
+    tracked = ["a.0", "b.name", "a.1", "c.5", "b.other"]
+    result = sort_tracked_values_for_filtering(tracked)
+    # Regular paths first (in original order), then indexed paths sorted by parent then by index descending
+    assert result == ["b.name", "b.other", "a.1", "a.0", "c.5"]
+
+
+def test_sort_tracked_values_empty_list():
+    """Test with empty input."""
+    assert sort_tracked_values_for_filtering([]) == []
+
+
+def test_sort_tracked_values_single_element():
+    """Test with single element."""
+    assert sort_tracked_values_for_filtering(["a.0"]) == ["a.0"]
+
+
+def test_sort_tracked_values_index_zero():
+    """Test that index 0 is handled correctly."""
+    tracked = ["keys.0"]
+    result = sort_tracked_values_for_filtering(tracked)
+    assert result == ["keys.0"]
+
+
+def test_sort_tracked_values_real_world_mas_keys():
+    """Test the real-world case from MAS individual keys migration."""
+    tracked = ["secrets.encryption", "secrets.keys.0", "secrets.keys.1", "secrets.keys.2"]
+    result = sort_tracked_values_for_filtering(tracked)
+    assert result == ["secrets.encryption", "secrets.keys.2", "secrets.keys.1", "secrets.keys.0"]

--- a/packages/ess-migration-tool/tests/test_secrets_wildcard.py
+++ b/packages/ess-migration-tool/tests/test_secrets_wildcard.py
@@ -10,6 +10,7 @@ for future features that use wildcard notation in ess_secrets_schema.
 """
 
 import logging
+from typing import Any
 
 import pytest
 from ess_migration_tool.interfaces import SecretDiscoveryStrategy
@@ -42,8 +43,8 @@ class MockWildcardStrategy(SecretDiscoveryStrategy):
         return "test-component"
 
     def discover_component_specific_secrets(
-        self, config_data: dict
-    ) -> tuple[dict[str, DiscoveredSecret], dict[str, str]]:
+        self, source_file: str, config_data: dict[str, Any]
+    ) -> tuple[dict[str, DiscoveredSecret], list[tuple[DiscoveredSecret, str]]]:
         """
         Discover secrets with wildcard-expanded keys.
 
@@ -54,17 +55,18 @@ class MockWildcardStrategy(SecretDiscoveryStrategy):
             Tuple of (discovered_secrets, failed_secrets)
         """
         discovered: dict[str, DiscoveredSecret] = {}
-        failed: dict[str, str] = {}
+        failed: list[tuple[DiscoveredSecret, str]] = []
 
         # Simulate discovering certificate values from config
-        certs = config_data.get("certificates", [])
+        certs: list[dict[str, Any]] = config_data.get("certificates", [])
         for i, cert in enumerate(certs):
             if "value" in cert:
-                secret_key = f"certificates.{i}.value"
-                discovered[secret_key] = DiscoveredSecret(
-                    source_file="test.yaml",
-                    secret_key=secret_key,
-                    config_key=f"certificates.{i}.value",
+                ess_secret_key = f"certificates.{i}.value"  # ESS path
+                source_config_key = f"source.certificates.{i}.value"  # Source path - different
+                discovered[ess_secret_key] = DiscoveredSecret(
+                    source_file=source_file,
+                    secret_key=ess_secret_key,
+                    config_key=source_config_key,
                     value=cert["value"],
                 )
 
@@ -177,8 +179,8 @@ class MockWildcardStrategyWithFailures(SecretDiscoveryStrategy):
         return "test-component"
 
     def discover_component_specific_secrets(
-        self, config_data: dict
-    ) -> tuple[dict[str, DiscoveredSecret], dict[str, str]]:
+        self, source_file: str, config_data: dict[str, Any]
+    ) -> tuple[dict[str, DiscoveredSecret], list[tuple[DiscoveredSecret, str]]]:
         """
         Discover secrets with wildcard-expanded keys, including some failures.
 
@@ -186,32 +188,40 @@ class MockWildcardStrategyWithFailures(SecretDiscoveryStrategy):
             Tuple of (discovered_secrets, failed_secrets)
         """
         discovered: dict[str, DiscoveredSecret] = {}
-        failed: dict[str, str] = {}
+        failed: list[tuple[DiscoveredSecret, str]] = []
 
         # Simulate discovering certificate values from config (all succeed)
-        certs = config_data.get("certificates", [])
+        certs: list[dict[str, Any]] = config_data.get("certificates", [])
         for i, cert in enumerate(certs):
             if "value" in cert:
-                secret_key = f"certificates.{i}.value"
-                discovered[secret_key] = DiscoveredSecret(
-                    source_file="test.yaml",
-                    secret_key=secret_key,
-                    config_key=f"certificates.{i}.value",
+                ess_secret_key = f"certificates.{i}.value"
+                source_config_key = f"source.certificates.{i}.value"
+                discovered[ess_secret_key] = DiscoveredSecret(
+                    source_file=source_file,
+                    secret_key=ess_secret_key,
+                    config_key=source_config_key,
                     value=cert["value"],
                 )
 
         # Simulate some key failures
-        keys = config_data.get("keys", [])
+        keys: list[dict[str, Any]] = config_data.get("keys", [])
         for i, key in enumerate(keys):
-            secret_key = f"keys.{i}.private"
+            ess_secret_key = f"keys.{i}.private"
+            source_config_key = f"keys.{i}.private"
             # Simulate failure for keys without "private" field
             if "private" not in key:
-                failed[secret_key] = f"Failed to read key file for keys.{i}.private"
+                failed_secret = DiscoveredSecret(
+                    source_file=source_file,
+                    secret_key=ess_secret_key,
+                    config_key=source_config_key,
+                    value="",
+                )
+                failed.append((failed_secret, f"Failed to read key file for keys.{i}.private"))
             else:
-                discovered[secret_key] = DiscoveredSecret(
-                    source_file="test.yaml",
-                    secret_key=secret_key,
-                    config_key=f"keys.{i}.private",
+                discovered[ess_secret_key] = DiscoveredSecret(
+                    source_file=source_file,
+                    secret_key=ess_secret_key,
+                    config_key=source_config_key,
                     value=key["private"],
                 )
 
@@ -244,11 +254,15 @@ def test_wildcard_secret_prompt_for_missing(monkeypatch: pytest.MonkeyPatch):
     discovery.discover_secrets(component_config)
 
     # The failed secret should be in missing_required_secrets
-    assert "keys.0.private" in discovery.missing_required_secrets
-    assert "keys.0.private" in discovery.secret_discovery_failures
+    failed_secret_keys = [ds.secret_key for ds, _ in discovery.missing_required_secrets]
+    assert "keys.0.private" in failed_secret_keys
 
     # Verify failure message
-    assert "Failed to read key file" in discovery.secret_discovery_failures["keys.0.private"]
+    failure_tuples = [t for t in discovery.missing_required_secrets if t[0].secret_key == "keys.0.private"]
+    assert len(failure_tuples) == 1
+    error_message = failure_tuples[0][1]
+    assert error_message is not None
+    assert "Failed to read key file" in error_message
 
     # Use monkeypatch to provide input for the prompt
     monkeypatch.setattr("builtins.input", lambda _: "my-secret-value")

--- a/packages/ess-migration-tool/tests/test_secrets_wildcard.py
+++ b/packages/ess-migration-tool/tests/test_secrets_wildcard.py
@@ -273,4 +273,6 @@ def test_wildcard_secret_prompt_for_missing(monkeypatch: pytest.MonkeyPatch):
     # After prompting, the secret should be discovered
     assert "keys.0.private" in discovery.discovered_secrets
     assert discovery.discovered_secrets["keys.0.private"].value == "my-secret-value"
-    assert "keys.0.private" not in discovery.missing_required_secrets
+    # Check that the secret is no longer in missing_required_secrets
+    missing_secret_keys = {ds.secret_key for ds, _ in discovery.missing_required_secrets}
+    assert "keys.0.private" not in missing_secret_keys

--- a/packages/ess-migration-tool/tests/test_synapse_secrets.py
+++ b/packages/ess-migration-tool/tests/test_synapse_secrets.py
@@ -29,7 +29,8 @@ def test_discover_secrets_from_synapse_config(basic_synapse_config):
 
     # Should have discovered direct values
     assert discovery.discovered_secrets["synapse.postgres.password"].value == "dbpassword"
-    assert set(discovery.missing_required_secrets) == set(["synapse.signingKey"])
+    missing_secret_keys = {ds.secret_key for ds, _ in discovery.missing_required_secrets}
+    assert missing_secret_keys == {"synapse.signingKey"}
 
     # Test validation (should fail due to missing synapse.signingKey)
     with pytest.raises(SecretsError):
@@ -57,7 +58,8 @@ def test_discover_secrets_from_synapse_config_ess_managed(basic_synapse_config):
     assert "synapse.postgres.password" not in discovery.discovered_secrets
     # But should still discover other secrets
     assert discovery.discovered_secrets["synapse.registrationSharedSecret"].value == "my_registration_secret"
-    assert set(discovery.missing_required_secrets) == set(["synapse.signingKey"])
+    missing_secret_keys = {ds.secret_key for ds, _ in discovery.missing_required_secrets}
+    assert missing_secret_keys == {"synapse.signingKey"}
 
     # Test validation (should fail due to missing synapse.signingKey)
     with pytest.raises(SecretsError):
@@ -102,12 +104,16 @@ def test_permission_error_handling_for_secrets(tmp_path, basic_synapse_config):
     discovery.discover_secrets(synapse_config)
 
     # Signing key should be in missing required secrets due to permission error
-    assert "synapse.signingKey" in discovery.missing_required_secrets
+    missing_secret_keys = {ds.secret_key for ds, _ in discovery.missing_required_secrets}
+    assert "synapse.signingKey" in missing_secret_keys
 
-    # Check that the failure information is stored
-    assert "synapse.signingKey" in discovery.secret_discovery_failures
-    assert "Permission denied reading file:" in discovery.secret_discovery_failures["synapse.signingKey"]
-    assert str(restricted_key) in discovery.secret_discovery_failures["synapse.signingKey"]
+    # Check that the failure information is stored in missing_required_secrets tuple
+    signing_key_failures = [
+        error_msg for ds, error_msg in discovery.missing_required_secrets if ds.secret_key == "synapse.signingKey"
+    ]
+    assert len(signing_key_failures) == 1
+    assert "Permission denied reading file:" in signing_key_failures[0]
+    assert str(restricted_key) in signing_key_failures[0]
 
     # Other secrets should be discovered normally
     assert "synapse.postgres.password" in discovery.discovered_secrets


### PR DESCRIPTION
This removes `secret_discovery_failures` which was mapping errors to secret keys in a distinct structure. Instead, failures are now returned as tuple of `DiscoveredSecret error_msg`. The DiscoveredSecret contains metadata about the secret we attempted to discovered but which failed (source file, config key, etc), and the error message contains the error.

We also add a test for e2e testing of MAS individual keys as it was missing.

Adding this test discovered an issue with tracking keys as it was causing indice shifting when cleaning up the keys array. This is now fixed using a new function sorting key indices in reverse order in tracked values.


Built with Mistral devstral 2.