### PR TITLE
fix an issue where yaml anchors could be generated in the values file

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1352.bugfix.md
+++ b/packages/ess-migration-tool/newsfragments/1352.bugfix.md
@@ -1,0 +1,1 @@
+Fix an issue where Matrix Authentication Service might be using the wrong password when using an existing database.

--- a/packages/ess-migration-tool/src/ess_migration_tool/utils.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/utils.py
@@ -46,7 +46,8 @@ def yaml_dump_with_pipe_for_multiline(data: Any) -> str:
 
     # Create a custom YAML dumper
     class CustomYAMLDumper(yaml.SafeDumper):
-        pass
+        def ignore_aliases(self, data: Any) -> bool:
+            return True
 
     CustomYAMLDumper.add_representer(str, multiline_string_representer)  # type: ignore[arg-type]
 


### PR DESCRIPTION
If the same value was shared between multiple strategies, a yaml anchors could be generated improperly.