### PR TITLE
Enable url previews by default in Element Web for unencrypted messages

### DIFF
--- a/charts/matrix-stack/configs/element-web/config.json.tpl
+++ b/charts/matrix-stack/configs/element-web/config.json.tpl
@@ -1,6 +1,6 @@
 {{- /*
 Copyright 2025 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}

--- a/charts/matrix-stack/configs/element-web/config.json.tpl
+++ b/charts/matrix-stack/configs/element-web/config.json.tpl
@@ -28,6 +28,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- $_ := set $settingDefaults "UIFeature.registration" false -}}
 {{- $_ := set $settingDefaults "UIFeature.passwordReset" false  -}}
 {{- $_ := set $settingDefaults "UIFeature.deactivate" false -}}
+{{- $_ := set $settingDefaults "urlPreviewsEnabled" true -}}
 {{- $_ := set $config "embedded_pages" $embeddedPages -}}
 {{- $_ := set $config "sso_redirect_options" $ssoRedirectOptions -}}
 {{- end }}

--- a/charts/matrix-stack/configs/element-web/config.json.tpl
+++ b/charts/matrix-stack/configs/element-web/config.json.tpl
@@ -11,6 +11,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- $config := dict -}}
 {{- $mHomeserver := dict }}
 {{- $settingDefaults := dict -}}
+{{- $_ := set $settingDefaults "urlPreviewsEnabled" true -}}
 {{- if $root.Values.serverName }}
 {{- $_ := set $mHomeserver "server_name" (tpl $root.Values.serverName $root) }}
 {{- end }}
@@ -28,7 +29,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- $_ := set $settingDefaults "UIFeature.registration" false -}}
 {{- $_ := set $settingDefaults "UIFeature.passwordReset" false  -}}
 {{- $_ := set $settingDefaults "UIFeature.deactivate" false -}}
-{{- $_ := set $settingDefaults "urlPreviewsEnabled" true -}}
 {{- $_ := set $config "embedded_pages" $embeddedPages -}}
 {{- $_ := set $config "sso_redirect_options" $ssoRedirectOptions -}}
 {{- end }}

--- a/newsfragments/1262.changed.md
+++ b/newsfragments/1262.changed.md
@@ -1,0 +1,1 @@
+Default Element Web's URL previews in unencrypted rooms to on.

--- a/tests/manifests/test_element_web.py
+++ b/tests/manifests/test_element_web.py
@@ -20,7 +20,9 @@ async def test_config_json_override(values, make_templates):
                 "default_server_config": {"m.homeserver": {}},
                 "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx",
                 "mobile_guide_app_variant": "element",
-                "setting_defaults": {},
+                "setting_defaults": {
+                    "urlPreviewsEnabled": True,
+                },
             }
             break
     else:
@@ -48,7 +50,9 @@ async def test_config_json_override(values, make_templates):
                 "default_server_config": {"m.homeserver": {}},
                 "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx",
                 "mobile_guide_app_variant": "element-classic",
-                "setting_defaults": {},
+                "setting_defaults": {
+                    "urlPreviewsEnabled": True,
+                },
                 "other_key": {"other_value": "value_second"},
                 "some_key": {"some_subkey": "override"},
                 "again_other_key": {"other_value": "value_third"},


### PR DESCRIPTION
Ref https://github.com/element-hq/element-web/blob/develop/apps/web/src/settings/Settings.tsx#L1122