### PR TITLE
pin pytest 8 for now

### DIFF
--- a/newsfragments/1301.internal.md
+++ b/newsfragments/1301.internal.md
@@ -1,0 +1,1 @@
+Pin pytest to pytest 8.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = []
 [dependency-groups]
 dev = [
   "ruff>=0.15.4",
-  "pytest>=8.4.2",
+  "pytest>=8.4.2,<9", # pytest 9 is causing issues with asyncio-cooperative
   "mypy>=1.19.1",
   "types-pyyaml>=6.0.12.20250915",
   "types-cryptography>=3.3.23.2",

--- a/uv.lock
+++ b/uv.lock
@@ -62,7 +62,7 @@ dev = [
     { name = "jsonschema", specifier = ">=4.26" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "platformdirs", specifier = ">=4.9.2" },
-    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest", specifier = ">=8.4.2,<9" },
     { name = "pytz", specifier = ">=2025.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rapidfuzz", specifier = ">=3.14.3" },


### PR DESCRIPTION
We are seeing issues with pytest 9. Let's pin it for now.