### PR TITLE
Document traffic policies on exposed port ranges

### DIFF
--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -551,6 +551,9 @@ extraInitContainers: []
   portType: {{ portType }}
   # External IPs addresses of this service.
   # externalIPs: []
+  # Either Local or Cluster
+  internalTrafficPolicy: Cluster
+  externalTrafficPolicy: Cluster
   portRange:
     # The beginning port of the range
     startPort: {{ startPort }}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -837,6 +837,9 @@ matrixRTC:
         portType: NodePort
         # External IPs addresses of this service.
         # externalIPs: []
+        # Either Local or Cluster
+        internalTrafficPolicy: Cluster
+        externalTrafficPolicy: Cluster
         portRange:
           # The beginning port of the range
           startPort: 31000

--- a/newsfragments/1309.fixed.md
+++ b/newsfragments/1309.fixed.md
@@ -1,0 +1,1 @@
+Fixed `matrixRTC.sfu.exposedServices.rtpUdp` not documenting `externalTrafficPolicy` or `internalTrafficPolicy`.


### PR DESCRIPTION
They're supported in the schema, tests and templates, just missing this documentation