### PR TITLE
Livekit: Upgrade to v1.12.0

### DIFF
--- a/charts/matrix-stack/source/matrix-rtc.yaml.j2
+++ b/charts/matrix-stack/source/matrix-rtc.yaml.j2
@@ -78,7 +78,7 @@ sfu:
     {{- sub_schema_values.exposedServicePort('turn', 30004, 'NodePort', defaultEnabled=False, nodePortTemplate="{{ .context.port }}") | indent(4) }}
 
 
-{{- sub_schema_values.image(registry='docker.io', repository='livekit/livekit-server', tag='v1.10.1') | indent(2) }}
+{{- sub_schema_values.image(registry='docker.io', repository='livekit/livekit-server', tag='v1.12.0') | indent(2) }}
 {{- sub_schema_values.extraEnv() | indent(2) }}
 {{- sub_schema_values.extraVolumes("Matrix RTC SFU") | indent(2) }}
 {{- sub_schema_values.extraVolumeMounts("Matrix RTC SFU") | indent(2) }}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -911,7 +911,7 @@ matrixRTC:
 
       ## The tag of the container image to use.
       ## One of tag or digest must be provided.
-      tag: "v1.10.1"
+      tag: "v1.12.0"
 
       ## Container digest to use. Used to pull the image instead of the image tag if set
       ## The tag will still be set as the app.kubernetes.io/version label

--- a/newsfragments/1366.changed.md
+++ b/newsfragments/1366.changed.md
@@ -1,0 +1,9 @@
+Upgrade MatrixRTC SFU to v1.12.0.
+
+Highlights:
+- Fix UDP Turn URLs when ipv6 is enabled
+- Fix local ip filtering from ICE candidates
+
+Full Changelogs:
+- [v1.11.0](https://github.com/livekit/livekit/releases/tag/v1.11.0)
+- [v1.12.0](https://github.com/livekit/livekit/releases/tag/v1.12.0)


### PR DESCRIPTION
We hope that this will fix some issues we found recently against v1.10.x regarding wrong Node IP being advertised, and issues with ipv6 clusters.

Especially thanks to the following PRs :
- https://github.com/livekit/livekit/pull/4476
- https://github.com/livekit/livekit/pull/4440