### PR TITLE
MatrixRTC SFU: set turn.external_tls appropriately

### DIFF
--- a/charts/matrix-stack/configs/matrix-rtc/sfu/config-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/matrix-rtc/sfu/config-overrides.yaml.tpl
@@ -75,6 +75,7 @@ turn:
   cert_file: /turn-tls/tls.crt
   key_file: /turn-tls/tls.key
 {{- end }}
+  external_tls: {{ not .tlsTerminationOnPod }}
 {{- end }}
 {{- end }}
 {{- with .exposedServices.turn }}

--- a/newsfragments/1310.fixed.md
+++ b/newsfragments/1310.fixed.md
@@ -1,0 +1,1 @@
+Ensure `turn.external_tls` is correctly set in the Matrix RTC SFU configuration depending on `matrixRTC.sfu.exposedServices.turnTLS.tlsTerminationOnPod`.


### PR DESCRIPTION
Was fine when TLS was being terminated in the `Pod` but needs to be set to `true` if `tlsTerminationOnPod` is `false`.

Omitted from #1053 