### PR TITLE
Fix overrides / underrides consistency

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1297.bugfix.md
+++ b/packages/ess-migration-tool/newsfragments/1297.bugfix.md
@@ -1,0 +1,1 @@
+Fix an issue where underrides would be logged as overrides.

--- a/packages/ess-migration-tool/src/ess_migration_tool/hookshot.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/hookshot.py
@@ -41,7 +41,6 @@ class HookshotMigration(MigrationStrategy):
             "bridge.url",
             "bridge.port",
             "bridge.bindAddress",
-            "bridge.mediaUrl",
             "listeners",
             "passFile",
             "cache.redisUri",

--- a/packages/ess-migration-tool/src/ess_migration_tool/synapse.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/synapse.py
@@ -240,7 +240,6 @@ class SynapseMigration(MigrationStrategy):
     def override_configs(self) -> set[str]:
         return {
             "public_baseurl",
-            "web_client_location",
             "server_name",
             "database.args.host",
             "database.args.port",
@@ -249,10 +248,6 @@ class SynapseMigration(MigrationStrategy):
             "database.args.database",
             "database.args.sslmode",
             "database.args.application_name",
-            "database.args.keepalives",
-            "database.args.keepalives_idle",
-            "database.args.keepalives_interval",
-            "database.args.keepalives_count",
             "ip_range_blacklist",
             "signing_key_path",
             "start_pushers",
@@ -270,10 +265,7 @@ class SynapseMigration(MigrationStrategy):
             "log_config",
             "macaroon_secret_key_path",
             "registration_shared_secret_path",
-            "worker_replication_secret_path",
-            "form_secret_path",
             "listeners",  # Listeners are also managed by ESS
-            'synapse.additional."listeners.yml".config',  # Additional listeners config
         }
 
     @property

--- a/packages/ess-migration-tool/tests/test_config_overrides.py
+++ b/packages/ess-migration-tool/tests/test_config_overrides.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""
+Tests to verify that override_configs and underride_configs don't conflict.
+"""
+
+import pytest
+from ess_migration_tool.element_web import ElementWebMigration
+from ess_migration_tool.hookshot import HookshotMigration
+from ess_migration_tool.mas import MASMigration
+from ess_migration_tool.models import GlobalOptions
+from ess_migration_tool.synapse import SynapseMigration
+from ess_migration_tool.well_known import WellKnownMigration
+
+# List of all migration strategies to test with their required arguments
+# Each entry is a tuple of (StrategyClass, kwargs_to_pass_to_init)
+STRATEGIES = [
+    (SynapseMigration, {}),
+    (MASMigration, {}),
+    (HookshotMigration, {}),
+    (ElementWebMigration, {}),
+    (WellKnownMigration, {"well_known_type": "client"}),
+    (WellKnownMigration, {"well_known_type": "server"}),
+    (WellKnownMigration, {"well_known_type": "support"}),
+    (WellKnownMigration, {"well_known_type": "element.json"}),
+]
+
+
+@pytest.fixture(params=STRATEGIES)
+def strategy(request):
+    """Fixture that provides each strategy instance."""
+    strategy_class, init_kwargs = request.param
+    return strategy_class(GlobalOptions(), **init_kwargs)
+
+
+def test_override_underride_no_conflict(strategy):
+    """Test that override_configs and underride_configs are disjoint sets."""
+    override_configs = strategy.override_configs
+    underride_configs = strategy.underride_configs
+
+    # Check that both sets are defined
+    assert override_configs is not None, f"{strategy.name}: override_configs is None"
+    assert underride_configs is not None, f"{strategy.name}: underride_configs is None"
+
+    # Check for conflicts
+    conflict = override_configs & underride_configs
+    assert conflict == set(), (
+        f"{strategy.name}: Config keys appear in both override_configs and underride_configs: {conflict}"
+    )
+
+
+def test_all_strategies_have_defined_configs():
+    """Test that all strategies define both override_configs and underride_configs."""
+    for strategy_class, init_kwargs in STRATEGIES:
+        strategy = strategy_class(GlobalOptions(), **init_kwargs)
+        assert hasattr(strategy, "override_configs"), f"{strategy.name} missing override_configs"
+        assert hasattr(strategy, "underride_configs"), f"{strategy.name} missing underride_configs"
+
+        override_configs = strategy.override_configs
+        underride_configs = strategy.underride_configs
+
+        assert isinstance(override_configs, set), f"{strategy.name}: override_configs is not a set"
+        assert isinstance(underride_configs, set), f"{strategy.name}: underride_configs is not a set"


### PR DESCRIPTION
Noticed that some configuration would be incorrectly logged as overrides.

Built with Mistral Medium 3.5.