### PR TITLE
The quarantined_media_changes stream writer must have main in it too

### DIFF
--- a/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
@@ -231,6 +231,10 @@ stream_writers:
 {{- $workerTypeName := include "element-io.synapse.process.workerTypeName" (dict "root" $root "context" $workerType) }}
 {{- range $stream_writer := include "element-io.synapse.process.streamWriters" (dict "root" $root "context" $workerType) | fromJsonArray }}
   {{ $stream_writer }}:
+{{- /* Yes this is disgusting but until we have to handle either multiple workers sharing the same stream or more streams with main in them too, this is fine */}}
+{{- if eq $stream_writer "quarantined_media_changes" }}
+  - main
+{{- end }}
 {{- range $index := untilStep 0 ($workerDetails.replicas | int | default 1) 1 }}
   - {{ $root.Release.Name }}-synapse-{{ $workerTypeName }}-{{ $index }}
 {{- end }}

--- a/newsfragments/1267.changed.md
+++ b/newsfragments/1267.changed.md
@@ -1,0 +1,13 @@
+Upgrade Synapse to v1.152.0.
+
+If upgrading directly from ESS Community 25.12.1 or earlier, the [`event_resign` background update](https://element-hq.github.io/synapse/latest/usage/administration/admin_api/background_updates.html) will need to be manually run.
+If ESS Community 25.12.2 to 26.4.0 have been run on a deployment with `initSecrets` enabled (the default), this background update does not need to be manually run.
+If upgrading from ESS Community 25.12.1 or earlier or `initSecrets` was later disabled, full [instructions are available](https://github.com/element-hq/ess-helm/blob/main/docs/maintenance.md#fixing-cve-2026-24044elementsec-2025-1670-manually)
+
+Highlights:
+- Add a ["Listing quarantined media changes" Admin API](https://element-hq.github.io/synapse/latest/admin_api/media_admin_api.html#listing-quarantined-media-changes) for retrieving a paginated record of when media became (un)quarantined
+- Add a way to re-sign local events with a new signing key
+- Reduce database disk space usage by pruning old rows from `device_lists_changes_in_room`
+
+Full Changelogs:
+- [v1.152.0](https://github.com/element-hq/synapse/releases/tag/v1.152.0)


### PR DESCRIPTION
Fixes up #1259.

`main` must be in the `quarantined_media_changes` stream writer as that handles the background update (not to be confused with background worker that the background worker does, or backgrounds progresses, :upside_down_face:)

Done in this hacky way as we've got nothing else like this and so inverting the whole logic to return workers for a stream writer rather than stream writers for a worker seems overkill