### PR TITLE
Poll rather than wait for the Traefik Service's LB IP

### DIFF
--- a/newsfragments/1308.internal.md
+++ b/newsfragments/1308.internal.md
@@ -1,0 +1,1 @@
+CI: poll for the Traefik `Service` having a load-balancer IP rather than waiting.

--- a/tests/integration/fixtures/cluster.py
+++ b/tests/integration/fixtures/cluster.py
@@ -136,21 +136,21 @@ async def ingress(cluster, kube_client: AsyncClient):
             # We can't just kubectl wait as that doesn't work with non-existent objects
             # This can be setup before the LB port is accessible externally, so we do it afterwards
             service = await kube_client.get(Service, name="traefik", namespace="kube-system")
-            await asyncio.to_thread(
-                cluster.wait,
-                name="service/traefik",
-                waitfor="jsonpath='{.status.loadBalancer.ingress[0].ip}'",
-                namespace="kube-system",
-            )
 
             assert service
+            assert service.status
+            assert service.status.loadBalancer
+            assert service.status.loadBalancer.ingress
+            assert service.status.loadBalancer.ingress[0]
+            assert service.status.loadBalancer.ingress[0].ip
             assert service.spec
             assert service.spec.clusterIP
+
             return service.spec.clusterIP
-        except ApiError:
+        except (ApiError, AssertionError):
             await asyncio.sleep(1)
             attempt += 1
-    raise Exception("Couldn't fetch Trafeik Service IP after 180s")
+    raise Exception("Couldn't fetch Traefik Service IP after 180s")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
We've seen things like `subprocess.TimeoutExpired: Command '/usr/local/bin/kubectl --kubeconfig /tmp/tmpdbz4qurg wait service/traefik --for=jsonpath='{.status.loadBalancer.ingress[0].ip}' --timeout=90s --namespace=kube-system' timed out after 90 seconds` in CI. This is despite the `Service` YAML shown afterwards having the LB IP. We have the `Service` anyway, so let's just use the existing polling to see if that's more reliable