### PR TITLE
Deduplicate discovered secrets when multiple strategies can discover it.

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1313.feature.md
+++ b/packages/ess-migration-tool/newsfragments/1313.feature.md
@@ -1,0 +1,1 @@
+Allow the migration process to discover MAS <-> Synapse shared secret from Synapse configuration, and resolve any conflicting configuration.

--- a/packages/ess-migration-tool/src/ess_migration_tool/mas.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/mas.py
@@ -368,6 +368,7 @@ class MASSecretDiscovery(SecretDiscoveryStrategy):
                 "matrixAuthenticationService.synapseSharedSecret": DiscoverableSecret(
                     description="MAS Synapse shared secret",
                     init_if_missing_from_source_cfg=True,  # Can be auto-generated
+                    takes_precedence_if_duplicates=True,  # MAS owns this secret when discovered by multiple strategies
                     discovery=SecretConfig(
                         config_inline="matrix.secret",
                         config_path="matrix.secret_file",

--- a/packages/ess-migration-tool/src/ess_migration_tool/migration.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/migration.py
@@ -307,8 +307,16 @@ class ConfigValueTransformer:
         # Create a Kubernetes Secret containing all discovered secrets
         secret_name = f"imported-{secret_discovery.strategy.secret_name}"
         secret_data = {}
+        current_strategy = secret_discovery.strategy.secret_name
 
         for secret_key, discover_secret in secret_discovery.discovered_secrets.items():
+            # Check if this secret should be owned by another strategy
+            owner = secret_discovery.secret_tracking.get_secret_owner(secret_key)
+            if owner and owner != current_strategy:
+                # This secret is owned by another strategy, skip it
+                logger.debug(f"Skipping {secret_key} for {current_strategy} - owned by {owner}")
+                continue
+
             # Base64 encode the secret value for Kubernetes Secret
             encoded_value = base64.b64encode(discover_secret.value.encode("utf-8")).decode("utf-8")
             secret_data[secret_key] = encoded_value
@@ -323,9 +331,13 @@ class ConfigValueTransformer:
         # Update ESS values to use credential schema instead of direct values
         # Use the ess_secret_schema to map secret keys to ESS configuration paths
         for secret_key, discover_secret in secret_discovery.discovered_secrets.items():
+            # Determine which secret file this secret belongs to
+            owner = secret_discovery.secret_tracking.get_secret_owner(secret_key)
+            owning_secret_name = secret.name if owner is None else f"imported-{owner}"
+
             # Convert secret key to credential schema format
             # Example: secret -> {"secret": "imported-synapse", "secretKey": "synapse.postgres.password"}
-            credential_config = {"secret": secret.name, "secretKey": secret_key}
+            credential_config = {"secret": owning_secret_name, "secretKey": secret_key}
 
             # Validate that the secret key matches a schema entry (supports wildcard patterns)
             matching_key = find_matching_schema_key(secret_key, secret_discovery.strategy.ess_secret_schema)

--- a/packages/ess-migration-tool/src/ess_migration_tool/models.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/models.py
@@ -146,6 +146,9 @@ class DiscoverableSecret:
     discovery: SecretConfig | None = None  # Discovery configuration (None if not discoverable from config)
     optional: bool = False  # Whether the secret is optional (not required for migration)
     init_if_missing_from_source_cfg: bool = False  # Whether to initialize secret if missing from source config
+    takes_precedence_if_duplicates: bool = (
+        False  # If True, this strategy owns the secret when discovered by multiple strategies
+    )
 
 
 @dataclass
@@ -199,6 +202,7 @@ class SecretSource:
     secret_key: str  # ESS secret key (e.g., "synapse.signingKey")
     value: str  # The secret value
     source_path: str  # Original configuration path in source file
+    takes_precedence: bool = False  # Whether this strategy takes precedence for duplicates
 
 
 @dataclass
@@ -207,7 +211,9 @@ class DiscoveredSecretTracking:
 
     sources: dict[str, list[SecretSource]] = field(default_factory=dict)
 
-    def add_source(self, secret_key: str, strategy_name: str, value: str, source_path: str) -> None:
+    def add_source(
+        self, secret_key: str, strategy_name: str, value: str, source_path: str, takes_precedence: bool = False
+    ) -> None:
         """Add a discovered secret source to tracking."""
         if secret_key not in self.sources:
             self.sources[secret_key] = []
@@ -217,6 +223,7 @@ class DiscoveredSecretTracking:
                 secret_key=secret_key,
                 value=value,
                 source_path=source_path,
+                takes_precedence=takes_precedence,
             )
         )
 
