### PR TITLE
Default homeserver usage statistics to on

### DIFF
--- a/charts/matrix-stack/ci/fragments/synapse-disable-usage-statistics.yaml
+++ b/charts/matrix-stack/ci/fragments/synapse-disable-usage-statistics.yaml
@@ -1,0 +1,9 @@
+# Copyright 2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+synapse:
+  additional:
+    disable-usage-statistics.yaml:
+      config: |
+        report_stats: false

--- a/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
@@ -10,7 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 web_client_location: https://{{ $root.Values.elementWeb.ingress.host }}/
 {{- end }}
 
-report_stats: false
+report_stats: true
 
 require_auth_for_profile_requests: true
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -16,6 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-only
    - [Configuring Element Web](#configuring-element-web)
    - [Configuring Hookshot](#configuring-hookshot)
    - [Configuring Synapse](#configuring-synapse)
+     - [Worked example: disabling homeserver usage statistics](#worked-example-disabling-homeserver-usage-statistics)
    - [Configuring Matrix Authentication Service](#configuring-matrix-authentication-service)
    - [Configuring Matrix RTC](#configuring-matrix-rtc)
      - [Networking](#networking)
@@ -168,6 +169,19 @@ synapse:
 One common Synapse configuration option that can't be set by this mechanism is `max_upload_size`.
 This is controlled by `synapse.media.maxUploadSize`.
 This is so that Ingress controller specific annotations can be adjusted to match.
+
+#### Worked example: disabling homeserver usage statistics
+
+By default ESS Community submits [homeserver usage statistics](https://element-hq.github.io/synapse/latest/usage/administration/monitoring/reporting_homeserver_usage_statistics.html).
+[`charts/matrix-stack/ci/fragments/synapse-disable-usage-statistics.yaml`] or below show how these can be disabled:
+
+```yml
+synapse:
+  additional:
+    disable-usage-statistics.yaml:
+      config: |
+        report_stats: false
+```
 
 ### Configuring Matrix Authentication Service
 

--- a/newsfragments/1263.changed.md
+++ b/newsfragments/1263.changed.md
@@ -1,0 +1,12 @@
+Report homeserver usage statistics by default.
+
+[Reporting Homeserver usage statistics](https://element-hq.github.io/synapse/latest/usage/administration/monitoring/reporting_homeserver_usage_statistics.html) documents what information is collected
+
+This can be opted out of with the below or `charts/matrix-stack/ci/fragments/synapse-disable-usage-statistics.yaml`:
+```yaml
+synapse:
+  additional:
+    disable-usage-statistics.yaml:
+      config: |
+        report_stats: false
+```


### PR DESCRIPTION
Draft as awaiting product decision