### PR TITLE
Pass a single instance of value source tracking around

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1294.feature.md
+++ b/packages/ess-migration-tool/newsfragments/1294.feature.md
@@ -1,0 +1,1 @@
+Handle configuration sources conflicts when generating ESS values.

--- a/packages/ess-migration-tool/src/ess_migration_tool/engine.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/engine.py
@@ -105,6 +105,7 @@ class MigrationEngine:
                         secrets=self.secrets,
                         configmaps=self.configmaps,
                         global_options=self.global_options,
+                        value_source_tracking=self.value_source_tracking,
                     )
                 )
 
@@ -119,16 +120,11 @@ class MigrationEngine:
         for migrator in self.migrators:
             migrator.migrate()
 
-            # Collect override and underride warnings, secrets, and value sources
+            # Collect override and underride warnings, secrets
             self.override_warnings.extend(migrator.override_warnings)
             self.underride_warnings.extend(migrator.underride_warnings)
             self.discovered_secrets.extend(migrator.discovered_secrets)
             self.init_by_ess_secrets.extend(migrator.init_by_ess_secrets)
-
-            # Collect value sources from this migrator
-            for path, sources in migrator.value_source_tracking.sources.items():
-                for source in sources:
-                    self.value_source_tracking.add_source(path, source.strategy_name, source.value, source.source_path)
 
         # Resolve conflicts after all migrations
         resolve_value_conflicts(self.pretty_logger, self.value_source_tracking, self.ess_config)

