### PR TITLE
MAS: Fix an issue with existing db

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1350.bugfix.md
+++ b/packages/ess-migration-tool/newsfragments/1350.bugfix.md
@@ -1,0 +1,1 @@
+Fix an issue where Matrix Authentication Service might be using the wrong password when using an existing database.

--- a/packages/ess-migration-tool/src/ess_migration_tool/mas.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/mas.py
@@ -354,7 +354,7 @@ class MASSecretDiscovery(SecretDiscoveryStrategy):
         if self.global_options.use_existing_database:
             schema["matrixAuthenticationService.postgres.password"] = DiscoverableSecret(
                 description="MAS database password",
-                init_if_missing_from_source_cfg=True,  # Must be provided
+                init_if_missing_from_source_cfg=False,  # Must be provided if using existing db
                 discovery=SecretConfig(
                     config_inline="database.uri",
                     config_path=None,


### PR DESCRIPTION
When using the external database, we do not allow the init the password if missing from the values.