### PR TITLE
Well-Known migration support

### DIFF
--- a/packages/ess-migration-tool/README.md
+++ b/packages/ess-migration-tool/README.md
@@ -35,8 +35,9 @@ Before running the migration tool, ensure you have:
 
 1. **A Synapse configuration file**: Access to `homeserver.yaml` file from your current Synapse installation
 2. **A Matrix Authentication Service configuration file (optional)**: Access to `config.yaml` file if you're already using MAS
-3. **Python 3.11+**: The tool requires Python 3.11 or higher
-4. **Access to configuration files**: Make sure your configuration files are accessible and readable
+3. **Well-Known delegation files (optional)**: Access to `.well-known/matrix/client`, `.well-known/matrix/server`, and `.well-known/matrix/support` files if you want to migrate Matrix delegation configuration
+4. **Python 3.11+**: The tool requires Python 3.11 or higher
+5. **Access to configuration files**: Make sure your configuration files are accessible and readable
 
 If the tool has access to the secrets referenced in the configuration files, the tool will automatically discover and use them in
 the resulting output files. If it does not have access to the secrets, it will prompt you to provide them manually.
@@ -55,10 +56,25 @@ ess-migration-tool --synapse-config /path/to/synapse/homeserver.yaml
 ess-migration-tool --synapse-config /path/to/synapse/homeserver.yaml --mas-config /path/to/mas/config.yaml
 ```
 
+### Migration with Well-Known Delegation Files
+
+```bash
+# From a directory containing client.json, server.json, support.json
+ess-migration-tool --synapse-config /path/to/synapse/homeserver.yaml --well-known-dir /path/to/well-known/
+
+# Or specify individual files
+ess-migration-tool --synapse-config /path/to/synapse/homeserver.yaml \
+  --well-known-client /path/to/client.json \
+  --well-known-server /path/to/server.json \
+  --well-known-support /path/to/support.json
+```
+
 ### Advanced Options
 
 ```bash
 usage: ess-migration-tool [-h] --synapse-config SYNAPSE_CONFIG [--mas-config MAS_CONFIG]
+                          [--well-known-dir WELL_KNOWN_DIR] [--well-known-client WELL_KNOWN_CLIENT]
+                          [--well-known-server WELL_KNOWN_SERVER] [--well-known-support WELL_KNOWN_SUPPORT]
                           [--output-dir OUTPUT_DIR] [--verbose] [--debug] [--quiet]
                           [--database-mode {existing,ess-managed}]
 
@@ -71,6 +87,18 @@ options:
                         configuration that contains server_name, database, listeners, etc.
   --mas-config MAS_CONFIG
                         Path to Matrix Authentication Service config.yaml configuration file.
+  --well-known-dir WELL_KNOWN_DIR
+                        Path to directory containing well-known delegation files (client.json, server.json,
+                        support.json). These files configure Matrix delegation for your domain.
+  --well-known-client WELL_KNOWN_CLIENT
+                        Path to a well-known client delegation file (client or client.json). Takes precedence
+                        over --well-known-dir if both are specified.
+  --well-known-server WELL_KNOWN_SERVER
+                        Path to a well-known server delegation file (server or server.json). Takes precedence
+                        over --well-known-dir if both are specified.
+  --well-known-support WELL_KNOWN_SUPPORT
+                        Path to a well-known support delegation file (support or support.json). Takes precedence
+                        over --well-known-dir if both are specified.
   --output-dir OUTPUT_DIR
                         Output directory for generated files (default: output). The migration will create Helm
                         values.yaml and any ConfigMap files in this directory.
@@ -86,9 +114,9 @@ options:
 
 The migration tool follows these steps:
 
-1. **Loading and validating input files**: Reads and validates your Synapse and MAS configuration files
+1. **Loading and validating input files**: Reads and validates your Synapse, MAS, and well-known delegation configuration files
 2. **Discovering secrets and extra files**: Automatically discovers secrets and extra files referenced in the configuration
-3. **Migrating configuration to ESS values**: Converts your existing configuration to ESS Helm values format
+3. **Migrating configuration to ESS values**: Converts your existing configuration to ESS Helm values format.
 5. **Writing output files**: Write the `values.yaml`, ConfigMaps, and Secrets to the output directory
 
 ## Output Files