--- a/packages/ess-migration-tool/src/ess_migration_tool/migration.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/migration.py
@@ -57,7 +57,6 @@ def additional_config_transformer(
     - component_root_key: str - Internal ESS config key (e.g., "synapse")
     - override_configs: set[str] - Set of configuration paths managed by ESS (users should not override)
     - underride_configs: set[str] - Set of configuration paths with ESS defaults (users can override)
-    - component_name: str - User-facing strategy name (e.g., "Synapse")
     - serialization_format: str - Format for additional config: "yaml" (default) or "json"
     - use_file_object_format: bool - If True (default), return {"filename": {"config": string}} format.
       If False, return {"filename": string} format (direct string without wrapper object).
@@ -81,7 +80,9 @@ def additional_config_transformer(
     file_name = kwargs.get("filename") or f"00-imported.{serialization_format}"
 
     # Get tracked source paths from value_source_tracking
-    tracked_source_paths = config_value_transformer.value_source_tracking.get_tracked_source_paths()
+    tracked_source_paths = config_value_transformer.value_source_tracking.get_tracked_source_paths(
+        config_value_transformer.strategy_name
+    )
 
     filtered_config = copy.deepcopy(source_config)
 
@@ -172,10 +173,10 @@ class ConfigValueTransformer:
 
     pretty_logger: logging.Logger = field(init=True)  # Pretty logger
     ess_config: dict[str, Any] = field(init=True)  # Target ESS configuration dictionary
+    value_source_tracking: ValueSourceTracking = field(init=True)  # Shared value source tracking instance
     results: list[TransformationResult] = field(default_factory=list)  # List of transformation results
     override_warnings: list[str] = field(default_factory=list)  # Warnings about ESS-managed overrides
     underride_warnings: list[str] = field(default_factory=list)  # Warnings about ESS default configurations
-    value_source_tracking: ValueSourceTracking = field(default_factory=ValueSourceTracking)
     strategy_name: str = ""  # Name of the strategy (for source tracking)
 
     def transform_from_config(
@@ -278,7 +279,7 @@ class ConfigValueTransformer:
         filtered_config = copy.deepcopy(config)
 
         # Get tracked source paths from value_source_tracking
-        tracked_source_paths = self.value_source_tracking.get_tracked_source_paths()
+        tracked_source_paths = self.value_source_tracking.get_tracked_source_paths(self.strategy_name)
 
         # Sort tracked values so list indices are removed in descending order to avoid shifting
         sorted_tracked = sort_tracked_values_for_filtering(tracked_source_paths)
@@ -444,6 +445,7 @@ class MigrationService:
     migration: MigrationStrategy = field(init=True)  # Migration strategy
     extra_files_strategy: ExtraFilesDiscoveryStrategy = field(init=True)  # Extra files discovery service
     secret_discovery_strategy: SecretDiscoveryStrategy | None = field(init=True)  # Secret discovery service
+    value_source_tracking: ValueSourceTracking = field(init=True)  # Shared value source tracking instance
     override_warnings: list[str] = field(default_factory=list)  # Warnings about overridden configurations
     underride_warnings: list[str] = field(default_factory=list)  # Warnings about ESS default configurations
     init_by_ess_secrets: list[str] = field(default_factory=list)  # List of secrets that will be initialized by ESS
@@ -455,7 +457,6 @@ class MigrationService:
     underride_configs: set[str] = field(default_factory=set)  # Set of configurations that are ESS defaults
     results: list[TransformationResult] = field(default_factory=list)  # List of transformation results
     global_options: GlobalOptions = field(default_factory=GlobalOptions)  # Global migration options
-    value_source_tracking: ValueSourceTracking = field(default_factory=ValueSourceTracking)
 
     def __post_init__(self):
         self.override_configs = self.migration.override_configs
@@ -503,7 +504,9 @@ class MigrationService:
         self.discovered_file_paths = extra_files_discovery.discovered_file_paths
         self.missing_file_paths = extra_files_discovery.missing_file_paths
 
-        config_to_ess_transformer = ConfigValueTransformer(self.pretty_logger, self.ess_config)
+        config_to_ess_transformer = ConfigValueTransformer(
+            self.pretty_logger, self.ess_config, self.value_source_tracking
+        )
 
         # Set strategy name for source tracking
         config_to_ess_transformer.strategy_name = self.migration.name
@@ -531,12 +534,7 @@ class MigrationService:
             extra_files_discovery=extra_files_discovery,
         )
 
-        # Step 6: Collect value sources from transformer
-        for path, sources in config_to_ess_transformer.value_source_tracking.sources.items():
-            for source in sources:
-                self.value_source_tracking.add_source(path, source.strategy_name, source.value, source.source_path)
-
-        # Step 7: Store results and override/underride warnings
+        # Step 6: Store results and override/underride warnings
         self.results.extend(config_to_ess_transformer.results)
         self.override_warnings.extend(config_to_ess_transformer.override_warnings)
         self.underride_warnings.extend(config_to_ess_transformer.underride_warnings)

--- a/packages/ess-migration-tool/src/ess_migration_tool/models.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/models.py
@@ -182,6 +182,11 @@ class ValueSourceTracking:
                     conflicts[path] = srcs_with_values
         return conflicts
 
-    def get_tracked_source_paths(self) -> list[str]:
+    def get_tracked_source_paths(self, strategy_name: str) -> list[str]:
         """Get all source paths that have been tracked (for filtering in additional config)."""
-        return [s.source_path for srcs in self.sources.values() for s in srcs if s.source_path is not None]
+        return [
+            s.source_path
+            for srcs in self.sources.values()
+            for s in srcs
+            if s.source_path is not None and s.strategy_name == strategy_name
+        ]

--- a/packages/ess-migration-tool/tests/conftest.py
+++ b/packages/ess-migration-tool/tests/conftest.py
@@ -8,13 +8,29 @@ Pytest fixtures for migration tests.
 Centralizes common test configurations to reduce duplication.
 """
 
+import logging
+
 import pytest
 import yaml
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
+from ess_migration_tool.migration import ConfigValueTransformer
+from ess_migration_tool.models import ValueSourceTracking
 
 from .helm_validation import validate_helm_template
+
+
+@pytest.fixture
+def config_value_transformer():
+    """Fixture providing a generator of ConfigValueTransformer instances for a given name."""
+
+    def _gen(name: str):
+        return ConfigValueTransformer(
+            logging.getLogger(name), ess_config={}, value_source_tracking=ValueSourceTracking()
+        )
+
+    return _gen
 
 
 @pytest.fixture

--- a/packages/ess-migration-tool/tests/test_additional_config.py
+++ b/packages/ess-migration-tool/tests/test_additional_config.py
@@ -11,15 +11,14 @@ additional configurations with proper YAML pipe formatting for multi-line string
 """
 
 import json
-import logging
 
 import yaml
-from ess_migration_tool.migration import ConfigValueTransformer, TransformationSpec, additional_config_transformer
+from ess_migration_tool.migration import TransformationSpec, additional_config_transformer
 
 
-def test_additional_config_transformer_uses_pipe_for_multiline():
+def test_additional_config_transformer_uses_pipe_for_multiline(config_value_transformer):
     """Test that additional_config_transformer uses pipe for multi-line strings."""
-    transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer = config_value_transformer(__name__)
     source_config = {
         "log_config": """line1
 line2
@@ -54,9 +53,9 @@ line3""",
     assert parsed == source_config, "Additional config should round-trip correctly"
 
 
-def test_additional_config_transformer_single_line_no_unnecessary_pipe():
+def test_additional_config_transformer_single_line_no_unnecessary_pipe(config_value_transformer):
     """Test that additional config with single-line strings doesn't force pipe usage unnecessarily."""
-    transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer = config_value_transformer(__name__)
 
     source_config = {"simple_setting": "value1", "path_setting": "/path/to/file.yaml"}
 
@@ -81,9 +80,9 @@ def test_additional_config_transformer_single_line_no_unnecessary_pipe():
     assert parsed == source_config, "Single-line config should round-trip correctly"
 
 
-def test_additional_config_transformer_mixed_content():
+def test_additional_config_transformer_mixed_content(config_value_transformer):
     """Test additional config transformer with mixed single-line and multi-line content."""
-    transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer = config_value_transformer(__name__)
 
     source_config = {
         "enable_metrics": True,
@@ -126,9 +125,9 @@ formatters:
     assert parsed["simple_setting"] == "value1"
 
 
-def test_additional_config_transformer_filters_tracked_values():
+def test_additional_config_transformer_filters_tracked_values(config_value_transformer):
     """Test that additional_config_transformer filters out tracked values."""
-    transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer = config_value_transformer(__name__)
 
     source_config = {
         "server_name": "test.example.com",
@@ -180,9 +179,9 @@ def test_additional_config_transformer_filters_tracked_values():
     assert "public_baseurl" not in parsed
 
 
-def test_additional_config_transformer_empty_when_all_tracked():
+def test_additional_config_transformer_empty_when_all_tracked(config_value_transformer):
     """Test that additional config is empty when all values are tracked."""
-    transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer = config_value_transformer(__name__)
 
     source_config = {
         "server_name": "test.example.com",
@@ -221,12 +220,12 @@ def test_additional_config_transformer_empty_when_all_tracked():
     assert result["synapse"].get("additional") == {}
 
 
-def test_additional_config_transformer_preserves_existing_additional():
+def test_additional_config_transformer_preserves_existing_additional(config_value_transformer):
     """Test that additional_config_transformer preserves existing additional entries."""
     # Start with existing additional config (e.g., from listeners transformer)
     ess_config = {"synapse": {"additional": {"listeners.yml": {"config": "port: 8080\n"}}}}
-
-    transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config)
+    transformer = config_value_transformer(__name__)
+    transformer.ess_config = ess_config
 
     source_config = {
         "extra_setting": "value1",
@@ -261,10 +260,9 @@ def test_additional_config_transformer_preserves_existing_additional():
     assert parsed == {"extra_setting": "value1"}
 
 
-def test_additional_config_transformer_direct_string_format():
+def test_additional_config_transformer_direct_string_format(config_value_transformer):
     """Test that additional_config_transformer can output direct string format."""
-    transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
-
+    transformer = config_value_transformer(__name__)
     source_config = {
         "simple_setting": "value1",
         "nested": {"key": "value2"},
@@ -298,9 +296,9 @@ def test_additional_config_transformer_direct_string_format():
     assert parsed == source_config
 
 
-def test_additional_config_transformer_direct_string_format_yaml():
+def test_additional_config_transformer_direct_string_format_yaml(config_value_transformer):
     """Test that additional_config_transformer can output direct YAML string format."""
-    transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer = config_value_transformer(__name__)
 
     source_config = {
         "simple_setting": "value1",

--- a/packages/ess-migration-tool/tests/test_config_value_tracker.py
+++ b/packages/ess-migration-tool/tests/test_config_value_tracker.py
@@ -10,13 +10,14 @@ from pathlib import Path
 
 from ess_migration_tool.extra_files import ExtraFilesDiscovery
 from ess_migration_tool.interfaces import ExtraFilesDiscoveryStrategy, SecretDiscoveryStrategy
-from ess_migration_tool.migration import ConfigValueTransformer, TransformationSpec
+from ess_migration_tool.migration import TransformationSpec
 from ess_migration_tool.models import DiscoveredPath, GlobalOptions, ValueSourceTracking
 
 
-def test_config_value_tracker_basic():
+def test_config_value_tracker_basic(config_value_transformer):
     """Test basic ConfigValueTransformer functionality with dict-based transformations."""
-    transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={"unchanged": "value"})
+    transformer = config_value_transformer(__name__)
+    transformer.ess_config = {"unchanged": "value"}
     transformer.strategy_name = "TestStrategy"
 
     # Create a test config
@@ -39,7 +40,7 @@ def test_config_value_tracker_basic():
     )
 
     # Check tracked values via value_source_tracking
-    tracked_source_paths = transformer.value_source_tracking.get_tracked_source_paths()
+    tracked_source_paths = transformer.value_source_tracking.get_tracked_source_paths(transformer.strategy_name)
     assert "database.host" in tracked_source_paths
     assert "database.port" in tracked_source_paths
     assert "server_name" in tracked_source_paths
@@ -57,9 +58,9 @@ def test_config_value_tracker_basic():
     assert ess_config["serverName"] == "example.com"
 
 
-def test_config_value_tracker_filter_config():
+def test_config_value_tracker_filter_config(config_value_transformer):
     """Test ConfigValueTransformer filter_config functionality."""
-    transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer = config_value_transformer(__name__)
     transformer.strategy_name = "TestStrategy"
 
     # Create a test config
@@ -104,9 +105,9 @@ def test_config_value_tracker_filter_config():
     assert "other_setting" in filtered_config  # Not tracked, should be preserved
 
 
-def test_config_value_tracker_nested_dict():
+def test_config_value_tracker_nested_dict(config_value_transformer):
     """Test ConfigValueTransformer with nested dictionaries."""
-    transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer = config_value_transformer(__name__)
     transformer.strategy_name = "TestStrategy"
 
     # Create a nested config
@@ -138,7 +139,7 @@ def test_config_value_tracker_nested_dict():
     )
 
     # Check tracked values via value_source_tracking
-    tracked_source_paths = transformer.value_source_tracking.get_tracked_source_paths()
+    tracked_source_paths = transformer.value_source_tracking.get_tracked_source_paths(transformer.strategy_name)
     assert "database.connection.host" in tracked_source_paths
     assert "database.connection.port" in tracked_source_paths
     assert "database.credentials.user" in tracked_source_paths
@@ -153,9 +154,9 @@ def test_config_value_tracker_nested_dict():
     assert ess_config["server"]["name"] == "example.com"
 
 
-def test_config_value_tracker_empty():
+def test_config_value_tracker_empty(config_value_transformer):
     """Test ConfigValueTransformer with no tracked values."""
-    transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer = config_value_transformer(__name__)
 
     # Create a config to filter
     config = {
@@ -176,9 +177,9 @@ def test_config_value_tracker_empty():
     assert transformer.ess_config == {}
 
 
-def test_update_paths_in_config_basic():
+def test_update_paths_in_config_basic(config_value_transformer):
     """Test update_paths_in_config with basic file path updates."""
-    transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer = config_value_transformer(__name__)
     transformer.strategy_name = "TestStrategy"
 
     # Create a mock ExtraFilesDiscovery with discovered file paths
@@ -244,12 +245,14 @@ def test_update_paths_in_config_basic():
     assert updated_config["other_setting"] == "preserved"  # Non-file setting should be unchanged
 
     # Verify tracked values (only skipped paths are tracked)
-    assert len(transformer.value_source_tracking.get_tracked_source_paths()) == 0  # No skipped paths in this test
+    assert (
+        len(transformer.value_source_tracking.get_tracked_source_paths(transformer.strategy_name)) == 0
+    )  # No skipped paths in this test
 
 
-def test_update_paths_in_config_with_skipped_paths():
+def test_update_paths_in_config_with_skipped_paths(config_value_transformer):
     """Test update_paths_in_config with skipped file paths."""
-    transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer = config_value_transformer(__name__)
     transformer.strategy_name = "TestStrategy"
 
     class MockStrategy(ExtraFilesDiscoveryStrategy):
@@ -310,14 +313,18 @@ def test_update_paths_in_config_with_skipped_paths():
     assert updated_config["templates"]["password_reset"] == "/path/to/password_reset.html"  # Unchanged
     assert updated_config["templates"]["registration"] == "/etc/some-component/extra/registration.html"  # Updated
 
-    assert "templates.password_reset" not in transformer.value_source_tracking.get_tracked_source_paths()
-    assert "templates.registration" not in transformer.value_source_tracking.get_tracked_source_paths()
-    assert len(transformer.value_source_tracking.get_tracked_source_paths()) == 0
+    assert "templates.password_reset" not in transformer.value_source_tracking.get_tracked_source_paths(
+        transformer.strategy_name
+    )
+    assert "templates.registration" not in transformer.value_source_tracking.get_tracked_source_paths(
+        transformer.strategy_name
+    )
+    assert len(transformer.value_source_tracking.get_tracked_source_paths(transformer.strategy_name)) == 0
 
 
-def test_update_paths_in_config_empty_discovery():
+def test_update_paths_in_config_empty_discovery(config_value_transformer):
     """Test update_paths_in_config with no discovered files."""
-    transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer = config_value_transformer(__name__)
     transformer.strategy_name = "TestStrategy"
 
     class MockStrategy(ExtraFilesDiscoveryStrategy):
@@ -359,12 +366,12 @@ def test_update_paths_in_config_empty_discovery():
 
     # Verify config is unchanged
     assert updated_config == source_config
-    assert len(transformer.value_source_tracking.get_tracked_source_paths()) == 0
+    assert len(transformer.value_source_tracking.get_tracked_source_paths(transformer.strategy_name)) == 0
 
 
-def test_update_paths_in_config_nested_config():
+def test_update_paths_in_config_nested_config(config_value_transformer):
     """Test update_paths_in_config with nested configuration structures."""
-    transformer = ConfigValueTransformer(logging.Logger(__name__), ess_config={})
+    transformer = config_value_transformer(__name__)
     transformer.strategy_name = "TestStrategy"
 
     class MockStrategy(ExtraFilesDiscoveryStrategy):
@@ -433,7 +440,9 @@ def test_update_paths_in_config_nested_config():
     assert updated_config["other_setting"] == "preserved"  # Unchanged
 
     # Verify tracked values (only skipped paths are tracked)
-    assert len(transformer.value_source_tracking.get_tracked_source_paths()) == 0  # No skipped paths in this test
+    assert (
+        len(transformer.value_source_tracking.get_tracked_source_paths(transformer.strategy_name)) == 0
+    )  # No skipped paths in this test
 
 
 def test_get_conflicts_filters_none_values():

--- a/packages/ess-migration-tool/tests/test_element_web.py
+++ b/packages/ess-migration-tool/tests/test_element_web.py
@@ -4,16 +4,13 @@
 
 """Tests for Element Web migration."""
 
-import logging
-
 from ess_migration_tool.element_web import ElementWebMigration
-from ess_migration_tool.migration import ConfigValueTransformer
 from ess_migration_tool.models import GlobalOptions
 
 
-def test_element_web_additional_config_excludes_default_server_config():
+def test_element_web_additional_config_excludes_default_server_config(config_value_transformer):
     """Test that default_server_config values are extracted and m.homeserver is empty in additional config."""
-    transformer = ConfigValueTransformer(logging.getLogger(), ess_config={})
+    transformer = config_value_transformer(__name__)
     migration = ElementWebMigration(GlobalOptions())
 
     config = {

--- a/packages/ess-migration-tool/tests/test_hookshot.py
+++ b/packages/ess-migration-tool/tests/test_hookshot.py
@@ -4,15 +4,12 @@
 
 """Tests for Hookshot migration."""
 
-import logging
-
 from ess_migration_tool.hookshot import (
     HOOKSHOT_STRATEGY_NAME,
     HookshotExtraFileDiscovery,
     HookshotMigration,
     HookshotSecretDiscovery,
 )
-from ess_migration_tool.migration import ConfigValueTransformer
 from ess_migration_tool.models import GlobalOptions
 
 
@@ -22,9 +19,9 @@ def test_hookshot_strategy_name():
     assert migration.name == HOOKSHOT_STRATEGY_NAME
 
 
-def test_hookshot_enabled_transformation():
+def test_hookshot_enabled_transformation(config_value_transformer):
     """Test that Hookshot component is enabled."""
-    transformer = ConfigValueTransformer(logging.getLogger(), ess_config={})
+    transformer = config_value_transformer(__name__)
     migration = HookshotMigration(GlobalOptions())
 
     config = {"bridge": {"domain": "test.example.com"}}
@@ -33,9 +30,9 @@ def test_hookshot_enabled_transformation():
     assert transformer.ess_config["hookshot"]["enabled"] is True
 
 
-def test_bridge_domain_to_server_name():
+def test_bridge_domain_to_server_name(config_value_transformer):
     """Test that bridge.domain is mapped to global serverName."""
-    transformer = ConfigValueTransformer(logging.getLogger(), ess_config={})
+    transformer = config_value_transformer(__name__)
     migration = HookshotMigration(GlobalOptions())
 
     config = {"bridge": {"domain": "test.example.com"}}

--- a/packages/ess-migration-tool/tests/test_mas_listeners.py
+++ b/packages/ess-migration-tool/tests/test_mas_listeners.py
@@ -4,20 +4,17 @@
 
 """Tests for MAS listeners filtering functionality."""
 
-import logging
-
 import yaml
 from ess_migration_tool.mas import filter_mas_listeners
-from ess_migration_tool.migration import ConfigValueTransformer
 
 
-def test_filter_mas_listeners_with_no_listeners():
+def test_filter_mas_listeners_with_no_listeners(config_value_transformer):
     """Test filtering when no listeners are provided."""
-    result = filter_mas_listeners(ConfigValueTransformer(logging.getLogger(), {}), None)
+    result = filter_mas_listeners(config_value_transformer(__name__), None)
     assert result is None
 
 
-def test_filter_mas_listeners_with_ess_managed_only():
+def test_filter_mas_listeners_with_ess_managed_only(config_value_transformer):
     """Test filtering when only ESS-managed listeners are provided."""
     listeners = [
         {
@@ -39,11 +36,11 @@ def test_filter_mas_listeners_with_ess_managed_only():
             "resources": [{"name": "health"}, {"name": "prometheus"}, {"name": "connection-info"}],
         },
     ]
-    result = filter_mas_listeners(ConfigValueTransformer(logging.getLogger(), {}), listeners)
+    result = filter_mas_listeners(config_value_transformer(__name__), listeners)
     assert result is None
 
 
-def test_filter_mas_listeners_with_custom_only():
+def test_filter_mas_listeners_with_custom_only(config_value_transformer):
     """Test filtering when only custom listeners are provided."""
     listeners = [
         {
@@ -52,7 +49,7 @@ def test_filter_mas_listeners_with_custom_only():
             "resources": [{"name": "custom-resource"}, {"name": "another-custom"}],
         }
     ]
-    result = filter_mas_listeners(ConfigValueTransformer(logging.getLogger(), {}), listeners)
+    result = filter_mas_listeners(config_value_transformer(__name__), listeners)
     assert result is not None
     assert "listeners.yml" in result
     assert "config" in result["listeners.yml"]
@@ -61,7 +58,7 @@ def test_filter_mas_listeners_with_custom_only():
     assert "custom-resource" in result["listeners.yml"]["config"]
 
 
-def test_filter_mas_listeners_with_mixed():
+def test_filter_mas_listeners_with_mixed(config_value_transformer):
     """Test filtering with mixed ESS-managed and custom listeners."""
     listeners = [
         {
@@ -74,7 +71,7 @@ def test_filter_mas_listeners_with_mixed():
         },
         {"name": "custom", "binds": [{"port": 9000, "host": "0.0.0.0"}], "resources": [{"name": "custom-only"}]},
     ]
-    result = filter_mas_listeners(ConfigValueTransformer(logging.getLogger(), {}), listeners)
+    result = filter_mas_listeners(config_value_transformer(__name__), listeners)
     assert result is not None
     assert "listeners.yml" in result
     # Should only contain the custom listener (port 9000)
@@ -84,21 +81,21 @@ def test_filter_mas_listeners_with_mixed():
     assert "port: 8080" not in result["listeners.yml"]["config"]
 
 
-def test_filter_mas_listeners_with_empty_resources():
+def test_filter_mas_listeners_with_empty_resources(config_value_transformer):
     """Test filtering when listener has no resources."""
     listeners = [{"name": "empty", "binds": [{"port": 8080, "host": "0.0.0.0"}], "resources": []}]
-    result = filter_mas_listeners(ConfigValueTransformer(logging.getLogger(), {}), listeners)
+    result = filter_mas_listeners(config_value_transformer(__name__), listeners)
     assert result is None  # Empty resources should be filtered out
 
 
-def test_filter_mas_listeners_with_no_binds():
+def test_filter_mas_listeners_with_no_binds(config_value_transformer):
     """Test filtering when listener has no binds."""
     listeners = [{"name": "no-binds", "binds": [], "resources": [{"name": "custom"}]}]
-    result = filter_mas_listeners(ConfigValueTransformer(logging.getLogger(), {}), listeners)
+    result = filter_mas_listeners(config_value_transformer(__name__), listeners)
     assert result is None  # No binds means no port, should be filtered out
 
 
-def test_filter_mas_listeners_with_multiple_binds():
+def test_filter_mas_listeners_with_multiple_binds(config_value_transformer):
     """Test filtering when listener has multiple binds, some managed and some custom."""
     listeners = [
         {
@@ -118,7 +115,7 @@ def test_filter_mas_listeners_with_multiple_binds():
             "resources": [{"name": "custom-api"}],
         },
     ]
-    result = filter_mas_listeners(ConfigValueTransformer(logging.getLogger(), {}), listeners)
+    result = filter_mas_listeners(config_value_transformer(__name__), listeners)
     assert result is not None
     assert "listeners.yml" in result
 
@@ -134,7 +131,7 @@ def test_filter_mas_listeners_with_multiple_binds():
     assert listeners[0]["binds"][1]["port"] == 9002
 
 
-def test_filter_mas_listeners_with_different_bind_formats():
+def test_filter_mas_listeners_with_different_bind_formats(config_value_transformer):
     """Test filtering with different bind formats (address, host/port, socket, fd)."""
     listeners = [
         {
@@ -168,7 +165,7 @@ def test_filter_mas_listeners_with_different_bind_formats():
             "resources": [{"name": "custom-api"}],
         },
     ]
-    result = filter_mas_listeners(ConfigValueTransformer(logging.getLogger(), {}), listeners)
+    result = filter_mas_listeners(config_value_transformer(__name__), listeners)
     assert result is not None
     assert "listeners.yml" in result
 

--- a/packages/ess-migration-tool/tests/test_prompts.py
+++ b/packages/ess-migration-tool/tests/test_prompts.py
@@ -109,10 +109,8 @@ def test_migration_with_missing_secrets_prompt(
         log_capture_string.close()
 
 
-def test_prompt_for_ingress_host_with_missing_public_baseurl(monkeypatch):
+def test_prompt_for_ingress_host_with_missing_public_baseurl(monkeypatch, config_value_transformer):
     """Test that missing public_baseurl triggers user prompt for ingress host."""
-    from ess_migration_tool.migration import ConfigValueTransformer
-
     pretty_logger = logging.getLogger(test_prompt_for_ingress_host_with_missing_public_baseurl.__name__)
     pretty_logger.propagate = False
     pretty_logger.setLevel(logging.INFO)
@@ -125,7 +123,9 @@ def test_prompt_for_ingress_host_with_missing_public_baseurl(monkeypatch):
 
     try:
         # Test with missing public_baseurl
-        result = prompt_for_ingress_host(ConfigValueTransformer(pretty_logger, {}), None)
+        result = prompt_for_ingress_host(
+            config_value_transformer(test_prompt_for_ingress_host_with_missing_public_baseurl.__name__), None
+        )
 
         # Verify the result
         assert result == "matrix.example.com"

--- a/packages/ess-migration-tool/tests/test_secrets_wildcard.py
+++ b/packages/ess-migration-tool/tests/test_secrets_wildcard.py
@@ -15,7 +15,14 @@ from typing import Any
 import pytest
 from ess_migration_tool.interfaces import SecretDiscoveryStrategy
 from ess_migration_tool.migration import ConfigValueTransformer
-from ess_migration_tool.models import DiscoverableSecret, DiscoveredSecret, GlobalOptions, Secret, SecretConfig
+from ess_migration_tool.models import (
+    DiscoverableSecret,
+    DiscoveredSecret,
+    GlobalOptions,
+    Secret,
+    SecretConfig,
+    ValueSourceTracking,
+)
 from ess_migration_tool.secrets import SecretDiscovery
 
 
@@ -114,6 +121,7 @@ def test_wildcard_secret_discovery_and_injection():
     transformer = ConfigValueTransformer(
         pretty_logger=logging.getLogger(),
         ess_config={},
+        value_source_tracking=ValueSourceTracking(),
     )
 
     transformer.handle_secrets(discovery, secrets_list)

--- a/packages/ess-migration-tool/tests/test_synapse_listeners.py
+++ b/packages/ess-migration-tool/tests/test_synapse_listeners.py
@@ -2,14 +2,11 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-import logging
-
 import yaml
-from ess_migration_tool.migration import ConfigValueTransformer
 from ess_migration_tool.synapse import filter_listeners
 
 
-def test_filter_listeners_with_chart_managed_resources():
+def test_filter_listeners_with_chart_managed_resources(config_value_transformer):
     """Test that filter_listeners removes listeners with only chart-managed resources."""
     listeners = [
         {
@@ -37,13 +34,13 @@ def test_filter_listeners_with_chart_managed_resources():
         },
     ]
 
-    result = filter_listeners(ConfigValueTransformer(logging.getLogger(), {}), listeners)
+    result = filter_listeners(config_value_transformer(__name__), listeners)
 
     # Should return None since all listeners serve only chart-managed resources
     assert result is None
 
 
-def test_filter_listeners_with_custom_resources():
+def test_filter_listeners_with_custom_resources(config_value_transformer):
     """Test that filter_listeners keeps listeners with custom resources."""
     listeners = [
         {
@@ -72,7 +69,7 @@ def test_filter_listeners_with_custom_resources():
         },
     ]
 
-    result = filter_listeners(ConfigValueTransformer(logging.getLogger(), {}), listeners)
+    result = filter_listeners(config_value_transformer(__name__), listeners)
 
     # Should keep only the listener with custom resource
     assert result is not None
@@ -93,19 +90,19 @@ def test_filter_listeners_with_custom_resources():
     }
 
 
-def test_filter_listeners_with_no_listeners():
+def test_filter_listeners_with_no_listeners(config_value_transformer):
     """Test that filter_listeners handles None input."""
-    result = filter_listeners(ConfigValueTransformer(logging.getLogger(), {}), None)
+    result = filter_listeners(config_value_transformer(__name__), None)
     assert result is None
 
 
-def test_filter_listeners_with_empty_list():
+def test_filter_listeners_with_empty_list(config_value_transformer):
     """Test that filter_listeners handles empty list."""
-    result = filter_listeners(ConfigValueTransformer(logging.getLogger(), {}), [])
+    result = filter_listeners(config_value_transformer(__name__), [])
     assert result is None
 
 
-def test_filter_listeners_with_mixed_resources():
+def test_filter_listeners_with_mixed_resources(config_value_transformer):
     """Test that filter_listeners correctly filters mixed chart-managed and custom resources."""
     listeners = [
         {
@@ -151,7 +148,7 @@ def test_filter_listeners_with_mixed_resources():
         },
     ]
 
-    result = filter_listeners(ConfigValueTransformer(logging.getLogger(), {}), listeners)
+    result = filter_listeners(config_value_transformer(__name__), listeners)
 
     # Should keep only the listeners with custom resources and no ESS-managed port
     assert result is not None
@@ -178,7 +175,7 @@ def test_filter_listeners_with_mixed_resources():
     }
 
 
-def test_filter_listeners_with_string_resource_names():
+def test_filter_listeners_with_string_resource_names(config_value_transformer):
     """Test that filter_listeners handles string resource names (not just lists)."""
     listeners = [
         {
@@ -195,7 +192,7 @@ def test_filter_listeners_with_string_resource_names():
         },
     ]
 
-    result = filter_listeners(ConfigValueTransformer(logging.getLogger(), {}), listeners)
+    result = filter_listeners(config_value_transformer(__name__), listeners)
 
     # Should keep only the listener with custom resource
     assert result is not None


### PR DESCRIPTION
Value source tracking now happens on a global level to be able to resolve conflicts. The code should reflect it. This avoids to have to copy data around during each MigrationService run.