### PR TITLE
Synapse: Discover MAS properties from configuration

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1306.feature.md
+++ b/packages/ess-migration-tool/newsfragments/1306.feature.md
@@ -1,0 +1,1 @@
+Trigger a values conflict resolution if Synapse `homeserver.yaml` does not have `matrix_authentication_service` configured despite a MAS `config.yaml` being passed.

--- a/packages/ess-migration-tool/src/ess_migration_tool/synapse.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/synapse.py
@@ -345,6 +345,12 @@ class SynapseMigration(MigrationStrategy):
                 transformer=filter_listeners,
                 required=False,
             ),  # Filter out chart-managed listeners and output to additional config
+            TransformationSpec(
+                src_key="matrix_authentication_service",
+                target_key="matrixAuthenticationService.enabled",
+                transformer=lambda _, mas, **__: mas.get("enabled") if mas else None,
+                required=False,
+            ),
             # ... other non-database transformations ...
         ]
 

--- a/packages/ess-migration-tool/tests/conftest.py
+++ b/packages/ess-migration-tool/tests/conftest.py
@@ -226,6 +226,18 @@ def synapse_config_with_ca_federation_list(tmp_path, basic_synapse_config):
 
 
 @pytest.fixture
+def synapse_config_with_mas(tmp_path, basic_synapse_config):
+    """Synapse configuration with a signing key file."""
+    config = basic_synapse_config.copy()
+    config["matrix_authentication_service"] = {
+        "enabled": True,
+        "endpoint": "http://mas.example.com:8080",
+        "secret": "synapse_shared_secret_abcdef",
+    }
+    return config
+
+
+@pytest.fixture
 def basic_mas_config():
     """Basic MAS configuration for testing."""
     return {

--- a/packages/ess-migration-tool/tests/test_main_e2e.py
+++ b/packages/ess-migration-tool/tests/test_main_e2e.py
@@ -222,6 +222,7 @@ def test_main_e2e_synapse_with_mas(
     monkeypatch,
     tmp_path,
     synapse_config_with_signing_key,
+    synapse_config_with_mas,
     basic_mas_config_with_keys,
     write_synapse_config,
     write_mas_config,
@@ -230,7 +231,7 @@ def test_main_e2e_synapse_with_mas(
 ):
     """Test the complete end-to-end migration workflow with Synapse and MAS."""
     # Write configuration files
-    synapse_config_file = write_synapse_config(synapse_config_with_signing_key)
+    synapse_config_file = write_synapse_config(synapse_config_with_signing_key | synapse_config_with_mas)
     mas_config_file = write_mas_config(basic_mas_config_with_keys)
 
     # Create output directory
@@ -318,6 +319,9 @@ def test_main_e2e_synapse_with_mas(
         additional_config = synapse_config["additional"]
         assert "listeners.yml" not in additional_config, (
             'synapse.additional."listeners.yml" should be absent when only chart-managed listeners exist'
+        )
+        assert "matrix_authentication_service" not in additional_config, (
+            'synapse.additional."matrix_authentication_service" should be absent when migrated from config'
         )
 
     # Verify MAS configuration was migrated and is explicitly enabled

--- a/packages/ess-migration-tool/tests/test_main_e2e.py
+++ b/packages/ess-migration-tool/tests/test_main_e2e.py
@@ -367,11 +367,15 @@ def test_main_e2e_synapse_with_mas(
             assert "name" in secret_content["metadata"]
             assert "data" in secret_content
             if secret_file.name == "imported-synapse-secret.yaml":
-                assert len(secret_content["data"]) == 4
+                assert len(secret_content["data"]) == 5
                 assert base64.b64decode(secret_content["data"]["synapse.macaroon"]) == b"test_macaroon_secret"
                 assert (
                     base64.b64decode(secret_content["data"]["synapse.registrationSharedSecret"])
                     == b"test_registration_secret"
+                )
+                assert (
+                    base64.b64decode(secret_content["data"]["matrixAuthenticationService.synapseSharedSecret"])
+                    == b"synapse_shared_secret_abcdef"
                 )
                 assert base64.b64decode(secret_content["data"]["synapse.signingKey"]) == b"test_signing_key_content"
             elif secret_file.name == "imported-matrix-authentication-service-secret.yaml":


### PR DESCRIPTION
Trigger a values conflict resolution if Synapse `homeserver.yaml` does not have `matrix_authentication_service` configured despite a MAS `config.yaml` being passed.

Adding the test discovered a secrets duplication issue that is being fixed in https://github.com/element-hq/ess-helm/pull/1313