### PR TITLE
Migration: Handle conflicts when multiple source config handle the same ESS value

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1266.feature.md
+++ b/packages/ess-migration-tool/newsfragments/1266.feature.md
@@ -1,0 +1,1 @@
+Handle configuration sources conflicts when generating ESS values.

--- a/packages/ess-migration-tool/src/ess_migration_tool/engine.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/engine.py
@@ -14,8 +14,9 @@ from typing import Any
 from .inputs import InputProcessor
 from .mas import MASExtraFileDiscovery, MASMigration, MASSecretDiscovery
 from .migration import MigrationService
-from .models import ConfigMap, DiscoveredSecret, GlobalOptions, Secret
+from .models import ConfigMap, DiscoveredSecret, GlobalOptions, Secret, ValueSourceTracking
 from .synapse import SynapseExtraFileDiscovery, SynapseMigration, SynapseSecretDiscovery
+from .utils import resolve_value_conflicts
 
 logger = logging.getLogger("migration")
 
@@ -34,6 +35,7 @@ class MigrationEngine:
     init_by_ess_secrets: list[str] = field(default_factory=list)
     migrators: list[MigrationService] = field(default_factory=list)
     global_options: GlobalOptions = field(default_factory=GlobalOptions)
+    value_source_tracking: ValueSourceTracking = field(default_factory=ValueSourceTracking)
 
     def __post_init__(self) -> None:
         """Initialize the migration engine."""
@@ -78,10 +80,18 @@ class MigrationEngine:
         for migrator in self.migrators:
             migrator.migrate()
 
-            # Collect override warnings
+            # Collect override warnings, secrets, and value sources
             self.override_warnings.extend(migrator.override_warnings)
             self.discovered_secrets.extend(migrator.discovered_secrets)
             self.init_by_ess_secrets.extend(migrator.init_by_ess_secrets)
+
+            # Collect value sources from this migrator
+            for path, sources in migrator.value_source_tracking.sources.items():
+                for source in sources:
+                    self.value_source_tracking.add_source(path, source.strategy_name, source.value, source.source_path)
+
+        # Resolve conflicts after all migrations
+        resolve_value_conflicts(self.pretty_logger, self.value_source_tracking, self.ess_config)
 
         # Disable any ESS component that was not migrated (absent from config)
         ALL_ESS_COMPONENTS = {"synapse", "matrixAuthenticationService", "elementWeb", "elementAdmin", "matrixRTC"}

--- a/packages/ess-migration-tool/src/ess_migration_tool/mas.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/mas.py
@@ -248,6 +248,12 @@ class MASMigration(MigrationStrategy):
                 target_key="matrixAuthenticationService.enabled",
                 transformer=lambda *_, **__: True,
             ),