--- a/packages/ess-migration-tool/newsfragments/1274.feature.md
+++ b/packages/ess-migration-tool/newsfragments/1274.feature.md
@@ -1,0 +1,1 @@
+Add support for migrating Well Known delegation configuration files (client.json, server.json, support.json) to ESS. Users can now specify well-known files via `--well-known-dir` for a directory containing the files, or individual files via `--well-known-client`, `--well-known-server`, and `--well-known-support`. Files can be with or without the `.json` extension.

--- a/packages/ess-migration-tool/src/ess_migration_tool/__main__.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/__main__.py
@@ -112,6 +112,33 @@ Examples:
     )
 
     parser.add_argument(
+        "--well-known-dir",
+        required=False,
+        help=(
+            "Path to directory containing well-known files "
+            "(client, client.json, server, server.json, support, support.json)"
+        ),
+    )
+
+    parser.add_argument(
+        "--well-known-client",
+        required=False,
+        help=("Path to client or client.json well-known file"),
+    )
+
+    parser.add_argument(
+        "--well-known-server",
+        required=False,
+        help=("Path to server or server.json well-known file"),
+    )
+
+    parser.add_argument(
+        "--well-known-support",
+        required=False,
+        help=("Path to support or support.json well-known file"),
+    )
+
+    parser.add_argument(
         "--output-dir",
         default="output",
         help=(
@@ -201,6 +228,14 @@ Examples:
             input_processor.load_migration_input(
                 name=ELEMENT_WEB_STRATEGY_NAME,
                 config_path=args.element_web_config,
+            )
+
+        if args.well_known_dir or args.well_known_client or args.well_known_server or args.well_known_support:
+            input_processor.load_well_known_inputs(
+                dir_path=args.well_known_dir,
+                client_path=args.well_known_client,
+                server_path=args.well_known_server,
+                support_path=args.well_known_support,
             )
 
         # Run migration

--- a/packages/ess-migration-tool/src/ess_migration_tool/engine.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/engine.py
@@ -19,6 +19,7 @@ from .migration import MigrationService
 from .models import ConfigMap, DiscoveredSecret, GlobalOptions, Secret, ValueSourceTracking
 from .synapse import SynapseExtraFileDiscovery, SynapseMigration, SynapseSecretDiscovery
 from .utils import resolve_value_conflicts
+from .well_known import WELL_KNOWN_COMPONENT_ROOT_KEY, WellKnownMigration
 
 logger = logging.getLogger("migration")
 
@@ -57,6 +58,30 @@ class MigrationEngine:
                 ElementWebMigration(self.global_options),
                 None,
                 GenericExtraFileDiscovery(component_name="Element Web", component_root_key="elementWeb"),
+            ),
+            (
+                WellKnownMigration(self.global_options, well_known_type="client"),
+                None,
+                GenericExtraFileDiscovery(
+                    component_name="Well Known Client",
+                    component_root_key=WELL_KNOWN_COMPONENT_ROOT_KEY,
+                ),
+            ),
+            (
+                WellKnownMigration(self.global_options, well_known_type="server"),
+                None,
+                GenericExtraFileDiscovery(
+                    component_name="Well Known Server",
+                    component_root_key=WELL_KNOWN_COMPONENT_ROOT_KEY,
+                ),
+            ),
+            (
+                WellKnownMigration(self.global_options, well_known_type="support"),
+                None,
+                GenericExtraFileDiscovery(
+                    component_name="Well Known Support",
+                    component_root_key=WELL_KNOWN_COMPONENT_ROOT_KEY,
+                ),
             ),
         ]
         for migration, secret_discovery_strategy, extra_file_strategy in components:

--- a/packages/ess-migration-tool/src/ess_migration_tool/inputs.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/inputs.py
@@ -17,6 +17,7 @@ from typing import Any
 import yaml
 
 from .models import MigrationError, MigrationInput
+from .well_known import WELL_KNOWN_FILE_PATTERNS, WELL_KNOWN_STRATEGY_NAMES
 
 logger = logging.getLogger("migration")
 
@@ -177,3 +178,85 @@ class InputProcessor:
                 config=config,
             )
         )
