### PR TITLE
Synapse: add index label to metrics based on the Pod the suffix

### DIFF
--- a/charts/matrix-stack/templates/synapse/synapse_service_monitor.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_service_monitor.yaml
@@ -1,6 +1,6 @@
 {{- /*
 Copyright 2024 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -24,6 +24,10 @@ spec:
     - targetLabel: instance
       action: replace
       replacement: {{ tpl .ingress.host $ }}
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      targetLabel: index
+      regex: '.*-([0-9]+)'
+      replacement: '$1'
   selector:
     matchLabels:
       app.kubernetes.io/part-of: matrix-stack

--- a/newsfragments/1364.changed.md
+++ b/newsfragments/1364.changed.md
@@ -1,0 +1,1 @@
+Synapse: add `index` label to metrics.


### PR DESCRIPTION
For better compatibility with the upstream Grafana dashboard