### PR TITLE
Add msc4452_enabled to experimental_features.

### DIFF
--- a/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
@@ -18,7 +18,7 @@ federation_client_minimum_tls_version: '1.2'
 
 experimental_features:
   msc4028_push_encrypted_events: true
-  # Enables URL Preview configuration to appear in capabilities.
+  # Enables URL Preview configuration to appear in /capabilities.
   msc4452_enabled: true
 
 url_preview_enabled: true

--- a/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
@@ -18,7 +18,6 @@ federation_client_minimum_tls_version: '1.2'
 
 experimental_features:
   msc4028_push_encrypted_events: true
-  # Enables URL Preview configuration to appear in /capabilities.
   msc4452_enabled: true
 
 url_preview_enabled: true

--- a/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
@@ -18,6 +18,8 @@ federation_client_minimum_tls_version: '1.2'
 
 experimental_features:
   msc4028_push_encrypted_events: true
+  # Enables URL Preview configuration to appear in capabilities.
+  msc4452_enabled: true
 
 url_preview_enabled: true
 # Both these lists are append only. If there are specific ranges within the denylist

--- a/newsfragments/1290.changed.md
+++ b/newsfragments/1290.changed.md
@@ -1,0 +1,1 @@
+Element Web now disables/enables link preview toggles based on Synapse configuration.

--- a/packages/ess-migration-tool/src/ess_migration_tool/synapse.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/synapse.py
@@ -314,6 +314,7 @@ class SynapseMigration(MigrationStrategy):
             "require_auth_for_profile_requests",
             "federation_client_minimum_tls_version",
             "experimental_features.msc4028_push_encrypted_events",
+            "experimental_features.msc4452_enabled",
             "url_preview_enabled",
             "url_preview_ip_range_whitelist",
             "url_preview_ip_range_blacklist",

--- a/packages/ess-migration-tool/src/ess_migration_tool/synapse.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/synapse.py
@@ -285,6 +285,7 @@ class SynapseMigration(MigrationStrategy):
             "require_auth_for_profile_requests",
             "federation_client_minimum_tls_version",
             "experimental_features.msc4028_push_encrypted_events",
+            "experimental_features.msc4452_enabled",
             "url_preview_enabled",
             "url_preview_ip_range_whitelist",
             "url_preview_ip_range_blacklist",

--- a/packages/ess-migration-tool/tests/conftest.py
+++ b/packages/ess-migration-tool/tests/conftest.py
@@ -55,7 +55,7 @@ def basic_synapse_config():
         "report_stats": False,
         "require_auth_for_profile_requests": True,
         "federation_client_minimum_tls_version": "1.2",
-        "experimental_features": {"msc4028_push_encrypted_events": True},
+        "experimental_features": {"msc4028_push_encrypted_events": True, "experimental_features.msc4452_enabled": True},
         "url_preview_enabled": True,
         "url_preview_ip_range_whitelist": [],
         "url_preview_ip_range_blacklist": ["192.168.0.0/16", "10.0.0.0/8"],

--- a/packages/ess-migration-tool/tests/conftest.py
+++ b/packages/ess-migration-tool/tests/conftest.py
@@ -103,7 +103,10 @@ def basic_synapse_config():
             "report_stats": False,
             "require_auth_for_profile_requests": True,
             "federation_client_minimum_tls_version": "1.2",
-            "experimental_features": {"msc4028_push_encrypted_events": True},
+            "experimental_features": {
+                "msc4028_push_encrypted_events": True,
+                "experimental_features.msc4452_enabled": True,
+            },
             "url_preview_enabled": True,
             "url_preview_ip_range_whitelist": [],
             "url_preview_ip_range_blacklist": ["192.168.0.0/16", "10.0.0.0/8"],


### PR DESCRIPTION
Uses https://github.com/element-hq/synapse/pull/19715 (and will be in Synapse v1.154.0).

We've evaluated the risks to clients and this shouldn't pose any problems, it just changes a status code for when the feature is off and adds an extra capability for Element Web to view.