### PR TITLE
Hookshot: Fix mounting its appservice registration file into Synapse

### DIFF
--- a/charts/matrix-stack/ci/synapse-hookshot-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/synapse-hookshot-secrets-externally-values.yaml
@@ -1,0 +1,70 @@
+# Copyright 2024-2025 New Vector Ltd
+# Copyright 2025-2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# source_fragments: hookshot-additional-secrets-externally.yaml hookshot-ingress.yaml hookshot-minimal.yaml hookshot-redis-secrets-externally.yaml hookshot-redis.yaml hookshot-secrets-externally.yaml init-secrets-disabled.yaml server-name.yaml synapse-additional-secrets-externally.yaml synapse-minimal.yaml synapse-postgres-secrets-externally.yaml synapse-postgres.yaml synapse-secrets-externally.yaml
+# DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
+
+# postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
+elementAdmin:
+  enabled: false
+elementWeb:
+  enabled: false
+hookshot:
+  additional:
+    example-value:
+      configSecret: "{{ $.Release.Name }}-hookshot-external"
+      configSecretKey: config
+  appserviceRegistration:
+    secret: "{{ $.Release.Name }}-hookshot-external-registration"
+    secretKey: registration.yaml
+  enabled: true
+  ingress:
+    host: hookshot.ess.localhost
+  passkey:
+    secret: "{{ $.Release.Name }}-hookshot-external-passkey"
+    secretKey: passfile
+  redis:
+    host: "external-redis.example.com"
+    password:
+      secret: "{{ $.Release.Name }}-redis-credentials"
+      secretKey: "password"
+    port: 6379
+initSecrets:
+  enabled: false
+matrixAuthenticationService:
+  enabled: false
+matrixRTC:
+  enabled: false
+serverName: ess.localhost
+synapse:
+  additional:
+    00-userconfig.yaml:
+      configSecret: "{{ $.Release.Name }}-synapse-secrets"
+      configSecretKey: "00-userconfig.yaml"
+  appservices:
+    - secret: "{{ $.Release.Name }}-synapse-external"
+      secretKey: bridge_registration.yaml
+  ingress:
+    host: synapse.ess.localhost
+  macaroon:
+    secret: "{{ $.Release.Name }}-synapse-external"
+    secretKey: macaroon
+  postgres:
+    database: synapse
+    host: ess-postgres
+    password:
+      secret: "{{ $.Release.Name }}-synapse-external"
+      secretKey: postgresPassword
+    user: synapse_user
+  registrationSharedSecret:
+    secret: "{{ $.Release.Name }}-synapse-external"
+    secretKey: registrationSharedSecret
+  signingKey:
+    secret: "{{ $.Release.Name }}-synapse-external"
+    secretKey: signingKey
+wellKnownDelegation:
+  enabled: false

--- a/charts/matrix-stack/ci/synapse-hookshot-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/synapse-hookshot-secrets-in-helm-values.yaml
@@ -1,0 +1,77 @@
+# Copyright 2024-2025 New Vector Ltd
+# Copyright 2025-2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# source_fragments: hookshot-additional-in-helm.yaml hookshot-ingress.yaml hookshot-minimal.yaml hookshot-redis-secrets-in-helm.yaml hookshot-redis.yaml hookshot-secrets-in-helm.yaml init-secrets-disabled.yaml server-name.yaml synapse-additional-in-helm.yaml synapse-minimal.yaml synapse-postgres-secrets-in-helm.yaml synapse-postgres.yaml synapse-secrets-in-helm.yaml
+# DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
+
+# postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
+elementAdmin:
+  enabled: false
+elementWeb:
+  enabled: false
+hookshot:
+  additional:
+    example-value:
+      config: |
+        example: value
+  appserviceRegistration:
+    value: |
+      rate_limited: false
+      namespaces:
+        users:
+          - regex: "@_github_.*:{{ $.Release.Name }}"
+            exclusive: true
+      id: hookshot
+      hs_token: "CHANGEME-cie9nehee2ohSahloh3Ahquii3ningai"
+      as_token: "CHANGEME-ushi5ieMaebooJahquaechucha7Owua2"
+      url: "http://hookshot:9993"
+      sender_localpart: "hookshot"
+  enabled: true
+  ingress:
+    host: hookshot.ess.localhost
+  passkey:
+    value: |
+      CHANGEME
+      -----BEGIN PRIVATE KEY-----
+      MIIJQQIBADANBgkqhkiG9w0BAQEFAASCCSswggknAgEAAoICAQDLtjXE9gRU9GVE
+      2Kt8VQORnOOlNlPvTwosXeSvJKl0llRW3ajDqpfbHfG2BOTvnHEqfO5KQGXCwBmx
+      3a0sbQ0x4upx47vOpX+zpOaF3gor
+      -----END PRIVATE KEY-----
+  redis:
+    host: "external-redis.example.com"
+    password:
+      value: "test-redis-password"
+    port: 6379
+initSecrets:
+  enabled: false
+matrixAuthenticationService:
+  enabled: false
+matrixRTC:
+  enabled: false
+serverName: ess.localhost
+synapse:
+  additional:
+    00-userconfig.yaml:
+      config: |
+        push:
+          jitter_delay: 10
+  ingress:
+    host: synapse.ess.localhost
+  macaroon:
+    value: CHANGEME-eek3Eigoh8ux8laeTingeej1
+  postgres:
+    database: synapse
+    host: ess-postgres
+    password:
+      value: CHANGEME-ooWo6jeidahhei3Hae0eer9U
+    user: synapse_user
+  registrationSharedSecret:
+    value: CHANGEME-ooWo6jeidahhei3Hae0eer9U
+  signingKey:
+    value: ed25519 0 bNQOzBUDszff7Ax81z6w0uZ1IPWoxYaazT7emaZEfpw
+wellKnownDelegation:
+  enabled: false

