### PR TITLE
Add `mas-helper` worker.

### DIFF
--- a/charts/matrix-stack/ci/fragments/synapse-all-workers-running.yaml
+++ b/charts/matrix-stack/ci/fragments/synapse-all-workers-running.yaml
@@ -1,5 +1,5 @@
 # Copyright 2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -30,6 +30,9 @@ synapse:
       enabled: true
     initial-synchrotron:
       enabled: true
+    # Can't be enabled as MAS isn't enabled in the one values file this is used in
+    mas-helper:
+      enabled: false
     media-repository:
       enabled: true
     presence-writer:

--- a/charts/matrix-stack/ci/synapse-worker-example-values.yaml
+++ b/charts/matrix-stack/ci/synapse-worker-example-values.yaml
@@ -47,6 +47,9 @@ synapse:
       enabled: true
     initial-synchrotron:
       enabled: true
+    # Can't be enabled as MAS isn't enabled in the one values file this is used in
+    mas-helper:
+      enabled: false
     media-repository:
       enabled: true
     presence-writer:

--- a/charts/matrix-stack/source/synapse.json
+++ b/charts/matrix-stack/source/synapse.json
@@ -235,6 +235,9 @@
         "initial-synchrotron": {
           "$ref": "file://synapse/scalable_worker.json"
         },
+        "mas-helper": {
+          "$ref": "file://synapse/scalable_worker.json"
+        },
         "media-repository": {
           "$ref": "file://synapse/single_worker.json"
         },

--- a/charts/matrix-stack/source/synapse.yaml.j2
+++ b/charts/matrix-stack/source/synapse.yaml.j2
@@ -66,6 +66,7 @@ workers:
 {{- synapse_sub_schema_values.scalable_worker('federation-reader') | indent(2) }}
 {{- synapse_sub_schema_values.scalable_worker('federation-sender') | indent(2) }}
 {{- synapse_sub_schema_values.scalable_worker('initial-synchrotron') | indent(2) }}
+{{- synapse_sub_schema_values.scalable_worker('mas-helper') | indent(2) }}
 {{- synapse_sub_schema_values.single_worker('media-repository') | indent(2) }}
 {{- synapse_sub_schema_values.single_worker('presence-writer') | indent(2) }}
 {{- synapse_sub_schema_values.single_worker('push-rules') | indent(2) }}

--- a/charts/matrix-stack/templates/synapse/_helpers.tpl
+++ b/charts/matrix-stack/templates/synapse/_helpers.tpl
@@ -29,6 +29,10 @@ SPDX-License-Identifier: AGPL-3.0-only
     {{- end }}
   {{- end }}
 {{- end }}
+{{- /* Deliberately not using element-io.matrix-authentication-service.readyToHandleAuth here as we want this to be enableable before syn2mas is initially run */}}
+{{- if and (dig "mas-helper" "enabled" false .workers) (not $root.Values.matrixAuthenticationService.enabled) }}
+{{ $messages = append $messages "synapse.workers.mas-helpers can't be enabled without matrixAuthenticationService.enabled=false" }}
+{{- end }}
 {{ $messages | toJson }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/_helpers.tpl
+++ b/charts/matrix-stack/templates/synapse/_helpers.tpl
@@ -33,6 +33,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- if and (dig "mas-helper" "enabled" false .workers) (not $root.Values.matrixAuthenticationService.enabled) }}
 {{ $messages = append $messages "synapse.workers.mas-helpers can't be enabled without matrixAuthenticationService.enabled=false" }}
 {{- end }}