+
+    def load_well_known_inputs(
+        self,
+        dir_path: str | None = None,
+        client_path: str | None = None,
+        server_path: str | None = None,
+        support_path: str | None = None,
+    ) -> None:
+        """Load well-known delegation files as migration inputs."""
+        file_results = self._load_well_known_files(dir_path, client_path, server_path, support_path)
+
+        for strategy_name, source_path, config in file_results:
+            self.inputs.append(
+                MigrationInput(
+                    name=strategy_name,
+                    config_path=source_path,
+                    config=config,
+                )
+            )
+            logger.info(f"{strategy_name}: loaded from {source_path}")
+
+    @staticmethod
+    def _load_well_known_files(
+        dir_path: str | None = None,
+        client_path: str | None = None,
+        server_path: str | None = None,
+        support_path: str | None = None,
+    ) -> list[tuple[str, str, dict[str, Any]]]:
+        """
+        Load well-known delegation files from directory and/or individual paths.
+
+        Args:
+            dir_path: Path to directory containing well-known files
+            client_path: Path to client or client.json file
+            server_path: Path to server or server.json file
+            support_path: Path to support or support.json file
+
+        Returns:
+            List of tuples: (strategy_name, source_path, config_dict)
+            Only includes files that were found and loaded
+        """
+        results: list[tuple[str, str, dict[str, Any]]] = []
+
+        # Mapping of CLI arg to well-known type
+        arg_to_type = {
+            client_path: "client",
+            server_path: "server",
+            support_path: "support",
+        }
+
+        # Load individual files from CLI args first (highest precedence)
+        for arg_path, wk_type in arg_to_type.items():
+            if arg_path:
+                try:
+                    config = InputProcessor.load_json_file(arg_path)
+                    strategy_name = WELL_KNOWN_STRATEGY_NAMES[wk_type]
+                    results.append((strategy_name, arg_path, config))
+                except Exception as e:
+                    logger.warning(f"Failed to load {wk_type} file {arg_path}: {e}")
+
+        # Load from directory (lower precedence, only if not already loaded via CLI arg)
+        if dir_path:
+            dir_path_obj = Path(dir_path)
+            loaded_strategies: set[str] = {r[0] for r in results}
+
+            for wk_type, file_names in WELL_KNOWN_FILE_PATTERNS.items():
+                strategy_name = WELL_KNOWN_STRATEGY_NAMES[wk_type]
+                if strategy_name in loaded_strategies:
+                    continue
+
+                for file_name in file_names:
+                    file_path = dir_path_obj / file_name
+                    if file_path.is_file():
+                        try:
+                            config = InputProcessor.load_json_file(str(file_path))
+                            results.append((strategy_name, str(file_path), config))
+                            break
+                        except Exception as e:
+                            logger.warning(f"Failed to load {file_name} from directory: {e}")
+                            break
+
+        return results

--- a/packages/ess-migration-tool/src/ess_migration_tool/inputs.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/inputs.py
@@ -189,6 +189,13 @@ class InputProcessor:
         """Load well-known delegation files as migration inputs."""
         file_results = self._load_well_known_files(dir_path, client_path, server_path, support_path)
 