@@ -248,3 +255,54 @@ class DiscoveredSecretTracking:
         if not self.is_discovered(secret_key):
             return []
         return [s.strategy_name for s in self.sources[secret_key]]
+
+    def get_secret_owner(self, secret_key: str) -> str | None:
+        """
+        Determine which strategy owns a secret that was discovered by multiple strategies.
+        A strategy owns a secret if it has `takes_precedence_if_duplicates=True` for that secret.
+        Only one strategy can own a duplicate secret.
+        If no strategy claims precedence or multiple claim it, falls back to the last
+        discovering strategy.
+
+        Args:
+            secret_key: The ESS secret key to determine ownership for
+
+        Returns:
+            The strategy name that owns this secret, or None if secret was not discovered
+        """
+        import logging
+
+        logger = logging.getLogger("migration")
+
+        # If secret was not discovered, return None
+        if not self.is_discovered(secret_key):
+            return None
+
+        # Get all sources (strategies that discovered this secret)
+        sources = self.sources.get(secret_key, [])
+
+        # Find the strategy with takes_precedence=True
+        owning_strategy: str | None = None
+        found_precedence = False
+        for source in sources:
+            if source.takes_precedence:
+                found_precedence = True
+                # This strategy wants to own this secret
+                if owning_strategy is not None:
+                    # More than one strategy wants to own it - this is a conflict
+                    logger.error(
+                        f"Multiple strategies claim precedence for secret {secret_key}: "
+                        f"{owning_strategy} and {source.strategy_name}. "
+                    )
+                owning_strategy = source.strategy_name
+
+        # If no strategy has takes_precedence,
+        if len(sources) > 1 and not found_precedence:
+            # More than one strategy wants to own it - this is a conflict
+            logger.error(
+                f"Multiple strategies discovered secret {secret_key}, but no strategy claims precedence: "
+                f"{owning_strategy} and {source.strategy_name}. "
+            )
+            # Find the last strategy that discovered the secret
+            owning_strategy = sources[-1].strategy_name
+        return owning_strategy

--- a/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/secrets.py
@@ -60,6 +60,8 @@ class SecretDiscovery:
             matching_schema_key = find_matching_schema_key(secret_key, self.strategy.ess_secret_schema)
             if matching_schema_key is None:
                 raise RuntimeError(f"Discovered component-specific secret '{secret_key}' not found in schema")
+            # Get the precedence flag from the schema
+            discoverable_secret = self.strategy.ess_secret_schema[matching_schema_key]
             # Add the discovered secret
             self.discovered_secrets[secret_key] = discovered_secret
             # Register with global tracking
@@ -68,6 +70,7 @@ class SecretDiscovery:
                 strategy_name=self.strategy.secret_name,
                 value=discovered_secret.value,
                 source_path=discovered_secret.config_key,
+                takes_precedence=discoverable_secret.takes_precedence_if_duplicates,
             )
 
         # Process component-specific discovery failures
@@ -113,7 +116,12 @@ class SecretDiscovery:
             discovered_value, error_msg = self._try_discover_from_config(secret_key, discovery_config, config_data)
 
             if discovered_value is not None:
-                self._add_discovered_secret(secret_key, discovery_config, discovered_value)
+                self._add_discovered_secret(
+                    secret_key,
+                    discovery_config,
+                    discovered_value,
+                    takes_precedence=discoverable_secret.takes_precedence_if_duplicates,
+                )
                 continue
 
             # Secret was not discovered from config - handle missing case
@@ -179,6 +187,7 @@ class SecretDiscovery:
         secret_key: str,
         discovery_config: SecretConfig,
         discovered_value: str,
+        takes_precedence: bool = False,
     ) -> None:
         """Add a discovered secret to the discovered_secrets dictionary."""
         config_key = discovery_config.config_inline or discovery_config.config_path
