### PR TITLE
uv: adjust build system version

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1277.misc.md
+++ b/packages/ess-migration-tool/newsfragments/1277.misc.md
@@ -1,0 +1,1 @@
+Adjust build system to support uv 0.11.

--- a/packages/ess-migration-tool/pyproject.toml
+++ b/packages/ess-migration-tool/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.10.9,<0.11.0"]
+requires = ["uv_build>=0.10.9,<0.12.0"]
 build-backend = "uv_build"
 
 [project.scripts]


### PR DESCRIPTION
Current uv version is 0.11.9. This should be marked as supported.