### PR TITLE
Migration tool: Import appservices as high level values

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1327.misc.md
+++ b/packages/ess-migration-tool/newsfragments/1327.misc.md
@@ -1,0 +1,1 @@
+Add support for importing appservices as high level values in `synapse.appservices`.

--- a/packages/ess-migration-tool/src/ess_migration_tool/synapse.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/synapse.py
@@ -16,7 +16,13 @@ from rapidfuzz import fuzz, process
 from .interfaces import ExtraFilesDiscoveryStrategy, SecretDiscoveryStrategy
 from .migration import ConfigValueTransformer, MigrationStrategy, TransformationSpec, additional_config_transformer
 from .models import DiscoverableSecret, DiscoveredSecret, GlobalOptions, MigrationError, SecretConfig
-from .utils import extract_hostname_from_url, prompt_choice, prompt_value, yaml_dump_with_pipe_for_multiline
+from .utils import (
+    extract_hostname_from_url,
+    get_nested_value,
+    prompt_choice,
+    prompt_value,
+    yaml_dump_with_pipe_for_multiline,
+)
 
 logger = logging.getLogger("migration")
 
@@ -404,6 +410,11 @@ class SynapseSecretDiscovery(SecretDiscoveryStrategy):
         """Get the ESS secret schema for Synapse."""
         schema: dict[str, DiscoverableSecret] = {
             # Synapse secrets
+            "synapse.appservices.*": DiscoverableSecret(
+                description="Appservice registration files",
+                init_if_missing_from_source_cfg=False,
+                optional=True,
+            ),
         }
 
         # Only include PostgreSQL password when using existing database
@@ -468,16 +479,50 @@ class SynapseSecretDiscovery(SecretDiscoveryStrategy):
         """
         Discover component-specific secrets from configuration.
 
-        Synapse doesn't have specialized secret discovery, so this returns empty dict/list.
+        Discovers appservice registration files from the app_service_config_files configuration.
 
         Args:
             source_file: Source configuration file name
             config_data: Synapse configuration data
 
         Returns:
-            Tuple of (empty dict, empty list) - no specialized secret discovery for Synapse
+            Tuple of (discovered_secrets, failed_secrets) where:
+            - discovered_secrets: Dictionary mapping ESS secret keys to DiscoveredSecret objects
+            - failed_secrets: List of (DiscoveredSecret, error_message) tuples for secrets
+              that were discovered but could not be read
         """
-        return ({}, [])
+        discovered: dict[str, DiscoveredSecret] = {}
+        failed: list[tuple[DiscoveredSecret, str]] = []
+
+        # Get app_service_config_files from config (always a list)
+        file_paths = get_nested_value(config_data, "app_service_config_files")
+        if not file_paths or not isinstance(file_paths, list):
+            return discovered, failed
+
+        # Read each file and create discovered secrets
+        for idx, file_path in enumerate(file_paths):
+            secret_key = f"synapse.appservices.{idx}"
+            config_key = f"app_service_config_files.{idx}"
+
+            try:
+                with open(file_path) as f:
+                    file_content = f.read()
+                discovered[secret_key] = DiscoveredSecret(
+                    source_file=source_file,
+                    secret_key=secret_key,
+                    config_key=config_key,
+                    value=file_content,
+                )
+            except Exception as e:
+                failed_secret = DiscoveredSecret(
+                    source_file=source_file,
+                    secret_key=secret_key,
+                    config_key=config_key,
+                    value="",
+                )
+                failed.append((failed_secret, f"Failed to read file {file_path}: {e}"))
+
+        return discovered, failed
 
 
 class SynapseExtraFileDiscovery(ExtraFilesDiscoveryStrategy):

--- a/packages/ess-migration-tool/tests/test_synapse_secrets.py
+++ b/packages/ess-migration-tool/tests/test_synapse_secrets.py
@@ -127,3 +127,85 @@ def test_permission_error_handling_for_secrets(tmp_path, basic_synapse_config):
 
     # Clean up: restore permissions for cleanup
     restricted_key.chmod(0o644)
