### PR TITLE
Skip None values during conflicts resolution

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1276.feature.md
+++ b/packages/ess-migration-tool/newsfragments/1276.feature.md
@@ -1,0 +1,1 @@
+Handle configuration sources conflicts when generating ESS values.

--- a/packages/ess-migration-tool/src/ess_migration_tool/models.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/models.py
@@ -165,10 +165,12 @@ class ValueSourceTracking:
         """Get all ESS paths that have multiple sources from different strategies."""
         conflicts = {}
         for path, srcs in self.sources.items():
-            if len(srcs) > 1:
-                strategies = set(s.strategy_name for s in srcs)
+            # Filter out sources with None values
+            srcs_with_values = [s for s in srcs if s.value is not None]
+            if len(srcs_with_values) > 1:
+                strategies = set(s.strategy_name for s in srcs_with_values)
                 if len(strategies) > 1:
-                    conflicts[path] = srcs
+                    conflicts[path] = srcs_with_values
         return conflicts
 
     def get_tracked_source_paths(self) -> list[str]:

--- a/packages/ess-migration-tool/tests/test_config_value_tracker.py
+++ b/packages/ess-migration-tool/tests/test_config_value_tracker.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from ess_migration_tool.extra_files import ExtraFilesDiscovery
 from ess_migration_tool.interfaces import ExtraFilesDiscoveryStrategy, SecretDiscoveryStrategy
 from ess_migration_tool.migration import ConfigValueTransformer, TransformationSpec
-from ess_migration_tool.models import DiscoveredPath, GlobalOptions
+from ess_migration_tool.models import DiscoveredPath, GlobalOptions, ValueSourceTracking
 
 
 def test_config_value_tracker_basic():
@@ -434,3 +434,30 @@ def test_update_paths_in_config_nested_config():
 
     # Verify tracked values (only skipped paths are tracked)
     assert len(transformer.value_source_tracking.get_tracked_source_paths()) == 0  # No skipped paths in this test
+
+
+def test_get_conflicts_filters_none_values():
+    """Test that get_conflicts() filters out sources with None values."""
+    tracking = ValueSourceTracking()
+
+    # Add sources where one has a real value and another has None
+    tracking.add_source("serverName", "Synapse", "synapse.example.com", "server_name")
+    tracking.add_source("serverName", "MAS", None, "matrix.homeserver")
+
+    # No conflict should be reported because MAS's None is filtered out
+    conflicts = tracking.get_conflicts()
+    assert conflicts == {}
+
+
+def test_get_conflicts_preserves_real_conflicts():
+    """Test that get_conflicts() still reports conflicts between non-None values."""
+    tracking = ValueSourceTracking()
+
+    # Add sources where both have real but different values
+    tracking.add_source("serverName", "Synapse", "synapse.example.com", "server_name")
+    tracking.add_source("serverName", "MAS", "mas.example.com", "matrix.homeserver")
+
+    # Conflict should be reported
+    conflicts = tracking.get_conflicts()
+    assert "serverName" in conflicts
+    assert len(conflicts["serverName"]) == 2


### PR DESCRIPTION
We dont want to prompt the user to choose between an actual value and a None value. None values are not applied during migration in `transform_from_config`.