### PR TITLE
Fix various Synapse Admin APIs relating to users being incorrectly routed to workers if Matrix Authentication Service is enabled

### DIFF
--- a/charts/matrix-stack/templates/synapse/_synapse_details.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_details.tpl
@@ -387,7 +387,7 @@ responsibleForMedia
     "^/_synapse/admin/v2/users/[^/]+$"
     "^/_synapse/admin/v1/username_available$"
     "^/_synapse/admin/v1/users/[^/]+/_allow_cross_signing_replacement_without_uia$"
-    "^/_synapse/admin/v1/users/[^/]+/devices$"
+    "^/_synapse/admin/v2/users/[^/]+/devices(/|$)"
 ) }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/_synapse_details.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_details.tpl
@@ -382,6 +382,8 @@ responsibleForMedia
   "^/_synapse/client/saml2/authn_response$"
   "^/_matrix/client/(api/v1|r0|v3|unstable)/login/cas/ticket$"
 ) }}
+{{- /*
+Commented out because these are only workerisable when using the experimental MAS config and not the stable one
 {{- if include "element-io.matrix-authentication-service.readyToHandleAuth" (dict "root" $root) }}
 {{ $workerPaths = concat $workerPaths (list
     "^/_synapse/admin/v2/users/[^/]+$"
@@ -390,6 +392,7 @@ responsibleForMedia
     "^/_synapse/admin/v2/users/[^/]+/devices(/|$)"
 ) }}
 {{- end }}
+*/}}
 {{- end }}
 
 {{- if eq . "synchrotron" }}

--- a/newsfragments/1278.fixed.md
+++ b/newsfragments/1278.fixed.md
@@ -1,0 +1,1 @@
+Fix various Synapse Admin APIs relating to users being incorrectly routed to workers if Matrix Authentication Service is enabled.


### PR DESCRIPTION
`/_synapse/admin/v2/users/.*` is routed for `GET` only in https://github.com/element-hq/ess-helm/blob/main/charts/matrix-stack/configs/synapse/path_map_file_get.tpl to the `client-reader` worker