+
+
+def test_discover_appservice_registration_files(tmp_path, basic_synapse_config):
+    """Test discovering appservice registration files from Synapse configuration."""
+    # Create test appservice registration files
+    appservice1 = tmp_path / "appservice1.yaml"
+    appservice1.write_text("id: appservice1\nurl: http://localhost:8001\n")
+
+    appservice2 = tmp_path / "appservice2.yaml"
+    appservice2.write_text("id: appservice2\nurl: http://localhost:8002\n")
+
+    # Create config with appservice config files
+    synapse_config = basic_synapse_config.copy()
+    synapse_config["app_service_config_files"] = [str(appservice1), str(appservice2)]
+    synapse_config["database"]["args"]["password"] = "test_password"
+
+    # Test secret discovery
+    global_options = GlobalOptions(use_existing_database=True)
+    synapse_secrets = SynapseSecretDiscovery(global_options)
+    discovery = SecretDiscovery(
+        synapse_secrets, logging.getLogger(), "synapse.yaml", global_options, DiscoveredSecretTracking()
+    )
+    discovery.discover_secrets(synapse_config)
+
+    # Appservice registration files should be discovered
+    assert "synapse.appservices.0" in discovery.discovered_secrets
+    assert "synapse.appservices.1" in discovery.discovered_secrets
+    assert (
+        discovery.discovered_secrets["synapse.appservices.0"].value == "id: appservice1\nurl: http://localhost:8001\n"
+    )
+    assert (
+        discovery.discovered_secrets["synapse.appservices.1"].value == "id: appservice2\nurl: http://localhost:8002\n"
+    )
+
+    # Appservice secrets should have correct source tracking
+    assert discovery.discovered_secrets["synapse.appservices.0"].source_file == "synapse.yaml"
+    assert discovery.discovered_secrets["synapse.appservices.0"].config_key == "app_service_config_files.0"
+    assert discovery.discovered_secrets["synapse.appservices.1"].config_key == "app_service_config_files.1"
+
+
+def test_appservice_files_missing(tmp_path, basic_synapse_config):
+    """Test handling of missing appservice registration files."""
+    # Create config with non-existent appservice config files
+    synapse_config = basic_synapse_config.copy()
+    synapse_config["app_service_config_files"] = ["/nonexistent/appservice1.yaml", "/nonexistent/appservice2.yaml"]
+    synapse_config["database"]["args"]["password"] = "test_password"
+
+    # Test secret discovery
+    global_options = GlobalOptions(use_existing_database=True)
+    synapse_secrets = SynapseSecretDiscovery(global_options)
+    discovery = SecretDiscovery(
+        synapse_secrets, logging.getLogger(), "synapse.yaml", global_options, DiscoveredSecretTracking()
+    )
+    discovery.discover_secrets(synapse_config)
+
+    # Missing appservice files should be in failed secrets (but optional, so not in missing_required)
+    # Since appservice secrets are optional, they won't block migration
+    assert "synapse.appservices.0" not in discovery.discovered_secrets
+    assert "synapse.appservices.1" not in discovery.discovered_secrets
+    # Other required secrets should still be missing
+    missing_secret_keys = {ds.secret_key for ds, _ in discovery.missing_required_secrets}
+    assert "synapse.signingKey" in missing_secret_keys
+
+
+def test_appservice_files_empty_list(basic_synapse_config):
+    """Test handling of empty app_service_config_files list."""
+    # Create config with empty appservice config files list
+    synapse_config = basic_synapse_config.copy()
+    synapse_config["app_service_config_files"] = []
+    synapse_config["database"]["args"]["password"] = "test_password"
+
+    # Test secret discovery
+    global_options = GlobalOptions(use_existing_database=True)
+    synapse_secrets = SynapseSecretDiscovery(global_options)
+    discovery = SecretDiscovery(
+        synapse_secrets, logging.getLogger(), "synapse.yaml", global_options, DiscoveredSecretTracking()
+    )
+    discovery.discover_secrets(synapse_config)
+
+    # No appservice secrets should be discovered
+    appservice_secrets = [k for k in discovery.discovered_secrets if "appservices" in k]
+    assert len(appservice_secrets) == 0


### PR DESCRIPTION
This allows the migration tool to import those appservices properly in ESS values.