--- a/charts/matrix-stack/templates/hookshot/_helpers.tpl
+++ b/charts/matrix-stack/templates/hookshot/_helpers.tpl
@@ -55,8 +55,13 @@ app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .
 {{- define "element-io.hookshot.secret-name" -}}
 {{- $root := .root -}}
 {{- with required "element-io.hookshot.secret-name requires context" .context -}}
+{{- $isHook := .isHook }}
+{{- if $isHook -}}
+{{ $root.Release.Name }}-hookshot-pre
+{{- else -}}
 {{ $root.Release.Name }}-hookshot
-{{- end -}}
+{{- end }}
+{{- end }}
 {{- end }}
 
 

--- a/charts/matrix-stack/templates/hookshot/hookshot_secret_hook.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_secret_hook.yaml
@@ -9,10 +9,14 @@ SPDX-License-Identifier: AGPL-3.0-only
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "element-io.hookshot.secret-name" (dict "root" $ "context"  (dict "isHook" false)) }}
+  name: {{ include "element-io.hookshot.secret-name" (dict "root" $ "context"  (dict "isHook" true)) }}
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "element-io.hookshot.labels" (dict "root" $ "context" .) | nindent 4 }}
+    "k8s.element.io/hook-for": "synapse-check-config"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
 type: Opaque
 data:
 {{- include "element-io.hookshot.secret-data" (dict "root" $ "context" .) | nindent 2 }}

--- a/charts/matrix-stack/templates/synapse/_synapse_details.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_details.tpl
@@ -182,6 +182,18 @@ responsibleForMedia
 {{- end }}
 {{- end }}
 {{- end }}
+{{- with $root.Values.hookshot -}}
+  {{- if .enabled }}
+    {{- with .appserviceRegistration }}
+      {{- with .value }}
+        {{- $configSecrets = append $configSecrets (include "element-io.hookshot.secret-name" (dict "root" $root "context" (dict "isHook" $isHook))) -}}
+      {{- end }}
+      {{- with .secret }}
+        {{- $configSecrets = append $configSecrets (tpl . $root) -}}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 {{ $configSecrets | uniq | toJson }}
 {{- end }}
 {{- end }}

--- a/newsfragments/1329.fixed.md
+++ b/newsfragments/1329.fixed.md
@@ -1,0 +1,1 @@
+Fix an issue where a custom appservice registration file configured for Hookshot would not be mounted properly into Synapse pods.

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -738,6 +738,8 @@ _extra_secret_values_files_to_test = [
     "matrix-authentication-service-synapse-syn2mas-dry-run-secrets-externally-values.yaml",
     "matrix-authentication-service-synapse-syn2mas-migrate-secrets-in-helm-values.yaml",
     "matrix-authentication-service-synapse-syn2mas-migrate-secrets-externally-values.yaml",
+    "synapse-hookshot-secrets-in-helm-values.yaml",
+    "synapse-hookshot-secrets-externally-values.yaml",
 ]
 
 _extra_services_values_files_to_test = [


### PR DESCRIPTION
It's currently failing with 

```
              ~~~~^^^^^^^^^^^^^
     FileNotFoundError: [Errno 2] No such file or directory: '/secrets/imported-hookshot/hookshot.appserviceRegistration'
 
```