### PR TITLE
uv: declare ess-migration-tool in root sources

### DIFF
--- a/newsfragments/1325.internal.md
+++ b/newsfragments/1325.internal.md
@@ -1,0 +1,1 @@
+CI: Configure dependabot to target `uv` ecosystem.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ members = ["packages/*", "tests"]
 
 [tool.uv.sources]
 ess-community-integration-tests = { workspace = true }
+ess-migration-tool = { workspace = true }
 
 [tool.pytest.ini_options]
 # we use asyncio-cooperative


### PR DESCRIPTION
All packages are declared as `tool.uv.sources` in the PR which added workspace support to uv in https://github.com/dependabot/dependabot-core/pull/14627/changes . 

I'm not sure how this [relates](https://docs.astral.sh/uv/concepts/projects/dependencies/#dependency-sources) to cryptography [not being updated in ess-migration-tool](https://github.com/element-hq/ess-helm/pull/1316) but it's worth giving a shot I suppose. 