+        if not file_results:
+            raise ValidationError(
+                "No well-known delegation files found. "
+                "Expected to find client, client.json, server, server.json, support, or support.json "
+                "in the provided directory or via individual file arguments."
+            )
+
         for strategy_name, source_path, config in file_results:
             self.inputs.append(
                 MigrationInput(

--- a/packages/ess-migration-tool/src/ess_migration_tool/migration.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/migration.py
@@ -62,6 +62,8 @@ def additional_config_transformer(
     - use_file_object_format: bool - If True (default), return {"filename": {"config": string}} format.
       If False, return {"filename": string} format (direct string without wrapper object).
       Element Web uses False since its Helm template expects the value to be a JSON/YAML string directly.
+    - filename: str - Custom filename to use instead of the default "00-imported.{serialization_format}".
+      If provided, the file extension from serialization_format will be appended if not already present.
     """
     import json
 
@@ -75,8 +77,8 @@ def additional_config_transformer(
     serialization_format = kwargs.get("serialization_format", "yaml")
     use_file_object_format = kwargs.get("use_file_object_format", True)
 
-    # Determine file name from serialization format
-    file_name = f"00-imported.{serialization_format}"
+    # Determine file name from custom filename or default
+    file_name = kwargs.get("filename") or f"00-imported.{serialization_format}"
 
     # Get tracked source paths from value_source_tracking
     tracked_source_paths = config_value_transformer.value_source_tracking.get_tracked_source_paths()
@@ -117,14 +119,15 @@ def additional_config_transformer(
     if extra_files_discovery:
         filtered_config = config_value_transformer.update_paths_in_config(filtered_config, extra_files_discovery)
 
-    # Return in the expected additional config format
-    # Also preserve any existing entries in additional (like listeners.yml from other transformers)
-    if not filtered_config:
-        return {}
-
     # Check if there are existing entries in the component's additional section
     component_config = config_value_transformer.ess_config.get(component_root_key, {})
     existing_additional = component_config.get("additional", {})
+
+    # Return in the expected additional config format
+    # Also preserve any existing entries in additional (like listeners.yml from other transformers)
+    # If there's nothing to add, return existing entries without creating a new entry
+    if not filtered_config:
+        return existing_additional
 
     # Serialize the config
     if serialization_format == "json":

--- a/packages/ess-migration-tool/src/ess_migration_tool/utils.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/utils.py
@@ -320,17 +320,23 @@ def remove_nested_value(config: dict[str, Any], path: str) -> None:
 
 def extract_hostname_from_url(_, url: str, **kwargs: Any) -> str:
     """
-    Extract hostname from a URL string.
+    Extract hostname from a URL string or host:port string.
 
     Args:
-        url: URL string to parse
+        url: URL string or host:port string to parse
         **kwargs: Optional context parameters (unused)
 
     Returns:
         Hostname as string if successful, empty string otherwise
     """
-    parsed_url = urllib.parse.urlparse(url)
-    return parsed_url.hostname or ""
+    if not url:
+        return ""
+    # Prepend // if no scheme and contains : (host:port format e.g., "example.com:443")
+    # or if no :// at all (bare hostname e.g., "example.com")
+    if "://" not in url:
+        url = f"//{url}"
+    parsed = urllib.parse.urlparse(url)
+    return parsed.hostname or ""
 
 
 def to_kebab_case(name: str) -> str:

--- a/packages/ess-migration-tool/src/ess_migration_tool/well_known.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/well_known.py
@@ -1,0 +1,107 @@
+# Copyright 2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Well Known delegation migration strategy."""
+
+import json
+import logging
+from typing import Any
+
+from .migration import ConfigValueTransformer, MigrationStrategy, TransformationSpec
+from .models import GlobalOptions
+from .utils import extract_hostname_from_url
+
+logger = logging.getLogger("migration")
+
+WELL_KNOWN_COMPONENT_ROOT_KEY = "wellKnownDelegation"
+
+# File name patterns for each well-known type
+WELL_KNOWN_FILE_PATTERNS: dict[str, list[str]] = {
+    "client": ["client", "client.json"],
+    "server": ["server", "server.json"],
+    "support": ["support", "support.json"],
+}
+
+# Strategy names for each well-known type
+WELL_KNOWN_STRATEGY_NAMES: dict[str, str] = {
+    "client": "Well Known Client",
+    "server": "Well Known Server",
+    "support": "Well Known Support",
+}
+
+
+def to_json_string(_: ConfigValueTransformer, value: Any, **__: Any) -> str:
+    """Transform a value to a JSON string."""
+    if value is None:
+        return "{}"
+    return json.dumps(value)
+
+
+class WellKnownMigration(MigrationStrategy):
+    """Well Known delegation migration implementation.
+
+    Parameterized by well_known_type which can be "client", "server", or "support".
+    """
+
+    def __init__(self, global_options: GlobalOptions, well_known_type: str) -> None:
+        self.global_options = global_options
+        self.well_known_type = well_known_type
+
+    @property
+    def name(self) -> str:
+        return WELL_KNOWN_STRATEGY_NAMES[self.well_known_type]
+
+    @property
+    def override_configs(self) -> set[str]:
+        """Well-known configs are all user-provided, no ESS-managed overrides."""
+        return set()
+
+    @property
+    def underride_configs(self) -> set[str]:
+        """Well-known configs override ESS defaults (m.homeserver, m.server) - this is intentional."""
+        return set()
+
+    @property
+    def transformations(self) -> list[TransformationSpec]:
+        """Get transformations for this well-known type."""
+        transformations: list[TransformationSpec] = [
+            # Enable well-known delegation (harmless if set multiple times)
+            TransformationSpec(
+                src_key=None,
+                target_key="wellKnownDelegation.enabled",
+                transformer=lambda *_, **__: True,
+            ),
+        ]
+
+        # For client well-known type, extract server_name and base_url
+        if self.well_known_type == "client":
+            transformations.extend(
+                [
+                    # Extract server_name from m.homeserver.server_name
+                    TransformationSpec(
+                        src_key="'m.homeserver'.server_name",
+                        target_key="serverName",
+                        required=False,
+                    ),
+                    # Extract base_url from m.homeserver.base_url and map to synapse.ingress.host
+                    TransformationSpec(
+                        src_key="'m.homeserver'.base_url",
+                        target_key="synapse.ingress.host",
+                        transformer=extract_hostname_from_url,
+                        required=False,
+                    ),
+                ]
+            )
+
+        # Map the full config to additional.<type> as JSON string
+        transformations.append(
+            TransformationSpec(
+                src_key=None,
+                target_key=f"wellKnownDelegation.additional.{self.well_known_type}",
+                transformer=to_json_string,
+                required=False,
+            )
+        )
+
+        return transformations

--- a/packages/ess-migration-tool/src/ess_migration_tool/well_known.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/well_known.py
@@ -94,6 +94,19 @@ class WellKnownMigration(MigrationStrategy):
                 ]
             )
 
+        # For server well-known type, extract m.server and map to synapse.ingress.host
+        if self.well_known_type == "server":
+            transformations.extend(
+                [
+                    TransformationSpec(
+                        src_key="'m.server'",
+                        target_key="synapse.ingress.host",
+                        transformer=extract_hostname_from_url,
+                        required=False,
+                    ),
+                ]
+            )
+
         # Map the full config to additional.<type> as JSON string
         transformations.append(
             TransformationSpec(

--- a/packages/ess-migration-tool/src/ess_migration_tool/well_known.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/well_known.py
@@ -4,11 +4,9 @@
 
 """Well Known delegation migration strategy."""
 
-import json
 import logging
-from typing import Any
 
-from .migration import ConfigValueTransformer, MigrationStrategy, TransformationSpec, additional_config_transformer
+from .migration import MigrationStrategy, TransformationSpec, additional_config_transformer
 from .models import GlobalOptions
 from .utils import extract_hostname_from_url
 
@@ -102,23 +100,22 @@ class WellKnownMigration(MigrationStrategy):
 
         # Map the full config to additional.<type> as JSON string, filtering out tracked values
         # Use additional_config_transformer with serialization_format="json" and no file wrapper
-        # Then extract just the config string from the result
+        # Each well-known type writes to wellKnownDelegation.additional with its own filename
         transformations.append(
             TransformationSpec(
                 src_key=None,
-                target_key=f"wellKnownDelegation.additional.{self.well_known_type}",
-                transformer=lambda config_value_transformer, value, **kw: (
-                    additional_config_transformer(
-                        config_value_transformer,
-                        value,
-                        component_root_key=WELL_KNOWN_COMPONENT_ROOT_KEY,
-                        override_configs=self.override_configs,
-                        underride_configs=self.underride_configs,
-                        component_name=self.name,
-                        serialization_format="json",
-                        use_file_object_format=False,
-                        **kw,
-                    ).get(f"00-imported.json", "{}")
+                target_key="wellKnownDelegation.additional",
+                transformer=lambda config_value_transformer, value, **kw: additional_config_transformer(
+                    config_value_transformer,
+                    value,
+                    component_root_key=WELL_KNOWN_COMPONENT_ROOT_KEY,
+                    override_configs=self.override_configs,
+                    underride_configs=self.underride_configs,
+                    component_name=self.name,
+                    serialization_format="json",
+                    use_file_object_format=False,
+                    filename=self.well_known_type,
+                    **kw,
                 ),
                 required=False,
             )

--- a/packages/ess-migration-tool/src/ess_migration_tool/well_known.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/well_known.py
@@ -8,7 +8,7 @@ import json
 import logging
 from typing import Any
 
-from .migration import ConfigValueTransformer, MigrationStrategy, TransformationSpec
+from .migration import ConfigValueTransformer, MigrationStrategy, TransformationSpec, additional_config_transformer
 from .models import GlobalOptions
 from .utils import extract_hostname_from_url
 
@@ -29,13 +29,6 @@ WELL_KNOWN_STRATEGY_NAMES: dict[str, str] = {
     "server": "Well Known Server",
     "support": "Well Known Support",
 }
-
-
-def to_json_string(_: ConfigValueTransformer, value: Any, **__: Any) -> str:
-    """Transform a value to a JSON string."""
-    if value is None:
-        return "{}"
-    return json.dumps(value)
 
 
 class WellKnownMigration(MigrationStrategy):
@@ -107,12 +100,26 @@ class WellKnownMigration(MigrationStrategy):
                 ]
             )
 
-        # Map the full config to additional.<type> as JSON string
+        # Map the full config to additional.<type> as JSON string, filtering out tracked values
+        # Use additional_config_transformer with serialization_format="json" and no file wrapper
+        # Then extract just the config string from the result
         transformations.append(
             TransformationSpec(
                 src_key=None,
                 target_key=f"wellKnownDelegation.additional.{self.well_known_type}",
-                transformer=to_json_string,
+                transformer=lambda config_value_transformer, value, **kw: (
+                    additional_config_transformer(
+                        config_value_transformer,
+                        value,
+                        component_root_key=WELL_KNOWN_COMPONENT_ROOT_KEY,
+                        override_configs=self.override_configs,
+                        underride_configs=self.underride_configs,
+                        component_name=self.name,
+                        serialization_format="json",
+                        use_file_object_format=False,
+                        **kw,
+                    ).get(f"00-imported.json", "{}")
+                ),
                 required=False,
             )
         )

--- a/packages/ess-migration-tool/tests/conftest.py
+++ b/packages/ess-migration-tool/tests/conftest.py
@@ -449,3 +449,40 @@ def helm_validator():
         return validate_helm_template(values)
 
     return _validate
+
+
+@pytest.fixture
+def basic_well_known_client_config():
+    """Basic well-known client configuration for testing."""
+    return {
+        "m.homeserver": {
+            "base_url": "https://matrix.example.com",
+            "server_name": "test.example.com",
+        }
+    }
+
+
+@pytest.fixture
+def basic_well_known_server_config():
+    """Basic well-known server configuration for testing."""
+    return {"m.server": "test.example.com:443"}
+
+
+@pytest.fixture
+def basic_well_known_support_config():
+    """Basic well-known support configuration for testing."""
+    return {"im.vector.matrix": {"room": "#support:element.io"}}
+
+
+@pytest.fixture
+def write_well_known_configs(tmp_path):
+    """Helper fixture to write well-known delegation config files."""
+    import json
+
+    def _write_configs(client_config, server_config, support_config):
+        (tmp_path / "client.json").write_text(json.dumps(client_config, indent=2))
+        (tmp_path / "server.json").write_text(json.dumps(server_config, indent=2))
+        (tmp_path / "support.json").write_text(json.dumps(support_config, indent=2))
+        return tmp_path
+
+    return _write_configs

--- a/packages/ess-migration-tool/tests/conftest.py
+++ b/packages/ess-migration-tool/tests/conftest.py
@@ -458,14 +458,20 @@ def basic_well_known_client_config():
         "m.homeserver": {
             "base_url": "https://matrix.example.com",
             "server_name": "test.example.com",
-        }
+        },
+        # Add an untracked value to ensure the client entry is created
+        "m.custom": {"setting": "value"},
     }
 
 
 @pytest.fixture
 def basic_well_known_server_config():
     """Basic well-known server configuration for testing."""
-    return {"m.server": "test.example.com:443"}
+    return {
+        "m.server": "test.example.com:443",
+        # Add an untracked value to ensure the server entry is created
+        "m.custom_server": "value",
+    }
 
 
 @pytest.fixture

--- a/packages/ess-migration-tool/tests/test_main_e2e.py
+++ b/packages/ess-migration-tool/tests/test_main_e2e.py
@@ -9,6 +9,7 @@ Tests the complete workflow from input to output generation.
 """
 
 import base64
+import json
 import sys
 
 import pytest
@@ -1008,4 +1009,67 @@ def test_main_e2e_synapse_with_element_web(
     other_components = ["matrixAuthenticationService", "elementAdmin", "matrixRTC"]
     for component in other_components:
         assert component in generated_values, f"{component} should be present in generated values"
-        assert generated_values[component]["enabled"] is False, f"{component}.enabled should be False"
+
+
+def test_well_known_migration(
+    tmp_path,
+    monkeypatch,
+    synapse_config_with_signing_key,
+    write_synapse_config,
+    basic_well_known_client_config,
+    basic_well_known_server_config,
+    basic_well_known_support_config,
+    write_well_known_configs,
+):
+    """Test end-to-end migration with well-known files."""
+    # Use fixture for synapse config and write it to file
+    synapse_file = write_synapse_config(synapse_config_with_signing_key)
+    write_well_known_configs(
+        basic_well_known_client_config,
+        basic_well_known_server_config,
+        basic_well_known_support_config,
+    )
+
+    # Run migration
+    output_dir = tmp_path / "output"
+
+    # Mock input for signing key path (from synapse_config_with_signing_key fixture)
+    side_effect = (n for n in ("",))  # Empty string for default choice
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "ess-migration-tool",
+            "--synapse-config",
+            str(synapse_file),
+            "--well-known-dir",
+            str(tmp_path),
+            "--output-dir",
+            str(output_dir),
+            "--database-mode",
+            "existing",
+        ],
+    )
+    monkeypatch.setattr("builtins.input", lambda _: next(side_effect))
+
+    result = __main__.main()
+
+    assert result == 0
+
+    # Check output
+    values_file = output_dir / "values.yaml"
+    assert values_file.exists()
+
+    values = yaml.safe_load(values_file.read_text())
+
+    assert values["wellKnownDelegation"]["enabled"] is True
+    assert "additional" in values["wellKnownDelegation"]
+
+    client_config = json.loads(values["wellKnownDelegation"]["additional"]["client"])
+    assert client_config["m.homeserver"]["base_url"] == "https://matrix.example.com"
+
+    server_config = json.loads(values["wellKnownDelegation"]["additional"]["server"])
+    assert server_config["m.server"] == "test.example.com:443"
+
+    support_config = json.loads(values["wellKnownDelegation"]["additional"]["support"])
+    assert support_config["im.vector.matrix"]["room"] == "#support:element.io"

--- a/packages/ess-migration-tool/tests/test_main_e2e.py
+++ b/packages/ess-migration-tool/tests/test_main_e2e.py
@@ -1072,11 +1072,16 @@ def test_well_known_migration(
     assert values["wellKnownDelegation"]["enabled"] is True
     assert "additional" in values["wellKnownDelegation"]
 
+    # Verify that transformed values are filtered out from additional config
     client_config = json.loads(values["wellKnownDelegation"]["additional"]["client"])
-    assert client_config["m.homeserver"]["base_url"] == "https://matrix.example.com"
+    # m.homeserver.base_url and m.homeserver.server_name should be filtered out
+    assert "m.homeserver" not in client_config or (
+        "base_url" not in client_config.get("m.homeserver", {})
+        and "server_name" not in client_config.get("m.homeserver", {})
+    )
 
     server_config = json.loads(values["wellKnownDelegation"]["additional"]["server"])
-    assert server_config["m.server"] == "test.example.com:443"
+    assert "m.server" not in server_config
 
     support_config = json.loads(values["wellKnownDelegation"]["additional"]["support"])
     assert support_config["im.vector.matrix"]["room"] == "#support:element.io"

--- a/packages/ess-migration-tool/tests/test_main_e2e.py
+++ b/packages/ess-migration-tool/tests/test_main_e2e.py
@@ -1034,7 +1034,14 @@ def test_well_known_migration(
     output_dir = tmp_path / "output"
 
     # Mock input for signing key path (from synapse_config_with_signing_key fixture)
-    side_effect = (n for n in ("",))  # Empty string for default choice
+    # and for conflict resolution (select matrix.example.com for synapse.ingress.host)
+    # The conflict is between:
+    # - Synapse (public_baseurl): matrix.example.com
+    # - Well Known Client (m.homeserver.base_url): matrix.example.com
+    # - Well Known Server (m.server): test.example.com
+    # Options will be: "matrix.example.com (from: Synapse, Well Known Client)", "test.example.com (from: Well Known Server)", "Enter custom value"
+    # Select option 1 (matrix.example.com)
+    side_effect = (n for n in ("", "1"))
     monkeypatch.setattr(
         sys,
         "argv",

--- a/packages/ess-migration-tool/tests/test_main_e2e.py
+++ b/packages/ess-migration-tool/tests/test_main_e2e.py
@@ -1039,7 +1039,8 @@ def test_well_known_migration(
     # - Synapse (public_baseurl): matrix.example.com
     # - Well Known Client (m.homeserver.base_url): matrix.example.com
     # - Well Known Server (m.server): test.example.com
-    # Options will be: "matrix.example.com (from: Synapse, Well Known Client)", "test.example.com (from: Well Known Server)", "Enter custom value"
+    # Options will be: "matrix.example.com (from: Synapse, Well Known Client)",
+    # "test.example.com (from: Well Known Server)", "Enter custom value"
     # Select option 1 (matrix.example.com)
     side_effect = (n for n in ("", "1"))
     monkeypatch.setattr(

--- a/packages/ess-migration-tool/tests/test_well_known.py
+++ b/packages/ess-migration-tool/tests/test_well_known.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Tests for well-known delegation migration."""
+
+from ess_migration_tool.inputs import InputProcessor
+from ess_migration_tool.models import GlobalOptions
+from ess_migration_tool.well_known import (
+    WellKnownMigration,
+)
+
+
+def test_strategy_names():
+    """Test that strategies have correct names based on type parameter."""
+    assert WellKnownMigration(GlobalOptions(), well_known_type="client").name == "Well Known Client"
+    assert WellKnownMigration(GlobalOptions(), well_known_type="server").name == "Well Known Server"
+    assert WellKnownMigration(GlobalOptions(), well_known_type="support").name == "Well Known Support"
+
+
+def test_load_from_directory(tmp_path):
+    """Test loading well-known files from a directory."""
+    (tmp_path / "client.json").write_text('{"m.homeserver": {"base_url": "https://example.com"}}')
+    (tmp_path / "server.json").write_text('{"m.server": "example.com:443"}')
+
+    processor = InputProcessor()
+    processor.load_well_known_inputs(dir_path=str(tmp_path))
+
+    assert len(processor.inputs) == 2
+
+    strategy_names = {i.name for i in processor.inputs}
+    assert "Well Known Client" in strategy_names
+    assert "Well Known Server" in strategy_names
+
+
+def test_load_individual_files(tmp_path):
+    """Test loading individual well-known files."""
+    client_file = tmp_path / "client.json"
+    client_file.write_text('{"m.homeserver": {"base_url": "https://test.com"}}')
+
+    processor = InputProcessor()
+    processor.load_well_known_inputs(client_path=str(client_file))
+
+    assert len(processor.inputs) == 1
+    assert processor.inputs[0].name == "Well Known Client"
+
+
+def test_files_without_json_extension(tmp_path):
+    """Test loading files without .json extension."""
+    (tmp_path / "client").write_text('{"m.homeserver": {"base_url": "https://noport.com"}}')
+
+    processor = InputProcessor()
+    processor.load_well_known_inputs(dir_path=str(tmp_path))
+
+    assert len(processor.inputs) == 1
+    assert processor.inputs[0].name == "Well Known Client"
+
+
+def test_cli_args_override_directory(tmp_path):
+    """Test that CLI args override directory files."""
+    dir_path = tmp_path / "well_known"
+    dir_path.mkdir()
+    (dir_path / "client.json").write_text('{"from": "directory"}')
+
+    cli_client = tmp_path / "cli_client.json"
+    cli_client.write_text('{"from": "cli"}')
+
+    processor = InputProcessor()
+    processor.load_well_known_inputs(dir_path=str(dir_path), client_path=str(cli_client))
+
+    # Should only have CLI version
+    assert len(processor.inputs) == 1
+    assert processor.inputs[0].name == "Well Known Client"
+    assert processor.inputs[0].config["from"] == "cli"


### PR DESCRIPTION
Add support for migrating Well Known delegation configuration files (client.json, server.json, support.json) to ESS. 

Users can now specify well-known files via `--well-known-dir` for a directory containing the files, or individual files via `--well-known-client`, `--well-known-server`, and `--well-known-support`.

 Files can be with or without the `.json` extension.