@@ -198,6 +207,7 @@ class SecretDiscovery:
             strategy_name=self.strategy.secret_name,
             value=discovered_value,
             source_path=config_key,
+            takes_precedence=takes_precedence,
         )
 
     def _handle_missing_secret(

--- a/packages/ess-migration-tool/tests/test_main_e2e.py
+++ b/packages/ess-migration-tool/tests/test_main_e2e.py
@@ -367,20 +367,22 @@ def test_main_e2e_synapse_with_mas(
             assert "name" in secret_content["metadata"]
             assert "data" in secret_content
             if secret_file.name == "imported-synapse-secret.yaml":
-                assert len(secret_content["data"]) == 5
+                assert len(secret_content["data"]) == 4, (
+                    "expected 4 synapse secrets (macaroon, registration, signing, postgres password)"
+                )
                 assert base64.b64decode(secret_content["data"]["synapse.macaroon"]) == b"test_macaroon_secret"
                 assert (
                     base64.b64decode(secret_content["data"]["synapse.registrationSharedSecret"])
                     == b"test_registration_secret"
                 )
-                assert (
-                    base64.b64decode(secret_content["data"]["matrixAuthenticationService.synapseSharedSecret"])
-                    == b"synapse_shared_secret_abcdef"
-                )
                 assert base64.b64decode(secret_content["data"]["synapse.signingKey"]) == b"test_signing_key_content"
+                assert base64.b64decode(secret_content["data"]["synapse.postgres.password"]) == b"test"
+                assert "matrixAuthenticationService.synapseSharedSecret" not in secret_content["data"], (
+                    "matrixAuthenticationService.synapseSharedSecret should be in MAS secret only"
+                )
+
             elif secret_file.name == "imported-matrix-authentication-service-secret.yaml":
-                # 3 original secrets + 2-4 keys (rsa, ecdsaPrime256v1, ecdsaSecp256k1, ecdsaSecp384r1)
-                assert 5 <= len(secret_content["data"]) <= 7  # 3 original + 2-4 keys
+                assert len(secret_content["data"]) == 5, "expected 2 original + 2 keys + 1 synapse shared secret"
                 assert (
                     base64.b64decode(secret_content["data"]["matrixAuthenticationService.synapseSharedSecret"])
                     == b"synapse_shared_secret_abcdef"
@@ -1290,7 +1292,8 @@ def test_main_e2e_synapse_mas_shared_secret_conflict(
     assert "secret" in mas_config_output["synapseSharedSecret"]
 
     # Verify the resolved value is mas_side_secret (we selected option 1)
-    # Check the secret file content
+    # Note: The shared secret is owned by MAS (takes_precedence_if_duplicates=True),
+    # so it should be in the MAS secret file, not the Synapse one
     secret_files = list(output_dir.glob("*secret.yaml"))
     mas_secret_file = next((sf for sf in secret_files if "matrix-authentication-service" in sf.name), None)
     assert mas_secret_file is not None, "MAS secret file should exist"
@@ -1301,3 +1304,12 @@ def test_main_e2e_synapse_mas_shared_secret_conflict(
     # The resolved value should be mas_side_secret (option 1 selected)
     decoded_value = base64.b64decode(secret_content["data"]["matrixAuthenticationService.synapseSharedSecret"])
     assert decoded_value == b"mas_side_secret", f"Expected mas_side_secret, got {decoded_value}"
+
+    # Verify the secret is NOT in the Synapse secret file
+    synapse_secret_file = next((sf for sf in secret_files if "synapse" in sf.name), None)
+    if synapse_secret_file:
+        with open(synapse_secret_file) as f:
+            synapse_secret_content = yaml.safe_load(f)
+        assert "matrixAuthenticationService.synapseSharedSecret" not in synapse_secret_content["data"], (
+            "matrixAuthenticationService.synapseSharedSecret should only be in MAS secret"
+        )


### PR DESCRIPTION
This fixes a minor issue where `synapseSharedSecret` value was rendered in 2 secrets (MAS & Synapse), despite being referred only once in the values file.

Built with Mistral Medium 3.5.