+            # matrix.homeserver -> serverName (maps to same ESS path as Synapse's server_name)
+            TransformationSpec(
+                src_key="matrix.homeserver",
+                target_key="serverName",
+                required=True,
+            ),
             TransformationSpec(
                 src_key="http.public_base",
                 target_key="matrixAuthenticationService.ingress.host",

--- a/packages/ess-migration-tool/src/ess_migration_tool/migration.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/migration.py
@@ -23,6 +23,7 @@ from .models import (
     MigrationInput,
     Secret,
     TransformationSpec,
+    ValueSourceTracking,
 )
 from .secrets import SecretDiscovery
 from .utils import (
@@ -64,16 +65,18 @@ def additional_config_transformer(
     override_configs = kwargs.get("override_configs", set())
     extra_files_discovery = kwargs.get("extra_files_discovery")
 
+    # Get tracked source paths from value_source_tracking
+    tracked_source_paths = config_value_transformer.value_source_tracking.get_tracked_source_paths()
+
     filtered_config = copy.deepcopy(source_config)
 
     # Filter out values already processed by other transformations
     # Sort tracked values so list indices are removed in descending order to avoid shifting
-    sorted_tracked = sort_tracked_values_for_filtering(config_value_transformer.tracked_values)
+    sorted_tracked = sort_tracked_values_for_filtering(tracked_source_paths)
     for source_path in sorted_tracked:
         remove_nested_value(filtered_config, source_path)
 
     # Note: This runs after filtering so we check the remaining config
-    # Get all src_keys from transformations that have been processed
     # Store warnings for future engine logging
     if override_configs and component_root_key:
         for override_config in override_configs:
@@ -126,8 +129,9 @@ class ConfigValueTransformer:
     pretty_logger: logging.Logger = field(init=True)  # Pretty logger
     ess_config: dict[str, Any] = field(init=True)  # Target ESS configuration dictionary
     results: list[TransformationResult] = field(default_factory=list)  # List of transformation results
-    tracked_values: list[str] = field(default_factory=list)  # Source paths that have been processed
     override_warnings: list[str] = field(default_factory=list)  # Warnings about ESS-managed overrides
+    value_source_tracking: ValueSourceTracking = field(default_factory=ValueSourceTracking)
+    strategy_name: str = ""  # Name of the strategy (for source tracking)
 
     def transform_from_config(
         self,
@@ -174,15 +178,15 @@ class ConfigValueTransformer:
                     f"Required configuration value '{transformation.src_key}' is missing from the source configuration"
                 )
             elif transformed_value is None:
-                # Even if transformation returns None, track the source key so it gets filtered out
-                # Skip tracking if src_key is None (it represents the full config, not a specific path)
-                if transformation.src_key is not None and transformation.src_key not in self.tracked_values:
-                    self.tracked_values.append(transformation.src_key)
+                # Even if transformation returns None, track it so it gets filtered out
+                if transformation.src_key is not None:
+                    self.register_value_source(
+                        ess_path=transformation.target_key,
+                        strategy_name=self.strategy_name,
+                        value=None,
+                        source_path=transformation.src_key,
+                    )
                 continue
-
-            # Track the source path if not already tracked (skip None as it's not a filterable path)
-            if transformation.src_key is not None and transformation.src_key not in self.tracked_values:
-                self.tracked_values.append(transformation.src_key)
 
             # Create TransformationResult using the current transformation spec
             result = TransformationResult(spec=transformation, value=transformed_value)
@@ -190,6 +194,19 @@ class ConfigValueTransformer:
 
             # Set the transformed value in the ESS config
             set_nested_value(self.ess_config, transformation.target_key, transformed_value)
+
+            # Auto-register value source for target_key if it has a src_key
+            if transformation.src_key is not None:
+                self.register_value_source(
+                    ess_path=transformation.target_key,
+                    strategy_name=self.strategy_name,
+                    value=transformed_value,
+                    source_path=transformation.src_key,
+                )
+
+    def register_value_source(self, ess_path: str, strategy_name: str, value: Any | None, source_path: str) -> None:
+        """Register that a strategy provides a value for an ESS path."""
+        self.value_source_tracking.add_source(ess_path, strategy_name, value, source_path)
 
     def get_component_config(self, component_key: str) -> dict[str, Any]:
         """
@@ -215,8 +232,11 @@ class ConfigValueTransformer:
         """
         filtered_config = copy.deepcopy(config)
 
+        # Get tracked source paths from value_source_tracking
+        tracked_source_paths = self.value_source_tracking.get_tracked_source_paths()
+
         # Sort tracked values so list indices are removed in descending order to avoid shifting
-        sorted_tracked = sort_tracked_values_for_filtering(self.tracked_values)
+        sorted_tracked = sort_tracked_values_for_filtering(tracked_source_paths)
         for source_path in sorted_tracked:
             remove_nested_value(filtered_config, source_path)
 
@@ -293,7 +313,12 @@ class ConfigValueTransformer:
 
             # Track the config value that is being passed to ESS
             # We need to track the original config path so it gets filtered out later
-            self.tracked_values.append(discover_secret.config_key)
+            self.register_value_source(
+                ess_path=discover_secret.secret_key,
+                strategy_name=self.strategy_name,
+                value=None,
+                source_path=discover_secret.config_key,
+            )
 
     def handle_extra_files_mounts(
         self,
@@ -317,10 +342,15 @@ class ConfigValueTransformer:
 
         configmap = ConfigMap(name=configmap_name, data=configmap_data)
 
-        # Add skipped paths to tracked_values for override detection
+        # Add skipped paths to tracking for filtering
         for discovered_path in extra_files_discovery.discovered_file_paths:
             if discovered_path.skipped_reason:
-                self.tracked_values.append(discovered_path.config_key)
+                self.register_value_source(
+                    ess_path=discovered_path.config_key,
+                    strategy_name=self.strategy_name,
+                    value=None,
+                    source_path=discovered_path.config_key,
+                )
 
         for extra_file in extra_files_discovery.discovered_extra_files.values():
             for discovered_path in extra_file.discovered_source_paths:
@@ -378,6 +408,7 @@ class MigrationService:
     override_configs: set[str] = field(default_factory=set)  # Set of configurations that are managed by ESS
     results: list[TransformationResult] = field(default_factory=list)  # List of transformation results
     global_options: GlobalOptions = field(default_factory=GlobalOptions)  # Global migration options
+    value_source_tracking: ValueSourceTracking = field(default_factory=ValueSourceTracking)
 
     def __post_init__(self):
         self.override_configs = self.migration.override_configs
@@ -421,6 +452,9 @@ class MigrationService:
 
         config_to_ess_transformer = ConfigValueTransformer(self.pretty_logger, self.ess_config)
 
+        # Set strategy name for source tracking
+        config_to_ess_transformer.strategy_name = self.migration.name
+
         # Step 3: Handle secrets for the component using the transformer's method
         # This will update the root ESS config directly and create Kubernetes Secrets
         config_to_ess_transformer.handle_secrets(
@@ -444,6 +478,11 @@ class MigrationService:
             extra_files_discovery=extra_files_discovery,
         )
 
-        # Step 6: Store results and override warnings
+        # Step 6: Collect value sources from transformer
+        for path, sources in config_to_ess_transformer.value_source_tracking.sources.items():
+            for source in sources:
+                self.value_source_tracking.add_source(path, source.strategy_name, source.value, source.source_path)
+
+        # Step 7: Store results and override warnings
         self.results.extend(config_to_ess_transformer.results)
         self.override_warnings.extend(config_to_ess_transformer.override_warnings)

--- a/packages/ess-migration-tool/src/ess_migration_tool/models.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/models.py
@@ -138,3 +138,39 @@ class SecretConfig:
     transformer: Callable[[str], str | None] | None = (
         None  # Optional transformer function for extracting secrets from complex values
     )
+
+
+@dataclass
+class ValueSource:
+    """Represents a source of a value for an ESS configuration path."""
+
+    strategy_name: str
+    source_path: str
+    value: Any | None
+
+
+@dataclass
+class ValueSourceTracking:
+    """Tracks all sources for ESS configuration values across strategies."""
+
+    sources: dict[str, list[ValueSource]] = field(default_factory=dict)
+
+    def add_source(self, ess_path: str, strategy_name: str, value: Any | None, source_path: str) -> None:
+        """Add a source for an ESS path."""
+        if ess_path not in self.sources:
+            self.sources[ess_path] = []
+        self.sources[ess_path].append(ValueSource(strategy_name=strategy_name, source_path=source_path, value=value))
+
+    def get_conflicts(self) -> dict[str, list[ValueSource]]:
+        """Get all ESS paths that have multiple sources from different strategies."""
+        conflicts = {}
+        for path, srcs in self.sources.items():
+            if len(srcs) > 1:
+                strategies = set(s.strategy_name for s in srcs)
+                if len(strategies) > 1:
+                    conflicts[path] = srcs
+        return conflicts
+
+    def get_tracked_source_paths(self) -> list[str]:
+        """Get all source paths that have been tracked (for filtering in additional config)."""
+        return [s.source_path for srcs in self.sources.values() for s in srcs if s.source_path is not None]

--- a/packages/ess-migration-tool/src/ess_migration_tool/utils.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/utils.py
@@ -19,7 +19,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 
-from .models import MigrationError
+from .models import MigrationError, ValueSourceTracking
 
 
 def yaml_dump_with_pipe_for_multiline(data: Any) -> str:
@@ -638,3 +638,51 @@ def prompt_yes_no(
         except EOFError as err:
             pretty_logger.info("\n   ❌ End of input reached")
             raise MigrationError("End of input reached during prompt") from err
+
+
+def resolve_value_conflicts(
+    pretty_logger: logging.Logger,
+    value_source_tracking: ValueSourceTracking,
+    ess_config: dict[str, Any],
+) -> None:
+    """Resolve conflicts where multiple strategies provide different values for same ESS path."""
+    conflicts = value_source_tracking.get_conflicts()
+    if not conflicts:
+        return
+
+    for ess_path, sources in sorted(conflicts.items()):
+        first_value = sources[0].value
+        all_same = all(str(v.value) == str(first_value) for v in sources)
+
+        if all_same:
+            logging.debug(f"Consistent values for {ess_path}: {first_value}")
+            continue
+
+        if is_quiet_mode(pretty_logger):
+            logging.info(f"Conflict detected for {ess_path}, using first value: {first_value}")
+            continue
+
+        pretty_logger.info(f"\n⚠️  CONFLICT for '{ess_path}'")
+        pretty_logger.info("   Multiple configurations provide different values:")
+        for source in sources:
+            pretty_logger.info(f"   • {source.strategy_name} ({source.source_path}): {source.value}")
+
+        value_to_strategies: dict[str, list[str]] = {}
+        for source in sources:
+            value_str = str(source.value)
+            value_to_strategies.setdefault(value_str, []).append(source.strategy_name)
+
+        options = [f"{v} (from: {', '.join(ss)})" for v, ss in value_to_strategies.items()]
+        options.append("Enter custom value")
+
+        choice = prompt_choice(pretty_logger, f"Select value for '{ess_path}':", options)
+
+        if choice == "Enter custom value":
+            new_value = prompt_value(pretty_logger, "Enter custom value:")
+            set_nested_value(ess_config, ess_path, new_value)
+        else:
+            value_str = choice.split(" (")[0]
+            final_value = next((s.value for s in sources if str(s.value) == value_str), first_value)
+            set_nested_value(ess_config, ess_path, final_value)
+
+        logging.info(f"Resolved {ess_path} = {final_value}")

--- a/packages/ess-migration-tool/tests/test_config_value_tracker.py
+++ b/packages/ess-migration-tool/tests/test_config_value_tracker.py
@@ -17,6 +17,7 @@ from ess_migration_tool.models import DiscoveredPath, GlobalOptions
 def test_config_value_tracker_basic():
     """Test basic ConfigValueTransformer functionality with dict-based transformations."""
     transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={"unchanged": "value"})
+    transformer.strategy_name = "TestStrategy"
 
     # Create a test config
     config = {
@@ -37,12 +38,12 @@ def test_config_value_tracker_basic():
         ],
     )
 
-    # Check tracked values
-    tracked_values = transformer.tracked_values
-    assert "database.host" in tracked_values
-    assert "database.port" in tracked_values
-    assert "server_name" in tracked_values
-    assert len(tracked_values) == 3
+    # Check tracked values via value_source_tracking
+    tracked_source_paths = transformer.value_source_tracking.get_tracked_source_paths()
+    assert "database.host" in tracked_source_paths
+    assert "database.port" in tracked_source_paths
+    assert "server_name" in tracked_source_paths
+    assert len(tracked_source_paths) == 3
 
     # Check transformations
     transformations = transformer.results
@@ -59,6 +60,7 @@ def test_config_value_tracker_basic():
 def test_config_value_tracker_filter_config():
     """Test ConfigValueTransformer filter_config functionality."""
     transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer.strategy_name = "TestStrategy"
 
     # Create a test config
     config = {
@@ -105,6 +107,7 @@ def test_config_value_tracker_filter_config():
 def test_config_value_tracker_nested_dict():
     """Test ConfigValueTransformer with nested dictionaries."""
     transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer.strategy_name = "TestStrategy"
 
     # Create a nested config
     config = {
@@ -134,13 +137,13 @@ def test_config_value_tracker_nested_dict():
         ],
     )
 
-    # Check tracked values
-    tracked_values = transformer.tracked_values
-    assert "database.connection.host" in tracked_values
-    assert "database.connection.port" in tracked_values
-    assert "database.credentials.user" in tracked_values
-    assert "server.name" in tracked_values
-    assert len(tracked_values) == 4
+    # Check tracked values via value_source_tracking
+    tracked_source_paths = transformer.value_source_tracking.get_tracked_source_paths()
+    assert "database.connection.host" in tracked_source_paths
+    assert "database.connection.port" in tracked_source_paths
+    assert "database.credentials.user" in tracked_source_paths
+    assert "server.name" in tracked_source_paths
+    assert len(tracked_source_paths) == 4
 
     # Check ESS config
     ess_config = transformer.ess_config
@@ -176,6 +179,7 @@ def test_config_value_tracker_empty():
 def test_update_paths_in_config_basic():
     """Test update_paths_in_config with basic file path updates."""
     transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer.strategy_name = "TestStrategy"
 
     # Create a mock ExtraFilesDiscovery with discovered file paths
     class MockStrategy(ExtraFilesDiscoveryStrategy):
@@ -240,12 +244,13 @@ def test_update_paths_in_config_basic():
     assert updated_config["other_setting"] == "preserved"  # Non-file setting should be unchanged
 
     # Verify tracked values (only skipped paths are tracked)
-    assert len(transformer.tracked_values) == 0  # No skipped paths in this test
+    assert len(transformer.value_source_tracking.get_tracked_source_paths()) == 0  # No skipped paths in this test
 
 
 def test_update_paths_in_config_with_skipped_paths():
     """Test update_paths_in_config with skipped file paths."""
     transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer.strategy_name = "TestStrategy"
 
     class MockStrategy(ExtraFilesDiscoveryStrategy):
         @property
@@ -305,14 +310,15 @@ def test_update_paths_in_config_with_skipped_paths():
     assert updated_config["templates"]["password_reset"] == "/path/to/password_reset.html"  # Unchanged
     assert updated_config["templates"]["registration"] == "/etc/some-component/extra/registration.html"  # Updated
 
-    assert "templates.password_reset" not in transformer.tracked_values
-    assert "templates.registration" not in transformer.tracked_values
-    assert len(transformer.tracked_values) == 0
+    assert "templates.password_reset" not in transformer.value_source_tracking.get_tracked_source_paths()
+    assert "templates.registration" not in transformer.value_source_tracking.get_tracked_source_paths()
+    assert len(transformer.value_source_tracking.get_tracked_source_paths()) == 0
 
 
 def test_update_paths_in_config_empty_discovery():
     """Test update_paths_in_config with no discovered files."""
     transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer.strategy_name = "TestStrategy"
 
     class MockStrategy(ExtraFilesDiscoveryStrategy):
         @property
@@ -353,12 +359,13 @@ def test_update_paths_in_config_empty_discovery():
 
     # Verify config is unchanged
     assert updated_config == source_config
-    assert len(transformer.tracked_values) == 0
+    assert len(transformer.value_source_tracking.get_tracked_source_paths()) == 0
 
 
 def test_update_paths_in_config_nested_config():
     """Test update_paths_in_config with nested configuration structures."""
     transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer.strategy_name = "TestStrategy"
 
     class MockStrategy(ExtraFilesDiscoveryStrategy):
         @property
@@ -426,4 +433,4 @@ def test_update_paths_in_config_nested_config():
     assert updated_config["other_setting"] == "preserved"  # Unchanged
 
     # Verify tracked values (only skipped paths are tracked)
-    assert len(transformer.tracked_values) == 0  # No skipped paths in this test
+    assert len(transformer.value_source_tracking.get_tracked_source_paths()) == 0  # No skipped paths in this test

--- a/packages/ess-migration-tool/tests/test_main_e2e.py
+++ b/packages/ess-migration-tool/tests/test_main_e2e.py
@@ -797,3 +797,90 @@ def test_main_e2e_mas_with_individual_keys(
     assert len(secrets_keys) == 1, "Unrecognized key (DSA) should remain in additional config"
     # The remaining key should be the DSA key at index 1
     assert secrets_keys[0]["key_file"] == str(dsa_key_file)
+
+
+def test_main_e2e_synapse_with_mas_different_server_name(
+    monkeypatch,
+    tmp_path,
+    synapse_config_with_signing_key,
+    basic_mas_config_with_keys,
+    write_synapse_config,
+    write_mas_config,
+    capsys,
+    helm_validator,
+):
+    """Test conflict resolution when Synapse and MAS have different serverName values.
+
+    Synapse has server_name='synapse.example.com' -> serverName
+    MAS has matrix.homeserver='mas.example.com' -> serverName
+    This should trigger a conflict prompt.
+    """
+    # Patch Synapse config to use different server_name
+    synapse_config = synapse_config_with_signing_key.copy()
+    synapse_config["server_name"] = "synapse.example.com"
+
+    # Patch MAS config to use different homeserver
+    mas_config = basic_mas_config_with_keys.copy()
+    mas_config["matrix"]["homeserver"] = "mas.example.com"
+
+    # Write configuration files
+    synapse_config_file = write_synapse_config(synapse_config)
+    mas_config_file = write_mas_config(mas_config)
+
+    # Create output directory
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    # Mock sys.argv to simulate CLI arguments
+    test_args = [
+        "migration",
+        "--synapse-config",
+        str(synapse_config_file),
+        "--mas-config",
+        str(mas_config_file),
+        "--output-dir",
+        str(output_dir),
+    ]
+
+    # Mock user inputs:
+    # 1. Database choice - use existing database (default, empty string)
+    # 2. Conflict resolution - select option 1 (synapse.example.com)
+    #    The prompt will be: "Select value for 'serverName':"
+    #    Options:
+    #    - "synapse.example.com (from: Synapse)"
+    #    - "mas.example.com (from: Matrix Authentication Service)"
+    #    - "Enter custom value"
+    #    Selection "1" picks synapse.example.com
+    side_effect = (n for n in ("", "1"))
+    monkeypatch.setattr(sys, "argv", test_args)
+    monkeypatch.setattr("builtins.input", lambda _: next(side_effect))
+    exit_code = __main__.main()
+
+    # Verify successful execution
+    assert exit_code == 0
+
+    # Check that output files were created
+    values_file = output_dir / "values.yaml"
+    assert values_file.exists(), "values.yaml should be created"
+
+    # Load and verify the generated values
+    with open(values_file) as f:
+        generated_values = yaml.safe_load(f)
+
+    # Validate generated values against Helm templates
+    success, message = helm_validator(generated_values)
+    assert success, f"Helm template validation failed: {message}"
+
+    # Verify the conflict was resolved to synapse.example.com (option 1)
+    assert generated_values["serverName"] == "synapse.example.com"
+
+    # Verify Synapse configuration was migrated
+    assert generated_values["synapse"]["enabled"] is True
+    assert generated_values["matrixAuthenticationService"]["enabled"] is True
+
+    # Verify the conflict prompt was shown in the output
+    captured = capsys.readouterr()
+    log_output = captured.err
+    assert "CONFLICT for 'serverName'" in log_output
+    assert "synapse.example.com" in log_output
+    assert "mas.example.com" in log_output


### PR DESCRIPTION
This tries to prevent an issue where the user might have misconfigured components and tries to migrate to ESS.

For MAS & Synapse, the existing setup would not work at all, so its probably a rare case. But with Element Web, config.json could target a distinct server name than the Synapse homeserver.yaml. We want the config to stay consistent, and the user should be warned of the inconsistencies.

If source configurations are misconfigured, the migration tool now prompts the user to choose a value between all that were found.