### PR TITLE
MatrixRTC Authoriser: match the resources given to Element Web and Element Admin by default

### DIFF
--- a/charts/matrix-stack/source/matrix-rtc.yaml.j2
+++ b/charts/matrix-stack/source/matrix-rtc.yaml.j2
@@ -35,7 +35,7 @@ replicas: 1
 {{- sub_schema_values.extraInitContainers("Matrix RTC") }}
 {{- sub_schema_values.nodeSelector() }}
 {{- sub_schema_values.podSecurityContext(user_id='10033', group_id='10033') }}
-{{- sub_schema_values.resources(requests_memory='20Mi', requests_cpu='50m', limits_memory='20Mi') }}
+{{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='200Mi') }}
 {{- sub_schema_values.serviceMonitors() }}
 {{- sub_schema_values.serviceAccount() }}
 {{- sub_schema_values.tolerations() }}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -651,12 +651,12 @@ matrixRTC:
   resources:
     ## Requests describes the minimum amount of compute resources required. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     requests:
-      memory: 20Mi
+      memory: 50Mi
       cpu: 50m
 
     ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     limits:
-      memory: 20Mi
+      memory: 200Mi
   ## Whether to deploy ServiceMonitors into the cluster for this component
   ## Requires the ServiceMonitor CRDs to be in the cluster
   serviceMonitors:

--- a/newsfragments/1334.changed.md
+++ b/newsfragments/1334.changed.md
@@ -1,0 +1,1 @@
+Increased default MatrixRTC authoriser resources for increased stability.


### PR DESCRIPTION
As [discussed in the #ess-community room](https://matrix.to/#/!Rgcca1Mbxv5WJUmoQdvjSZwkkaAIbIbc89AwD_n7q8E/$NK9M8BZ7ohml0_1vd7ogi_I1fM56sWG8fwnaz65zE6M?via=element.io&via=matrix.org&via=vlot.cloud)

20/20 is really tight. Element Admin and Element Web have 50/200