### PR TITLE
Secrets discovery refactoring 

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1288.misc.md
+++ b/packages/ess-migration-tool/newsfragments/1288.misc.md
@@ -1,0 +1,1 @@
+Refactor internal handling of secrets to allow multiple secrets discovery implementations.

--- a/packages/ess-migration-tool/src/ess_migration_tool/extra_files.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/extra_files.py
@@ -30,7 +30,7 @@ def ess_schema_config_key_secret_paths(ess_schema: dict[str, DiscoverableSecret]
     return [
         secret_config.discovery.config_path
         for secret_config in ess_schema.values()
-        if secret_config.discovery.config_path is not None
+        if secret_config.discovery is not None and secret_config.discovery.config_path is not None
     ]
 
 

--- a/packages/ess-migration-tool/src/ess_migration_tool/hookshot.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/hookshot.py
@@ -134,10 +134,7 @@ class HookshotSecretDiscovery(SecretDiscoveryStrategy):
                 description="Hookshot appservice registration file",
                 optional=True,
                 init_if_missing_from_source_cfg=True,
-                discovery=SecretConfig(
-                    config_inline=None,
-                    config_path=None,
-                ),
+                discovery=None,
             ),
             "hookshot.passkey": DiscoverableSecret(
                 description="Hookshot passkey for token encryption",

--- a/packages/ess-migration-tool/src/ess_migration_tool/mas.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/mas.py
@@ -383,40 +383,24 @@ class MASSecretDiscovery(SecretDiscoveryStrategy):
                 "matrixAuthenticationService.privateKeys.rsa": DiscoverableSecret(
                     description="MAS RSA private key for signing operations",
                     init_if_missing_from_source_cfg=True,
-                    discovery=SecretConfig(
-                        config_inline=None,
-                        config_path=None,
-                        transformer=None,
-                    ),
+                    discovery=None,
                 ),
                 "matrixAuthenticationService.privateKeys.ecdsaPrime256v1": DiscoverableSecret(
                     description="MAS ECDSA Prime256v1 private key for signing operations",
                     init_if_missing_from_source_cfg=True,
-                    discovery=SecretConfig(
-                        config_inline=None,
-                        config_path=None,
-                        transformer=None,
-                    ),
+                    discovery=None,
                 ),
                 "matrixAuthenticationService.privateKeys.ecdsaSecp256k1": DiscoverableSecret(
                     description="MAS ECDSA Secp256k1 private key for signing operations",
                     optional=True,  # This key type is optional
                     init_if_missing_from_source_cfg=False,
-                    discovery=SecretConfig(
-                        config_inline=None,
-                        config_path=None,
-                        transformer=None,
-                    ),
+                    discovery=None,
                 ),
                 "matrixAuthenticationService.privateKeys.ecdsaSecp384r1": DiscoverableSecret(
                     description="MAS ECDSA Secp384r1 private key for signing operations",
                     optional=True,  # This key type is optional
                     init_if_missing_from_source_cfg=False,
-                    discovery=SecretConfig(
-                        config_inline=None,
-                        config_path=None,
-                        transformer=None,
-                    ),
+                    discovery=None,
                 ),
             }
         )

--- a/packages/ess-migration-tool/src/ess_migration_tool/models.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/models.py
@@ -144,7 +144,7 @@ class DiscoverableSecret:
     """A discoverable secret with metadata and discovery configuration."""
 
     description: str  # User-friendly description of the secret
-    discovery: SecretConfig  # Discovery configuration
+    discovery: SecretConfig | None = None  # Discovery configuration (None if not discoverable from config)
     optional: bool = False  # Whether the secret is optional (not required for migration)
     init_if_missing_from_source_cfg: bool = False  # Whether to initialize secret if missing from source config
 

--- a/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
@@ -93,48 +93,54 @@ class SecretDiscovery:
             discovered_value = None
             error_msg: str | None = None
 
-            if discovery_config.config_inline:
-                # Direct value
-                value = get_nested_value(config_data, discovery_config.config_inline)
-                if value is not None:
-                    discovered_value = value
-                    logging.info(f"Found direct value for {secret_key}")
+            # If discovery is None, this secret cannot be discovered from config files
+            # It can only be discovered through component-specific discovery
+            if discovery_config is not None:
+                if discovery_config.config_inline:
+                    # Direct value
+                    value = get_nested_value(config_data, discovery_config.config_inline)
+                    if value is not None:
+                        discovered_value = value
+                        logging.info(f"Found direct value for {secret_key}")
 