+{{- /* Deliberately not using element-io.matrix-authentication-service.readyToHandleAuth here as we want this to be disabled before the actual migration */}}
+{{- if and (dig "sso-login" "enabled" false .workers) $root.Values.matrixAuthenticationService.enabled }}
+{{ $messages = append $messages "synapse.workers.sso-login can't be enabled when matrixAuthenticationService.enabled=true" }}
+{{- end }}
 {{ $messages | toJson }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/_synapse_details.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_details.tpl
@@ -332,6 +332,12 @@ responsibleForMedia
 
 {{- /* initial-synchrotron routing is done in configs/synapse/partial-haproxy.cfg.tpl so that it can fallback -> synchrotron -> main */}}
 
+{{- if eq . "mas-helper" }}
+{{ $workerPaths = concat $workerPaths (list
+  "^/_synapse/mas/"
+) }}
+{{- end }}
+
 {{- if eq . "media-repository" }}
 {{ $workerPaths = concat $workerPaths (list
   "^/_matrix/media/"

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -13615,6 +13615,282 @@
               "type": "object",
               "additionalProperties": false
             },
+            "mas-helper": {
+              "required": [
+                "replicas"
+              ],
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "replicas": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "resources": {
+                  "properties": {
+                    "limits": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                      },
+                      "type": "object"
+                    },
+                    "requests": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "topologySpreadConstraints": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "maxSkew",
+                      "topologyKey"
+                    ],
+                    "properties": {
+                      "labelSelector": {
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "enum": [
+                                    "In",
+                                    "NotIn",
+                                    "Exists",
+                                    "DoesNotExist"
+                                  ]
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "matchLabels": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "maxSkew": {
+                        "type": "integer",
+                        "minium": 1
+                      },
+                      "minDomains": {
+                        "type": "integer",
+                        "minium": 0
+                      },
+                      "nodeAffinityPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "nodeTaintsPolicy": {
+                        "type": "string",
+                        "enum": [
+                          "Honor",
+                          "Ignore"
+                        ]
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "type": "string",
+                        "enum": [
+                          "DoNotSchedule",
+                          "ScheduleAnyway"
+                        ]
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "livenessProbe": {
+                  "type": "object",
+                  "properties": {
+                    "failureThreshold": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "initialDelaySeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 0
+                    },
+                    "periodSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "successThreshold": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "timeoutSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "readinessProbe": {
+                  "type": "object",
+                  "properties": {
+                    "failureThreshold": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "initialDelaySeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 0
+                    },
+                    "periodSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "successThreshold": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "timeoutSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "startupProbe": {
+                  "type": "object",
+                  "properties": {
+                    "failureThreshold": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "initialDelaySeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 0
+                    },
+                    "periodSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "successThreshold": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    },
+                    "timeoutSeconds": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "media-repository": {
               "properties": {
                 "enabled": {

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -4351,6 +4351,64 @@ synapse:
 
         ## Number of seconds after which the probe times out
         timeoutSeconds: 1
+    mas-helper:
+      ## Set to true to deploy this worker
+      enabled: false
+
+      ## The number of replicas of this worker to run
+      replicas: 1
+
+      ## Resources for this worker.
+      ## If omitted the global Synapse resources are used
+      # resources: {}
+      ## Configuration of the thresholds and frequencies of the livenessProbe
+      livenessProbe:
+        ## How many consecutive failures for the probe to be considered failed
+        failureThreshold: 3
+
+        ## Number of seconds after the container has started before the probe starts
+        initialDelaySeconds: 0
+
+        ## How often (in seconds) to perform the probe
+        periodSeconds: 6
+
+        ## How many consecutive successes for the probe to be consider successful after having failed
+        successThreshold: 1
+
+        ## Number of seconds after which the probe times out
+        timeoutSeconds: 2
+      ## Configuration of the thresholds and frequencies of the readinessProbe
+      readinessProbe:
+        ## How many consecutive failures for the probe to be considered failed
+        failureThreshold: 3
+
+        ## Number of seconds after the container has started before the probe starts
+        initialDelaySeconds: 0
+
+        ## How often (in seconds) to perform the probe
+        periodSeconds: 2
+
+        ## How many consecutive successes for the probe to be consider successful after having failed
+        successThreshold: 2
+
+        ## Number of seconds after which the probe times out
+        timeoutSeconds: 2
+      ## Configuration of the thresholds and frequencies of the startupProbe
+      startupProbe:
+        ## How many consecutive failures for the probe to be considered failed
+        failureThreshold: 21
+
+        ## Number of seconds after the container has started before the probe starts
+        initialDelaySeconds: 0
+
+        ## How often (in seconds) to perform the probe
+        periodSeconds: 2
+
+        ## How many consecutive successes for the probe to be consider successful after having failed
+        successThreshold: 1
+
+        ## Number of seconds after which the probe times out
+        timeoutSeconds: 1
     media-repository:
       ## Set to true to deploy this worker
       enabled: false

--- a/newsfragments/1279.added.md
+++ b/newsfragments/1279.added.md
@@ -1,0 +1,1 @@
+Introduce the `mas-helper` worker to support the Matrix Authentication Service admin API endpoints in Synapse.

--- a/newsfragments/1279.removed.md
+++ b/newsfragments/1279.removed.md
@@ -1,0 +1,1 @@
+Disallow the `sso-login` worker in Synapse when Matrix Authentication Service is in use or about to be migrated to.


### PR DESCRIPTION
Also don't allow deployment of `sso-login` when MAS is running as it is useless and causes confusion.

We very deliberately only look at whether MAS is being deployed or not, not whether it is handling auth. This means that any changes to the worker deployment happen when preparing for the migration not when the migration actually happens for real