### PR TITLE
Fix secrets discovered being displayed as ess-initiliazed

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1296.bugfix.md
+++ b/packages/ess-migration-tool/newsfragments/1296.bugfix.md
@@ -1,0 +1,1 @@
+Fix an issue where dynamically discovered secrets would still be logged as initialied by ESS.

--- a/packages/ess-migration-tool/src/ess_migration_tool/engine.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/engine.py
@@ -127,6 +127,12 @@ class MigrationEngine:
                 self.discovered_secrets.extend(migrator.secret_discovery.discovered_secrets.values())
                 self.init_by_ess_secrets.extend(migrator.secret_discovery.init_by_ess_secrets)
 
+        # Filter out any secrets that were actually discovered by any strategy
+        # This ensures that secrets which were discovered (even by a different strategy)
+        # are not in the final init_by_ess_secrets list
+        all_discovered_keys = {secret.secret_key for secret in self.discovered_secrets}
+        self.init_by_ess_secrets = [key for key in self.init_by_ess_secrets if key not in all_discovered_keys]
+
         # Prompt for missing secrets and validate after all strategies have resolved their secrets
         # This allows strategies to find secrets that previous strategies may have missed
         for migrator in self.migrators:

--- a/packages/ess-migration-tool/tests/test_main_e2e.py
+++ b/packages/ess-migration-tool/tests/test_main_e2e.py
@@ -286,6 +286,15 @@ def test_main_e2e_synapse_with_mas(
     assert "'report_stats' found in" in log_output
     assert "'url_preview_enabled' found in" in log_output
 
+    # Verify that discovered MAS private keys are in MIGRATED SECRETS but NOT in ESS-INITIALIZED SECRETS
+    # The basic_mas_config_with_keys has RSA and ECDSA keys that are discovered
+    # All MAS secrets with init_if_missing_from_source_cfg=True are discovered,
+    # so they should appear in MIGRATED SECRETS and engine.init_by_ess_secrets should be empty
+    assert "🔐 MIGRATED SECRETS:" in log_output
+    assert "matrixAuthenticationService.privateKeys.rsa" in log_output
+    assert "matrixAuthenticationService.privateKeys.ecdsaPrime256v1" in log_output
+    assert "ESS-INITIALIZED SECRETS:" not in log_output
+
     # Check that output files were created
     values_file = output_dir / "values.yaml"
     assert values_file.exists(), "values.yaml should be created"


### PR DESCRIPTION
Fixes the following behaviour : 

```

🔐 MIGRATED SECRETS:
   • k8s://element-onprem/first-element-deployment-synapse-main#instance_template.yaml: macaroon_secret_key → synapse.macaroon
   • k8s://element-onprem/first-element-deployment-synapse-main#instance_template.yaml: registration_shared_secret → synapse.registrationSharedSecret
   • k8s://element-onprem/first-element-deployment-matrix-authentication-service-config#config.yaml: matrix.secret → matrixAuthenticationService.synapseSharedSecret
   • k8s://element-onprem/first-element-deployment-matrix-authentication-service-config#config.yaml: secrets.encryption → matrixAuthenticationService.encryptionSecret
   • k8s://element-onprem/first-element-deployment-matrix-authentication-service-config#config.yaml: secrets.keys.0 → matrixAuthenticationService.privateKeys.ecdsaPrime256v1
   • k8s://element-onprem/first-element-deployment-matrix-authentication-service-config#config.yaml: secrets.keys.1 → matrixAuthenticationService.privateKeys.rsa
   • k8s://element-onprem/first-element-deployment-matrix-authentication-service-config#config.yaml: secrets.keys.2 → matrixAuthenticationService.privateKeys.ecdsaSecp256k1
   • k8s://element-onprem/first-element-deployment-matrix-authentication-service-config#config.yaml: secrets.keys.3 → matrixAuthenticationService.privateKeys.ecdsaSecp384r1
   • k8s://element-onprem/first-element-deployment: spec.components.synapse.config.delegatedAuth.oidc.0.clientSecretSecretKey → authentication.oidc.0.clientSecret
   • k8s://element-onprem/first-element-deployment: spec.components.synapse.config.delegatedAuth.ldap.0.bindPasswordSecretKey → authentication.ldap.0.bindPassword
   • k8s://element-onprem/first-element-deployment: spec.components.synapse.config.signingKeySecretKey → synapse.signingKey
   • k8s://element-onprem/first-element-deployment: spec.components.hookshot.registration.yaml → hookshot.appserviceRegistration
   Press Enter to continue...



⚠  ESS-INITIALIZED SECRETS:
The following Synapse secrets will be auto-generated by ESS:
   • matrixAuthenticationService.privateKeys.rsa
   • matrixAuthenticationService.privateKeys.ecdsaPrime256v1

```