-            # Also try file path if direct value wasn't found
-            if discovered_value is None and discovery_config.config_path:
-                # From file
-                file_path = get_nested_value(config_data, discovery_config.config_path)
-                if file_path is not None:
+                # Also try file path if direct value wasn't found
+                if discovered_value is None and discovery_config.config_path:
+                    # From file
+                    file_path = get_nested_value(config_data, discovery_config.config_path)
+                    if file_path is not None:
+                        try:
+                            with open(file_path) as f:
+                                discovered_value = f.read()
+                            logging.info(f"Found file value for {secret_key}")
+                        except FileNotFoundError:
+                            logger.warning(f"File not found: {file_path}")
+                            error_msg = f"File not found: {file_path}"
+                        except PermissionError:
+                            logger.warning(f"Permission denied when reading file: {file_path}")
+                            error_msg = f"Permission denied reading file: {file_path}"
+
+                # Apply transformer if available and we have a value
+                if discovered_value is not None and discovery_config.transformer is not None:
                     try:
-                        with open(file_path) as f:
-                            discovered_value = f.read()
-                        logging.info(f"Found file value for {secret_key}")
-                    except FileNotFoundError:
-                        logger.warning(f"File not found: {file_path}")
-                        error_msg = f"File not found: {file_path}"
-                    except PermissionError:
-                        logger.warning(f"Permission denied when reading file: {file_path}")
-                        error_msg = f"Permission denied reading file: {file_path}"
+                        discovered_value = discovery_config.transformer(discovered_value)
+                        logger.info(f"Applied transformer to {secret_key}")
+                    except Exception as e:
+                        logger.warning(f"Failed to apply transformer for {secret_key}: {e}")
+                        discovered_value = None
 
-            # Apply transformer if available and we have a value
-            if discovered_value is not None and discovery_config.transformer is not None:
-                try:
-                    discovered_value = discovery_config.transformer(discovered_value)
-                    logger.info(f"Applied transformer to {secret_key}")
-                except Exception as e:
-                    logger.warning(f"Failed to apply transformer for {secret_key}: {e}")
-                    discovered_value = None
+                if discovered_value is not None:
+                    # Track the source information
+                    config_key = discovery_config.config_inline or discovery_config.config_path
+                    if not config_key:
+                        raise RuntimeError(f"Missing configuration path for {secret_key}")
+                    discovered_secret = DiscoveredSecret(
+                        source_file=self.source_file,
+                        secret_key=secret_key,
+                        config_key=config_key,
+                        value=discovered_value,
+                    )
 
-            if discovered_value is not None:
-                # Track the source information
-                config_key = discovery_config.config_inline or discovery_config.config_path
-                if not config_key:
-                    raise RuntimeError(f"Missing configuration path for {secret_key}")
-                discovered_secret = DiscoveredSecret(
-                    source_file=self.source_file, secret_key=secret_key, config_key=config_key, value=discovered_value
-                )
-
-                self.discovered_secrets[secret_key] = discovered_secret
+                    self.discovered_secrets[secret_key] = discovered_secret
 
             if secret_key not in self.discovered_secrets:
                 if discoverable_secret.optional:
@@ -142,12 +148,15 @@ class SecretDiscovery:
                     continue
 
                 # Build DiscoveredSecret with config_key from schema
-                # If there was an error reading from config_path, use that; otherwise prefer config_inline
-                config_key_for_missing = (
-                    discovery_config.config_path
-                    if error_msg
-                    else discovery_config.config_inline or discovery_config.config_path
-                )
+                # If discovery is None or there was an error reading from config_path, use that
+                if discovery_config is None:
+                    config_key_for_missing = None
+                else:
+                    config_key_for_missing = (
+                        discovery_config.config_path
+                        if error_msg
+                        else discovery_config.config_inline or discovery_config.config_path
+                    )
 
                 # If there's no way to discover this secret from the config (no config_inline or config_path),
                 # handle it specially:

--- a/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
@@ -10,7 +10,7 @@ import logging
 from dataclasses import dataclass, field
 
 from .interfaces import SecretDiscoveryStrategy
