### PR TITLE
bump version before calculating next version

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -162,6 +162,9 @@ jobs:
     - name: Bump version for next PR
       id: versions
       run: |
+        if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+          uv --directory packages/ess-migration-tool version "${GITHUB_REF_NAME#ess-migration-tool-v}"
+        fi
         this_version=$(uv --directory packages/ess-migration-tool version --short)
         uv --directory packages/ess-migration-tool version --bump patch --bump dev=1
         next_version=$(uv --directory packages/ess-migration-tool version --short)

--- a/packages/ess-migration-tool/newsfragments/1355.misc.md
+++ b/packages/ess-migration-tool/newsfragments/1355.misc.md
@@ -1,0 +1,1 @@
+CI: Fix version bumps after release.


### PR DESCRIPTION
Noticed that the bump was incorrect in release in https://github.com/element-hq/ess-helm/actions/runs/26510438849/job/78073795023

>   [b2e01d76-a5c5-4cbb-8d3c-9df0136cfe3d f1705db] Bump ess-migration-tool version to 0.1.4.dev1

Instead of `0.2.1dev1`