-from .models import DiscoveredSecret, GlobalOptions
+from .models import DiscoverableSecret, DiscoveredSecret, GlobalOptions, SecretConfig
 from .utils import (
     find_matching_schema_key,
     get_nested_value,
@@ -89,97 +89,152 @@ class SecretDiscovery:
             if is_wildcard_pattern(secret_key):
                 continue
 
+            # Skip if already discovered (e.g., by component-specific discovery)
+            if secret_key in self.discovered_secrets:
+                continue
+
             discovery_config = discoverable_secret.discovery
-            discovered_value = None
-            error_msg: str | None = None
 
             # If discovery is None, this secret cannot be discovered from config files
-            # It can only be discovered through component-specific discovery
-            if discovery_config is not None:
-                if discovery_config.config_inline:
-                    # Direct value
-                    value = get_nested_value(config_data, discovery_config.config_inline)
-                    if value is not None:
-                        discovered_value = value
-                        logging.info(f"Found direct value for {secret_key}")
+            # Skip directly to missing secret handling
+            if discovery_config is None:
+                self._handle_missing_secret(secret_key, discoverable_secret, None)
+                continue
 
-                # Also try file path if direct value wasn't found
-                if discovered_value is None and discovery_config.config_path:
-                    # From file
-                    file_path = get_nested_value(config_data, discovery_config.config_path)
-                    if file_path is not None:
-                        try:
-                            with open(file_path) as f:
-                                discovered_value = f.read()
-                            logging.info(f"Found file value for {secret_key}")
-                        except FileNotFoundError:
-                            logger.warning(f"File not found: {file_path}")
-                            error_msg = f"File not found: {file_path}"
-                        except PermissionError:
-                            logger.warning(f"Permission denied when reading file: {file_path}")
-                            error_msg = f"Permission denied reading file: {file_path}"
+            # Try to discover the secret from config
+            discovered_value, error_msg = self._try_discover_from_config(secret_key, discovery_config, config_data)
 
-                # Apply transformer if available and we have a value
-                if discovered_value is not None and discovery_config.transformer is not None:
-                    try:
-                        discovered_value = discovery_config.transformer(discovered_value)
-                        logger.info(f"Applied transformer to {secret_key}")
-                    except Exception as e:
-                        logger.warning(f"Failed to apply transformer for {secret_key}: {e}")
-                        discovered_value = None
+            if discovered_value is not None:
+                self._add_discovered_secret(secret_key, discovery_config, discovered_value)
+                continue
 
-                if discovered_value is not None:
-                    # Track the source information
-                    config_key = discovery_config.config_inline or discovery_config.config_path
-                    if not config_key:
-                        raise RuntimeError(f"Missing configuration path for {secret_key}")
-                    discovered_secret = DiscoveredSecret(
-                        source_file=self.source_file,
-                        secret_key=secret_key,
-                        config_key=config_key,
-                        value=discovered_value,
-                    )
+            # Secret was not discovered from config - handle missing case
+            self._handle_missing_secret(secret_key, discoverable_secret, error_msg)
 
-                    self.discovered_secrets[secret_key] = discovered_secret
+    def _try_discover_from_config(
+        self,
+        secret_key: str,
+        discovery_config: SecretConfig,
+        config_data: dict,
+    ) -> tuple[str | None, str | None]:
+        """
+        Try to discover a secret value from configuration.
 
-            if secret_key not in self.discovered_secrets:
-                if discoverable_secret.optional:
-                    # Optional secrets are ignored if not found
-                    continue
+        Args:
+            secret_key: The ESS secret key
+            discovery_config: The discovery configuration (SecretConfig)
+            config_data: The source configuration data
 
-                # Build DiscoveredSecret with config_key from schema
-                # If discovery is None or there was an error reading from config_path, use that
-                if discovery_config is None:
-                    config_key_for_missing = None
-                else:
-                    config_key_for_missing = (
-                        discovery_config.config_path
-                        if error_msg
-                        else discovery_config.config_inline or discovery_config.config_path
-                    )
+        Returns:
+            Tuple of (discovered_value, error_msg) where:
+            - discovered_value: The secret value if found, None otherwise
+            - error_msg: Error message if file reading failed, None otherwise
+        """
+        discovered_value = None
+        error_msg: str | None = None
 
-                # If there's no way to discover this secret from the config (no config_inline or config_path),
-                # handle it specially:
-                # - If init_if_missing_from_source_cfg is True, add to init_by_ess_secrets
-                # - Otherwise, it will be discovered via component-specific discovery
-                if config_key_for_missing is None:
-                    if discoverable_secret.init_if_missing_from_source_cfg:
-                        self.init_by_ess_secrets.append(secret_key)
-                    # In either case, we don't add to missing_required_secrets
-                    # because component-specific discovery will handle these
-                    continue
+        # Try inline value first
+        if discovery_config.config_inline:
+            value = get_nested_value(config_data, discovery_config.config_inline)
+            if value is not None:
+                discovered_value = value
+                logging.info(f"Found direct value for {secret_key}")
 
-                discovered_secret_still_missing = DiscoveredSecret(
-                    source_file=self.source_file,
-                    secret_key=secret_key,
-                    config_key=config_key_for_missing,
-                    value="",
-                )
+        # Try file path if inline value wasn't found
+        if discovered_value is None and discovery_config.config_path:
+            file_path = get_nested_value(config_data, discovery_config.config_path)
+            if file_path is not None:
+                try:
+                    with open(file_path) as f:
+                        discovered_value = f.read()
+                    logging.info(f"Found file value for {secret_key}")
+                except FileNotFoundError:
+                    logger.warning(f"File not found: {file_path}")
+                    error_msg = f"File not found: {file_path}"
+                except PermissionError:
+                    logger.warning(f"Permission denied when reading file: {file_path}")
+                    error_msg = f"Permission denied reading file: {file_path}"
 
-                if discoverable_secret.init_if_missing_from_source_cfg:
-                    self.init_by_ess_secrets.append(secret_key)
-                else:
-                    self.missing_required_secrets.append((discovered_secret_still_missing, error_msg))
+        # Apply transformer if available and we have a value
+        if discovered_value is not None and discovery_config.transformer is not None:
+            try:
+                discovered_value = discovery_config.transformer(discovered_value)
+                logger.info(f"Applied transformer to {secret_key}")
+            except Exception as e:
+                logger.warning(f"Failed to apply transformer for {secret_key}: {e}")
+                discovered_value = None
+
+        return discovered_value, error_msg
+
+    def _add_discovered_secret(
+        self,
+        secret_key: str,
+        discovery_config: SecretConfig,
+        discovered_value: str,
+    ) -> None:
+        """Add a discovered secret to the discovered_secrets dictionary."""
+        config_key = discovery_config.config_inline or discovery_config.config_path
+        if not config_key:
+            raise RuntimeError(f"Missing configuration path for {secret_key}")
+
+        discovered_secret = DiscoveredSecret(
+            source_file=self.source_file,
+            secret_key=secret_key,
+            config_key=config_key,
+            value=discovered_value,
+        )
+        self.discovered_secrets[secret_key] = discovered_secret
+
+    def _handle_missing_secret(
+        self,
+        secret_key: str,
+        discoverable_secret: DiscoverableSecret,
+        error_msg: str | None,
+    ) -> None:
+        """
+        Handle a secret that was not discovered from config.
+
+        Based on the secret's configuration, either:
+        - Ignore it (if optional)
+        - Add to init_by_ess_secrets (if init_if_missing_from_source_cfg)
+        - Add to missing_required_secrets (if required)
+        """
+        # Optional secrets are ignored if not found
+        if discoverable_secret.optional:
+            return
+
+        discovery_config = discoverable_secret.discovery
+
+        # Determine config_key for the missing secret
+        if discovery_config is None:
+            config_key_for_missing = None
+        else:
+            config_key_for_missing = (
+                discovery_config.config_path
+                if error_msg
+                else discovery_config.config_inline or discovery_config.config_path
+            )
+
+        # If there's no way to discover this secret from the config,
+        # it can only be initialized by ESS or discovered via component-specific discovery
+        if config_key_for_missing is None:
+            if discoverable_secret.init_if_missing_from_source_cfg:
+                self.init_by_ess_secrets.append(secret_key)
+            # Don't add to missing_required_secrets - component-specific discovery will handle these
+            return
+
+        # Secret has a config path but wasn't found - create a placeholder
+        discovered_secret_still_missing = DiscoveredSecret(
+            source_file=self.source_file,
+            secret_key=secret_key,
+            config_key=config_key_for_missing,
+            value="",
+        )
+
+        if discoverable_secret.init_if_missing_from_source_cfg:
+            self.init_by_ess_secrets.append(secret_key)
+        else:
+            self.missing_required_secrets.append((discovered_secret_still_missing, error_msg))
 
     def validate_required_secrets(self) -> None:
         """Validate that all required secrets are present."""


### PR DESCRIPTION
Now that discoverable secret schema is composed of `SecretConfig` , let's allow `None` discovery. This replaces `SecretConfig` with no-op fields `config_inline` and `config_path` being None, and makes it easier to read.

Also refactor a bit `_discover_secrets_from_schema` to cut it in sub-functions.