### PR TITLE
Migration fixtures : Use frozendict

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1370.misc.md
+++ b/packages/ess-migration-tool/newsfragments/1370.misc.md
@@ -1,0 +1,1 @@
+Internal: Use frozendict as fixtures returned values.

--- a/packages/ess-migration-tool/tests/conftest.py
+++ b/packages/ess-migration-tool/tests/conftest.py
@@ -17,8 +17,13 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
 from ess_migration_tool.migration import ConfigValueTransformer
 from ess_migration_tool.models import GlobalOptions, ValueSourceTracking
+from frozendict import frozendict
+from yaml import SafeDumper, representer
 
 from .helm_validation import validate_helm_template
+
+# Add representer for frozendict to allow YAML serialization
+SafeDumper.add_representer(frozendict, representer.SafeRepresenter.represent_dict)
 
 
 @pytest.fixture
@@ -37,120 +42,116 @@ def config_value_transformer():
 
 
 @pytest.fixture
+def write_config(tmp_path):
+    """Generic fixture to write config files.
+
+    Supports YAML and JSON formats.
+    """
+
+    def _write(config_data, filename, format="yaml"):
+        import json
+
+        config_file = tmp_path / filename
+        with open(config_file, "w") as f:
+            if format == "yaml":
+                yaml.dump(config_data, f, Dumper=SafeDumper)
+            elif format == "json":
+                json.dump(config_data, f, indent=2)
+            else:
+                raise ValueError(f"Unsupported format: {format}")
+        return config_file
+
+    return _write
+
+
+@pytest.fixture
 def basic_synapse_config():
     """Basic Synapse configuration for testing."""
-    return {
-        "server_name": "test.example.com",
-        "public_baseurl": "https://matrix.example.com",
-        "listeners": [
-            {
-                "port": 8008,
-                "tls": False,
-                "type": "http",
-                "x_forwarded": False,
-                "resources": [
-                    {
-                        "names": ["client", "federation"],
-                        "compression": False,
-                    }
-                ],
-            }
-        ],
-        "max_upload_size": "60M",
-        "database": {
-            "args": {
-                "database": "synapse",
-                "user": "synapse",
-                "host": "postgres",
-                "port": 5432,
-                "password": "test",
-                "keepalives": 1,
-                "keepalives_idle": 10,
-                "keepalives_interval": 10,
-                "keepalives_count": 3,
-                "cp_min": 5,
-                "cp_max": 10,
-            }
-        },
-        "report_stats": False,
-        "require_auth_for_profile_requests": True,
-        "federation_client_minimum_tls_version": "1.2",
-        "experimental_features": {"msc4028_push_encrypted_events": True},
-        "url_preview_enabled": True,
-        "url_preview_ip_range_whitelist": [],
-        "url_preview_ip_range_blacklist": ["192.168.0.0/16", "10.0.0.0/8"],
-        "rc_message": {"per_second": 0.5, "burst_count": 30},
-        "rc_delayed_event_mgmt": {"per_second": 1, "burst_count": 20},
-        "macaroon_secret_key": "test_macaroon_secret",
-        "registration_shared_secret": "test_registration_secret",
-    }
+    return frozendict(
+        {
+            "server_name": "test.example.com",
+            "public_baseurl": "https://matrix.example.com",
+            "listeners": [
+                {
+                    "port": 8008,
+                    "tls": False,
+                    "type": "http",
+                    "x_forwarded": False,
+                    "resources": [
+                        {
+                            "names": ["client", "federation"],
+                            "compression": False,
+                        }
+                    ],
+                }
+            ],
+            "max_upload_size": "60M",
+            "database": {
+                "args": {
+                    "database": "synapse",
+                    "user": "synapse",
+                    "host": "postgres",
+                    "port": 5432,
+                    "password": "test",
+                    "keepalives": 1,
+                    "keepalives_idle": 10,
+                    "keepalives_interval": 10,
+                    "keepalives_count": 3,
+                    "cp_min": 5,
+                    "cp_max": 10,
+                }
+            },
+            "report_stats": False,
+            "require_auth_for_profile_requests": True,
+            "federation_client_minimum_tls_version": "1.2",
+            "experimental_features": {"msc4028_push_encrypted_events": True},
+            "url_preview_enabled": True,
+            "url_preview_ip_range_whitelist": [],
+            "url_preview_ip_range_blacklist": ["192.168.0.0/16", "10.0.0.0/8"],
+            "rc_message": {"per_second": 0.5, "burst_count": 30},
+            "rc_delayed_event_mgmt": {"per_second": 1, "burst_count": 20},
+            "macaroon_secret_key": "test_macaroon_secret",
+            "registration_shared_secret": "test_registration_secret",
+        }
+    )
 
 
 @pytest.fixture
 def basic_element_web_config():
     """Basic Element Web configuration for testing."""
-    return {
-        "default_server_config": {
-            "m.homeserver": {
-                "base_url": "https://matrix.example.com/",
-                "server_name": "test.example.com",
-            }
-        },
-        "setting_defaults": {"customTheme": True},
-    }
-
-
-@pytest.fixture
-def write_element_web_config(tmp_path):
-    """Helper fixture to write an Element Web config file."""
-
-    def _write_config(config_data):
-        element_web_config_file = tmp_path / "element-web.json"
-        with open(element_web_config_file, "w") as f:
-            import json
-
-            json.dump(config_data, f, indent=2)
-        return element_web_config_file
-
-    return _write_config
+    return frozendict(
+        {
+            "default_server_config": {
+                "m.homeserver": {
+                    "base_url": "https://matrix.example.com/",
+                    "server_name": "test.example.com",
+                }
+            },
+            "setting_defaults": {"customTheme": True},
+        }
+    )
 
 
 @pytest.fixture
 def synapse_config_with_custom_listeners(basic_synapse_config):
     """Synapse configuration with custom listeners for testing."""
-    config = basic_synapse_config.copy()
-    # Replace the chart-managed listener with a custom one
-    config["listeners"] = [
-        {
-            "port": 9010,
-            "tls": True,
-            "type": "http",
-            "resources": [{"names": ["custom_api"], "compress": False}],
-        }
-    ]
-    return config
+    return frozendict(basic_synapse_config) | {
+        "listeners": [
+            {
+                "port": 9010,
+                "tls": True,
+                "type": "http",
+                "resources": [{"names": ["custom_api"], "compress": False}],
+            }
+        ]
+    }
 
 
 @pytest.fixture
 def synapse_config_without_public_baseurl(basic_synapse_config):
     """Synapse configuration without public_baseurl for testing prompt functionality."""
-    config = basic_synapse_config.copy()
     # Remove public_baseurl to test prompt functionality
-    del config["public_baseurl"]
-    return config
-
-
-@pytest.fixture
-def write_synapse_config(tmp_path):
-    """Helper fixture to write a Synapse config file."""
-
-    def _write_config(config_data):
-        synapse_config_file = tmp_path / "synapse.yaml"
-        with open(synapse_config_file, "w") as f:
-            yaml.dump(config_data, f)
-        return synapse_config_file
-
-    return _write_config
+    return frozendict({k: v for k, v in basic_synapse_config.items() if k != "public_baseurl"})
 
 
 @pytest.fixture
@@ -161,38 +162,31 @@ def synapse_config_with_signing_key(tmp_path, basic_synapse_config):
     signing_key_file.write_text("test_signing_key_content")
 
     # Add signing key to config
-    config = basic_synapse_config.copy()
-    config["signing_key_path"] = str(signing_key_file)
-
-    return config
+    return frozendict(basic_synapse_config) | {"signing_key_path": str(signing_key_file)}
 
 
 @pytest.fixture
 def synapse_config_with_web_client_location(basic_synapse_config):
     """Synapse configuration with web_client_location for Element Web."""
-    config = basic_synapse_config.copy()
-    config["web_client_location"] = "https://element.example.com/"
-    return config
+    return frozendict(basic_synapse_config) | {"web_client_location": "https://element.example.com/"}
 
 
 @pytest.fixture
 def synapse_config_with_instance_map(tmp_path, basic_synapse_config):
-    """Synapse configuration with a signing key file."""
-    # Add signing key to config
-    config = basic_synapse_config.copy()
-    config["instance_map"] = {
-        "main": {"host": "main-instance.local", "port": 9093},
-        "funny-name": {"host": "funny-instance.local", "port": 9093},
-        "synchrotron": {"host": "synchro.local", "port": 9093},
-        "synchrotron2": {"host": "synchro.local", "port": 9094},
+    """Synapse configuration with instance map."""
+    return frozendict(basic_synapse_config) | {
+        "instance_map": {
+            "main": {"host": "main-instance.local", "port": 9093},
+            "funny-name": {"host": "funny-instance.local", "port": 9093},
+            "synchrotron": {"host": "synchro.local", "port": 9093},
+            "synchrotron2": {"host": "synchro.local", "port": 9094},
+        }
     }
-
-    return config
 
 
 @pytest.fixture
 def synapse_config_with_email_templates(tmp_path, basic_synapse_config):
-    """Synapse configuration with a signing key file."""
+    """Synapse configuration with email templates directory."""
     # Create email templates directory
     templates_dir = tmp_path / "email_templates"
     templates_dir.mkdir()
@@ -201,69 +195,67 @@ def synapse_config_with_email_templates(tmp_path, basic_synapse_config):
     (templates_dir / "registration.html").write_text("test_registration_content")
 
     # Add email templates to config
-    config = basic_synapse_config.copy()
-    config.setdefault("templates", {})["custom_template_directory"] = str(templates_dir)
-
-    return config
+    return frozendict(basic_synapse_config) | {"templates": {"custom_template_directory": str(templates_dir)}}
 
 
 @pytest.fixture
 def synapse_config_with_ca_federation_list(tmp_path, basic_synapse_config):
-    """Synapse configuration with a signing key file."""
-    # Create email templates directory
-    templates_dir = tmp_path / "ca"
-    templates_dir.mkdir()
-    # Add password reset, registration templates
-    (templates_dir / "ca1.pem").write_text("CA1")
-    (templates_dir / "ca-second.pem").write_text("CA2")
-    (templates_dir / "another-ca.pem").write_text("CA3")
+    """Synapse configuration with CA federation list."""
+    # Create CA directory
+    ca_dir = tmp_path / "ca"
+    ca_dir.mkdir()
+    # Add CA files
+    (ca_dir / "ca1.pem").write_text("CA1")
+    (ca_dir / "ca-second.pem").write_text("CA2")
+    (ca_dir / "another-ca.pem").write_text("CA3")
 
-    # Add email templates to config
-    config = basic_synapse_config.copy()
-    config["federation_custom_ca_list"] = [
-        str(templates_dir / "ca1.pem"),
-        str(templates_dir / "ca-second.pem"),
-        str(templates_dir / "another-ca.pem"),
-    ]
-
-    return config
+    # Add CA list to config
+    return frozendict(basic_synapse_config) | {
+        "federation_custom_ca_list": [
+            str(ca_dir / "ca1.pem"),
+            str(ca_dir / "ca-second.pem"),
+            str(ca_dir / "another-ca.pem"),
+        ]
+    }
 
 
 @pytest.fixture
 def synapse_config_with_mas(tmp_path, basic_synapse_config):
-    """Synapse configuration with a signing key file."""
-    config = basic_synapse_config.copy()
-    config["matrix_authentication_service"] = {
-        "enabled": True,
-        "endpoint": "http://mas.example.com:8080",
-        "secret": "synapse_shared_secret_abcdef",
+    """Synapse configuration with MAS."""
+    return frozendict(basic_synapse_config) | {
+        "matrix_authentication_service": {
+            "enabled": True,
+            "endpoint": "http://mas.example.com:8080",
+            "secret": "synapse_shared_secret_abcdef",
+        }
     }
-    return config
 
 
 @pytest.fixture
 def basic_mas_config():
     """Basic MAS configuration for testing."""
-    return {
-        "http": {"public_base": "https://auth.example.com", "bind": {"address": "0.0.0.0", "port": 8080}},
-        "database": {"uri": "postgresql://mas:mas_password@postgres:5432/mas?sslmode=prefer"},
-        "secrets": {"encryption": "my_encryption_key"},
-        "matrix": {
-            "homeserver": "test.example.com",
-            "secret": "synapse_shared_secret_abcdef",
-            "endpoint": "http://synapse:8008",
-        },
-        "policy": {
-            "data": {
-                "admin_clients": ["test_client"],
-                "admin_users": ["@admin:test.example.com"],
-                "client_registration": {
-                    "allow_host_mismatch": False,
-                    "allow_insecure_uris": False,
-                },
-            }
-        },
-    }
+    return frozendict(
+        {
+            "http": {"public_base": "https://auth.example.com", "bind": {"address": "0.0.0.0", "port": 8080}},
+            "database": {"uri": "postgresql://mas:mas_password@postgres:5432/mas?sslmode=prefer"},
+            "secrets": {"encryption": "my_encryption_key"},
+            "matrix": {
+                "homeserver": "test.example.com",
+                "secret": "synapse_shared_secret_abcdef",
+                "endpoint": "http://synapse:8008",
+            },
+            "policy": {
+                "data": {
+                    "admin_clients": ["test_client"],
+                    "admin_users": ["@admin:test.example.com"],
+                    "client_registration": {
+                        "allow_host_mismatch": False,
+                        "allow_insecure_uris": False,
+                    },
+                }
+            },
+        }
+    )
 
 
 @pytest.fixture
@@ -293,23 +285,9 @@ def basic_mas_config_with_keys(tmp_path, basic_mas_config):
     (keys_dir / "ecdsa_key.pem").write_bytes(ecdsa_pem)
 
     # Update config with keys directory
-    mas_config = basic_mas_config.copy()
-    mas_config["secrets"]["keys_dir"] = str(keys_dir)
-
-    return mas_config
-
-
-@pytest.fixture
-def write_mas_config(tmp_path):
-    """Helper fixture to write a MAS config file."""
-
-    def _write_config(config_data):
-        mas_config_file = tmp_path / "mas.yaml"
-        with open(mas_config_file, "w") as f:
-            yaml.dump(config_data, f)
-        return mas_config_file
-
-    return _write_config
+    return frozendict(basic_mas_config) | {
+        "secrets": {"keys_dir": str(keys_dir), "encryption": basic_mas_config["secrets"]["encryption"]}
+    }
 
 
 @pytest.fixture
@@ -356,23 +334,25 @@ def basic_mas_config_with_individual_keys(tmp_path):
     ecdsa_key_file.write_bytes(ecdsa_pem)
 
     # Create MAS config with individual keys
-    config = {
-        "http": {"public_base": "https://auth.example.com", "bind": {"address": "0.0.0.0", "port": 8080}},
-        "database": {"uri": "postgresql://mas:mas_password@postgres:5432/mas?sslmode=prefer"},
-        "secrets": {
-            "encryption": "my_encryption_key",
-            "keys": [
-                {"key_file": str(rsa_key_file)},  # Recognized: RSA
-                {"key_file": str(dsa_key_file)},  # Unrecognized: DSA - should NOT be imported
-                {"key_file": str(ecdsa_key_file)},  # Recognized: ECDSA with secp256r1
-            ],
-        },
-        "matrix": {
-            "homeserver": "test.example.com",
-            "secret": "synapse_shared_secret_abcdef",
-            "endpoint": "http://synapse:8008",
-        },
-    }
+    config = frozendict(
+        {
+            "http": {"public_base": "https://auth.example.com", "bind": {"address": "0.0.0.0", "port": 8080}},
+            "database": {"uri": "postgresql://mas:mas_password@postgres:5432/mas?sslmode=prefer"},
+            "secrets": {
+                "encryption": "my_encryption_key",
+                "keys": [
+                    {"key_file": str(rsa_key_file)},  # Recognized: RSA
+                    {"key_file": str(dsa_key_file)},  # Unrecognized: DSA - should NOT be imported
+                    {"key_file": str(ecdsa_key_file)},  # Recognized: ECDSA with secp256r1
+                ],
+            },
+            "matrix": {
+                "homeserver": "test.example.com",
+                "secret": "synapse_shared_secret_abcdef",
+                "endpoint": "http://synapse:8008",
+            },
+        }
+    )
     return config
 
 
@@ -471,52 +451,53 @@ def ecdsa_secp384r1_key_der():
 @pytest.fixture
 def basic_hookshot_config():
     """Basic Hookshot configuration for testing."""
-    return {
-        "bridge": {
-            "domain": "test.example.com",
-            "url": "http://synapse:8008",
-            "mediaUrl": "https://matrix.example.com",
-            "port": 9993,
-            "bindAddress": "0.0.0.0",
-        },
-        "logging": {
-            "level": "info",
-            "colorize": True,
-            "json": False,
-            "timestampFormat": "HH:mm:ss:SSS",
-        },
-        "user": {
-            "localpart": "hookshot",
-        },
-        "enableEncryption": False,
-        "listeners": [
-            {
-                "port": 9000,
+    return frozendict(
+        {
+            "bridge": {
+                "domain": "test.example.com",
+                "url": "http://synapse:8008",
+                "mediaUrl": "https://matrix.example.com",
+                "port": 9993,
                 "bindAddress": "0.0.0.0",
-                "resources": ["webhooks"],
             },
-            {
-                "port": 9001,
-                "bindAddress": "0.0.0.0",
-                "resources": ["widgets"],
+            "logging": {
+                "level": "info",
+                "colorize": True,
+                "json": False,
+                "timestampFormat": "HH:mm:ss:SSS",
             },
-        ],
-    }
+            "user": {
+                "localpart": "hookshot",
+            },
+            "enableEncryption": False,
+            "listeners": [
+                {
+                    "port": 9000,
+                    "bindAddress": "0.0.0.0",
+                    "resources": ["webhooks"],
+                },
+                {
+                    "port": 9001,
+                    "bindAddress": "0.0.0.0",
+                    "resources": ["widgets"],
+                },
+            ],
+        }
+    )
 
 
 @pytest.fixture
 def hookshot_config_with_custom_listeners(basic_hookshot_config):
     """Hookshot configuration with custom listeners for testing."""
-    config = basic_hookshot_config.copy()
-    # Replace the ESS-managed listeners with a custom one
-    config["listeners"] = [
-        {
-            "port": 9010,
-            "bindAddress": "0.0.0.0",
-            "resources": ["custom_service"],
-        }
-    ]
-    return config
+    return frozendict(basic_hookshot_config) | {
+        "listeners": [
+            {
+                "port": 9010,
+                "bindAddress": "0.0.0.0",
+                "resources": ["custom_service"],
+            }
+        ]
+    }
 
 
 @pytest.fixture
@@ -532,23 +513,7 @@ MIIJQQIBADANBgkqhkiG9w0BAQEFAASCCSswggknAgEAAoICAQDLtjXE9gRU9GVE
     passkey_file.write_text(passkey_content)
 
     # Add passFile to config
-    config = basic_hookshot_config.copy()
-    config["passFile"] = str(passkey_file)
-
-    return config
-
-
-@pytest.fixture
-def write_hookshot_config(tmp_path):
-    """Helper fixture to write a Hookshot config file."""
-
-    def _write_config(config_data):
-        hookshot_config_file = tmp_path / "hookshot-config.yaml"
-        with open(hookshot_config_file, "w") as f:
-            yaml.dump(config_data, f)
-        return hookshot_config_file
-
-    return _write_config
+    return frozendict(basic_hookshot_config) | {"passFile": str(passkey_file)}
 
 
 @pytest.fixture
@@ -569,30 +534,34 @@ def helm_validator():
 @pytest.fixture
 def basic_well_known_client_config():
     """Basic well-known client configuration for testing."""
-    return {
-        "m.homeserver": {
-            "base_url": "https://matrix.example.com",
-            "server_name": "test.example.com",
-        },
-        # Add an untracked value to ensure the client entry is created
-        "m.custom": {"setting": "value"},
-    }
+    return frozendict(
+        {
+            "m.homeserver": {
+                "base_url": "https://matrix.example.com",
+                "server_name": "test.example.com",
+            },
+            # Add an untracked value to ensure the client entry is created
+            "m.custom": {"setting": "value"},
+        }
+    )
 
 
 @pytest.fixture
 def basic_well_known_server_config():
     """Basic well-known server configuration for testing."""
-    return {
-        "m.server": "test.example.com:443",
-        # Add an untracked value to ensure the server entry is created
-        "m.custom_server": "value",
-    }
+    return frozendict(
+        {
+            "m.server": "test.example.com:443",
+            # Add an untracked value to ensure the server entry is created
+            "m.custom_server": "value",
+        }
+    )
 
 
 @pytest.fixture
 def basic_well_known_support_config():
     """Basic well-known support configuration for testing."""
-    return {"im.vector.matrix": {"room": "#support:element.io"}}
+    return frozendict({"im.vector.matrix": {"room": "#support:element.io"}})
 
 
 @pytest.fixture

--- a/packages/ess-migration-tool/tests/conftest.py
+++ b/packages/ess-migration-tool/tests/conftest.py
@@ -8,6 +8,7 @@ Pytest fixtures for migration tests.
 Centralizes common test configurations to reduce duplication.
 """
 
+import json
 import logging
 
 import pytest
@@ -49,8 +50,6 @@ def write_config(tmp_path):
     """
 
     def _write(config_data, filename, format="yaml"):
-        import json
-
         config_file = tmp_path / filename
         with open(config_file, "w") as f:
             if format == "yaml":
@@ -284,14 +283,14 @@ def basic_mas_config_with_keys(tmp_path, basic_mas_config):
     )
     (keys_dir / "ecdsa_key.pem").write_bytes(ecdsa_pem)
 
+    config = dict(basic_mas_config)
+    config["secrets"]["keys_dir"] = str(keys_dir)
     # Update config with keys directory
-    return frozendict(basic_mas_config) | {
-        "secrets": {"keys_dir": str(keys_dir), "encryption": basic_mas_config["secrets"]["encryption"]}
-    }
+    return frozendict(config)
 
 
 @pytest.fixture
-def basic_mas_config_with_individual_keys(tmp_path):
+def basic_mas_config_with_individual_keys(basic_mas_config, tmp_path):
     """MAS configuration with individual keys in the secrets.keys array for testing.
 
     This fixture creates three key files:
@@ -333,27 +332,14 @@ def basic_mas_config_with_individual_keys(tmp_path):
     ecdsa_key_file = tmpdir_path / "ecdsa_key.pem"
     ecdsa_key_file.write_bytes(ecdsa_pem)
 
-    # Create MAS config with individual keys
-    config = frozendict(
-        {
-            "http": {"public_base": "https://auth.example.com", "bind": {"address": "0.0.0.0", "port": 8080}},
-            "database": {"uri": "postgresql://mas:mas_password@postgres:5432/mas?sslmode=prefer"},
-            "secrets": {
-                "encryption": "my_encryption_key",
-                "keys": [
-                    {"key_file": str(rsa_key_file)},  # Recognized: RSA
-                    {"key_file": str(dsa_key_file)},  # Unrecognized: DSA - should NOT be imported
-                    {"key_file": str(ecdsa_key_file)},  # Recognized: ECDSA with secp256r1
-                ],
-            },
-            "matrix": {
-                "homeserver": "test.example.com",
-                "secret": "synapse_shared_secret_abcdef",
-                "endpoint": "http://synapse:8008",
-            },
-        }
-    )
-    return config
+    config = dict(basic_mas_config)
+    config["secrets"]["keys"] = [
+        {"key_file": str(rsa_key_file)},  # Recognized: RSA
+        {"key_file": str(dsa_key_file)},  # Unrecognized: DSA - should NOT be imported
+        {"key_file": str(ecdsa_key_file)},  # Recognized: ECDSA with secp256r1
+    ]
+    # Update config with keys directory
+    return frozendict(config)
 
 
 @pytest.fixture

--- a/packages/ess-migration-tool/tests/test_main_e2e.py
+++ b/packages/ess-migration-tool/tests/test_main_e2e.py
@@ -24,7 +24,7 @@ def test_main_e2e_synapse_only(
     synapse_config_with_email_templates,
     synapse_config_with_ca_federation_list,
     synapse_config_without_public_baseurl,
-    write_synapse_config,
+    write_config,
     helm_validator,
 ):
     """Test the complete end-to-end migration workflow with Synapse only."""
@@ -38,11 +38,13 @@ def test_main_e2e_synapse_only(
     monkeypatch.setattr("builtins.input", mock_input)
 
     # Write Synapse config without public_baseurl to test prompt functionality
-    synapse_config_file = write_synapse_config(
+    synapse_config_file = write_config(
         synapse_config_without_public_baseurl
         | synapse_config_with_signing_key
         | synapse_config_with_email_templates
-        | synapse_config_with_ca_federation_list
+        | synapse_config_with_ca_federation_list,
+        "synapse.yaml",
+        "yaml",
     )
 
     # Create output directory
@@ -221,14 +223,15 @@ def test_main_e2e_synapse_with_mas(
     synapse_config_with_signing_key,
     synapse_config_with_mas,
     basic_mas_config_with_keys,
-    write_synapse_config,
-    write_mas_config,
+    write_config,
     helm_validator,
 ):
     """Test the complete end-to-end migration workflow with Synapse and MAS."""
     # Write configuration files
-    synapse_config_file = write_synapse_config(synapse_config_with_signing_key | synapse_config_with_mas)
-    mas_config_file = write_mas_config(basic_mas_config_with_keys)
+    synapse_config_file = write_config(
+        synapse_config_with_signing_key | synapse_config_with_mas, "synapse.yaml", "yaml"
+    )
+    mas_config_file = write_config(basic_mas_config_with_keys, "mas.yaml", "yaml")
 
     # Create output directory
     output_dir = tmp_path / "output"
@@ -414,14 +417,13 @@ def test_main_e2e_mas_with_custom_listeners_and_ess_managed_database(
     tmp_path,
     synapse_config_with_signing_key,
     basic_mas_config_with_keys,
-    write_synapse_config,
-    write_mas_config,
+    write_config,
     capsys,
     helm_validator,
 ):
     """Test that custom MAS listeners are preserved in additional config."""
     # Add listeners structure to MAS config (it doesn't have one by default)
-    mas_config = basic_mas_config_with_keys.copy()
+    mas_config = dict(basic_mas_config_with_keys)
     mas_config["http"]["listeners"] = [
         {
             "name": "web",
@@ -449,8 +451,8 @@ def test_main_e2e_mas_with_custom_listeners_and_ess_managed_database(
     ]
 
     # Write configuration files
-    synapse_config_file = write_synapse_config(synapse_config_with_signing_key)
-    mas_config_file = write_mas_config(mas_config)
+    synapse_config_file = write_config(synapse_config_with_signing_key, "synapse.yaml", "yaml")
+    mas_config_file = write_config(mas_config, "mas.yaml", "yaml")
 
     # Create output directory
     output_dir = tmp_path / "output"
@@ -525,12 +527,12 @@ def test_main_e2e_synapse_existing_database(
     monkeypatch,
     tmp_path,
     synapse_config_with_signing_key,
-    write_synapse_config,
+    write_config,
     helm_validator,
 ):
     """Test the complete end-to-end migration workflow with Synapse using existing database."""
     # Write Synapse config
-    synapse_config_file = write_synapse_config(synapse_config_with_signing_key)
+    synapse_config_file = write_config(synapse_config_with_signing_key, "synapse.yaml", "yaml")
 
     # Create output directory
     output_dir = tmp_path / "output"
@@ -588,12 +590,12 @@ def test_main_e2e_synapse_ess_managed_database(
     monkeypatch,
     tmp_path,
     synapse_config_with_signing_key,
-    write_synapse_config,
+    write_config,
     helm_validator,
 ):
     """Test the complete end-to-end migration workflow with Synapse using ESS-managed PostgreSQL."""
     # Write Synapse config
-    synapse_config_file = write_synapse_config(synapse_config_with_signing_key)
+    synapse_config_file = write_config(synapse_config_with_signing_key, "synapse.yaml", "yaml")
 
     # Create output directory
     output_dir = tmp_path / "output"
@@ -663,14 +665,14 @@ def test_main_e2e_synapse_listeners_with_custom_listeners(
     tmp_path,
     synapse_config_with_custom_listeners,
     synapse_config_with_signing_key,
-    write_synapse_config,
+    write_config,
     helm_validator,
 ):
     """Test that custom listeners are preserved in additional config."""
     # Use config with custom listeners that should be preserved
-    custom_config = synapse_config_with_custom_listeners.copy()
+    custom_config = dict(synapse_config_with_custom_listeners)
     custom_config["signing_key_path"] = synapse_config_with_signing_key["signing_key_path"]
-    synapse_config_file = write_synapse_config(custom_config)
+    synapse_config_file = write_config(custom_config, "synapse.yaml", "yaml")
 
     # Create output directory
     output_dir = tmp_path / "output"
@@ -735,8 +737,7 @@ def test_main_e2e_mas_with_individual_keys(
     tmp_path,
     synapse_config_with_signing_key,
     basic_mas_config_with_individual_keys,
-    write_synapse_config,
-    write_mas_config,
+    write_config,
     capsys,
     helm_validator,
 ):
@@ -752,10 +753,10 @@ def test_main_e2e_mas_with_individual_keys(
     dsa_key_file = tmp_path / "mas_keys" / "dsa_key.pem"
 
     # Write Synapse config
-    synapse_config_file = write_synapse_config(synapse_config_with_signing_key)
+    synapse_config_file = write_config(synapse_config_with_signing_key, "synapse.yaml", "yaml")
 
     # Write MAS config with individual keys (using the fixture)
-    mas_config_file = write_mas_config(basic_mas_config_with_individual_keys)
+    mas_config_file = write_config(basic_mas_config_with_individual_keys, "mas.yaml", "yaml")
 
     # Create output directory
     output_dir = tmp_path / "output"
@@ -836,8 +837,7 @@ def test_main_e2e_synapse_with_mas_different_server_name(
     tmp_path,
     synapse_config_with_signing_key,
     basic_mas_config_with_keys,
-    write_synapse_config,
-    write_mas_config,
+    write_config,
     helm_validator,
 ):
     """Test conflict resolution when Synapse and MAS have different serverName values.
@@ -847,16 +847,16 @@ def test_main_e2e_synapse_with_mas_different_server_name(
     This should trigger a conflict prompt.
     """
     # Patch Synapse config to use different server_name
-    synapse_config = synapse_config_with_signing_key.copy()
+    synapse_config = dict(synapse_config_with_signing_key)
     synapse_config["server_name"] = "synapse.example.com"
 
     # Patch MAS config to use different homeserver
-    mas_config = basic_mas_config_with_keys.copy()
+    mas_config = dict(basic_mas_config_with_keys)
     mas_config["matrix"]["homeserver"] = "mas.example.com"
 
     # Write configuration files
-    synapse_config_file = write_synapse_config(synapse_config)
-    mas_config_file = write_mas_config(mas_config)
+    synapse_config_file = write_config(synapse_config, "synapse.yaml", "yaml")
+    mas_config_file = write_config(mas_config, "mas.yaml", "yaml")
 
     # Create output directory
     output_dir = tmp_path / "output"
@@ -921,8 +921,7 @@ def test_main_e2e_synapse_with_element_web(
     synapse_config_with_signing_key,
     synapse_config_with_web_client_location,
     basic_element_web_config,
-    write_synapse_config,
-    write_element_web_config,
+    write_config,
     helm_validator,
 ):
     """Test migration with Synapse and Element Web.
@@ -934,12 +933,12 @@ def test_main_e2e_synapse_with_element_web(
     4. The Synapse template uses elementWeb.ingress.host for web_client_location
     """
     # Merge signing key and web_client_location into Synapse config
-    synapse_config = synapse_config_with_signing_key.copy()
+    synapse_config = dict(synapse_config_with_signing_key)
     synapse_config["web_client_location"] = "https://element.example.com/"
 
     # Write configuration files
-    synapse_config_file = write_synapse_config(synapse_config)
-    element_web_config_file = write_element_web_config(basic_element_web_config)
+    synapse_config_file = write_config(synapse_config, "synapse.yaml", "yaml")
+    element_web_config_file = write_config(basic_element_web_config, "element-web.json", "json")
 
     # Create output directory
     output_dir = tmp_path / "output"
@@ -1028,7 +1027,7 @@ def test_well_known_migration(
     tmp_path,
     monkeypatch,
     synapse_config_with_signing_key,
-    write_synapse_config,
+    write_config,
     basic_well_known_client_config,
     basic_well_known_server_config,
     basic_well_known_support_config,
@@ -1036,7 +1035,7 @@ def test_well_known_migration(
 ):
     """Test end-to-end migration with well-known files."""
     # Use fixture for synapse config and write it to file
-    synapse_file = write_synapse_config(synapse_config_with_signing_key)
+    synapse_file = write_config(synapse_config_with_signing_key, "synapse.yaml", "yaml")
     write_well_known_configs(
         basic_well_known_client_config,
         basic_well_known_server_config,
@@ -1106,20 +1105,19 @@ def test_main_e2e_hookshot(
     tmp_path,
     basic_hookshot_config,
     synapse_config_with_signing_key,
-    write_hookshot_config,
-    write_synapse_config,
+    write_config,
     helm_validator,
 ):
     """Test the complete end-to-end migration workflow with Hookshot."""
     # Write Hookshot config
     # Note: We need to use a Hookshot config where bridge.url matches the synapse base URL
     # to avoid conflicts with Synapse's public_baseurl
-    hookshot_config = basic_hookshot_config.copy()
+    hookshot_config = dict(basic_hookshot_config)
     hookshot_config["bridge"]["url"] = "https://matrix.example.com"
-    hookshot_config_file = write_hookshot_config(hookshot_config)
+    hookshot_config_file = write_config(hookshot_config, "hookshot-config.yaml", "yaml")
 
     # Write Synapse config using the existing fixture
-    synapse_config_file = write_synapse_config(synapse_config_with_signing_key)
+    synapse_config_file = write_config(synapse_config_with_signing_key, "synapse.yaml", "yaml")
 
     # Create output directory
     output_dir = tmp_path / "output"
@@ -1194,8 +1192,7 @@ def test_main_e2e_synapse_mas_shared_secret_conflict(
     tmp_path,
     synapse_config_with_signing_key,
     basic_mas_config,
-    write_synapse_config,
-    write_mas_config,
+    write_config,
     helm_validator,
 ):
     """Test conflict resolution for Synapse <-> MAS shared secret.
@@ -1205,16 +1202,16 @@ def test_main_e2e_synapse_mas_shared_secret_conflict(
     This should trigger a secret conflict prompt.
     """
     # Use existing fixture and add the shared secret
-    synapse_config = synapse_config_with_signing_key.copy()
+    synapse_config = dict(synapse_config_with_signing_key)
     synapse_config["matrix_authentication_service"] = {
         "secret": "synapse_side_secret",
     }
-    synapse_config_file = write_synapse_config(synapse_config)
+    synapse_config_file = write_config(synapse_config, "synapse.yaml", "yaml")
 
     # Create MAS config with matrix.secret (different value)
-    mas_config = basic_mas_config.copy()
+    mas_config = dict(basic_mas_config)
     mas_config["matrix"]["secret"] = "mas_side_secret"  # Different from Synapse's value
-    mas_config_file = write_mas_config(mas_config)
+    mas_config_file = write_config(mas_config, "mas.yaml", "yaml")
 
     # Create output directory
     output_dir = tmp_path / "output"

--- a/packages/ess-migration-tool/tests/test_prompts.py
+++ b/packages/ess-migration-tool/tests/test_prompts.py
@@ -23,12 +23,10 @@ from ess_migration_tool.synapse import SYNAPSE_STRATEGY_NAME, prompt_for_ingress
 from ess_migration_tool.utils import prompt_for_database_choice
 
 
-def test_migration_with_missing_secrets_prompt(
-    monkeypatch, tmp_path, synapse_config_with_signing_key, write_synapse_config
-):
+def test_migration_with_missing_secrets_prompt(monkeypatch, tmp_path, synapse_config_with_signing_key, write_config):
     """Test migration workflow that prompts for missing secrets with timeout."""
     # Create Synapse configuration with missing secrets
-    synapse_config = synapse_config_with_signing_key.copy()
+    synapse_config = dict(synapse_config_with_signing_key)
     # Remove password to simulate missing secret
     del synapse_config["database"]["args"]["password"]
     # Remove other secrets to simulate missing secrets
@@ -36,7 +34,7 @@ def test_migration_with_missing_secrets_prompt(
     del synapse_config["registration_shared_secret"]
 
     # Write Synapse config
-    synapse_config_file = write_synapse_config(synapse_config)
+    synapse_config_file = write_config(synapse_config, "synapse.yaml", "yaml")
     # Load migration input - this should prompt for missing secrets
     input_processor = InputProcessor()
     input_processor.load_migration_input(
@@ -143,16 +141,16 @@ def test_prompt_for_ingress_host_with_missing_public_baseurl(monkeypatch, config
         log_capture_string.close()
 
 
-def test_quiet_mode_fails_on_missing_secrets(tmp_path, synapse_config_with_signing_key, write_synapse_config):
+def test_quiet_mode_fails_on_missing_secrets(tmp_path, synapse_config_with_signing_key, write_config):
     """Test that migration fails in quiet mode when secrets are missing."""
     # Create Synapse configuration with missing secrets
-    synapse_config = synapse_config_with_signing_key.copy()
+    synapse_config = dict(synapse_config_with_signing_key)
     # Remove password to simulate missing secret
     del synapse_config["database"]["args"]["password"]
     del synapse_config["macaroon_secret_key"]
 
     # Write Synapse config
-    synapse_config_file = write_synapse_config(synapse_config)
+    synapse_config_file = write_config(synapse_config, "synapse.yaml", "yaml")
 
     # Load migration input
     input_processor = InputProcessor()
@@ -181,11 +179,13 @@ def test_quiet_mode_fails_on_missing_secrets(tmp_path, synapse_config_with_signi
 
 
 def test_quiet_mode_fails_on_missing_extra_files(
-    tmp_path, synapse_config_with_signing_key, synapse_config_with_email_templates, write_synapse_config
+    tmp_path, synapse_config_with_signing_key, synapse_config_with_email_templates, write_config
 ):
     """Test that migration fails in quiet mode when extra files are missing."""
     # Write Synapse config
-    synapse_config_file = write_synapse_config(synapse_config_with_signing_key | synapse_config_with_email_templates)
+    synapse_config_file = write_config(
+        synapse_config_with_signing_key | synapse_config_with_email_templates, "synapse.yaml", "yaml"
+    )
 
     # Remove the email templates directory to simulate missing files
     shutil.rmtree(tmp_path / "email_templates")
@@ -220,12 +220,14 @@ def test_migration_with_unknown_workers_prompt(
     tmp_path,
     synapse_config_with_signing_key,
     synapse_config_with_instance_map,
-    write_synapse_config,
+    write_config,
 ):
     """Test migration workflow that prompts for missing secrets with timeout."""
 
     # Write Synapse config
-    synapse_config_file = write_synapse_config(synapse_config_with_signing_key | synapse_config_with_instance_map)
+    synapse_config_file = write_config(
+        synapse_config_with_signing_key | synapse_config_with_instance_map, "synapse.yaml", "yaml"
+    )
     # Load migration input - this should prompt for missing secrets
     input_processor = InputProcessor()
     input_processor.load_migration_input(
@@ -287,11 +289,13 @@ def test_migration_with_missing_extra_files_prompt(
     tmp_path,
     synapse_config_with_signing_key,
     synapse_config_with_email_templates,
-    write_synapse_config,
+    write_config,
 ):
     """Test migration workflow that prompts for missing secrets with timeout."""
     # Write Synapse config
-    synapse_config_file = write_synapse_config(synapse_config_with_signing_key | synapse_config_with_email_templates)
+    synapse_config_file = write_config(
+        synapse_config_with_signing_key | synapse_config_with_email_templates, "synapse.yaml", "yaml"
+    )
     # Load migration input - this should prompt for missing secrets
     input_processor = InputProcessor()
     input_processor.load_migration_input(
@@ -355,11 +359,11 @@ def test_database_choice_prompt_existing_database(
     monkeypatch,
     tmp_path,
     synapse_config_with_signing_key,
-    write_synapse_config,
+    write_config,
 ):
     """Test database choice prompt when user selects existing database."""
     # Write Synapse config
-    synapse_config_file = write_synapse_config(synapse_config_with_signing_key)
+    synapse_config_file = write_config(synapse_config_with_signing_key, "synapse.yaml", "yaml")
 
     # Load migration input
     input_processor = InputProcessor()
@@ -418,11 +422,11 @@ def test_database_choice_prompt_ess_managed(
     monkeypatch,
     tmp_path,
     synapse_config_with_signing_key,
-    write_synapse_config,
+    write_config,
 ):
     """Test database choice prompt when user selects ESS-managed PostgreSQL."""
     # Write Synapse config
-    synapse_config_file = write_synapse_config(synapse_config_with_signing_key)
+    synapse_config_file = write_config(synapse_config_with_signing_key, "synapse.yaml", "yaml")
 
     # Load migration input
     input_processor = InputProcessor()
@@ -481,11 +485,11 @@ def test_database_choice_prompt_default(
     monkeypatch,
     tmp_path,
     synapse_config_with_signing_key,
-    write_synapse_config,
+    write_config,
 ):
     """Test database choice prompt when user presses Enter (default choice)."""
     # Write Synapse config
-    synapse_config_file = write_synapse_config(synapse_config_with_signing_key)
+    synapse_config_file = write_config(synapse_config_with_signing_key, "synapse.yaml", "yaml")
 
     # Load migration input
     input_processor = InputProcessor()

--- a/packages/ess-migration-tool/tests/test_schema_validation.py
+++ b/packages/ess-migration-tool/tests/test_schema_validation.py
@@ -148,13 +148,13 @@ def test_transformation_specs_target_keys_valid():
         pytest.fail("TransformationSpec target_keys not in schema:\n" + "\n".join(invalid_targets))
 
 
-def test_migration_output_schema_validation(tmp_path, synapse_config_with_signing_key, write_synapse_config):
+def test_migration_output_schema_validation(tmp_path, synapse_config_with_signing_key, write_config):
     """Test that MigrationEngine output validates against the Helm chart schema."""
 
     # Load the Helm chart schema
     schema = load_helm_schema()
 
-    synapse_path = write_synapse_config(synapse_config_with_signing_key)
+    synapse_path = write_config(synapse_config_with_signing_key, "synapse.yaml", "yaml")
 
     # Load migration input
     input_processor = InputProcessor()

--- a/packages/ess-migration-tool/tests/test_synapse_secrets.py
+++ b/packages/ess-migration-tool/tests/test_synapse_secrets.py
@@ -14,7 +14,7 @@ def test_discover_secrets_from_synapse_config(basic_synapse_config):
     """Test discovering secrets from Synapse configuration with existing database."""
 
     # Start with basic config and add secret file references
-    synapse_config = basic_synapse_config.copy()
+    synapse_config = dict(basic_synapse_config)
     synapse_config["macaroon_secret_key"] = "./macaroon_key.txt"
     synapse_config["registration_shared_secret"] = "my_registration_secret"
 
@@ -43,7 +43,7 @@ def test_discover_secrets_from_synapse_config_ess_managed(basic_synapse_config):
     """Test discovering secrets from Synapse configuration with ESS-managed database."""
 
     # Start with basic config and add secret file references
-    synapse_config = basic_synapse_config.copy()
+    synapse_config = dict(basic_synapse_config)
     synapse_config["macaroon_secret_key"] = "./macaroon_key.txt"
     synapse_config["registration_shared_secret"] = "my_registration_secret"
 
@@ -74,7 +74,7 @@ def test_discover_extra_files_from_synapse_config(tmp_path, synapse_config_with_
     """Test discovering extra files from Synapse configuration."""
 
     # Start with basic config and add secret file references
-    synapse_config = synapse_config_with_email_templates.copy()
+    synapse_config = dict(synapse_config_with_email_templates)
     discovery = ExtraFilesDiscovery(
         summary_logger=logging.getLogger(),
         secrets_strategy=SynapseSecretDiscovery(GlobalOptions(use_existing_database=True)),
@@ -97,7 +97,7 @@ def test_permission_error_handling_for_secrets(tmp_path, basic_synapse_config):
     restricted_key.chmod(0o200)  # Write-only for owner
 
     # Create config with restricted file reference
-    synapse_config = basic_synapse_config.copy()
+    synapse_config = dict(basic_synapse_config)
     synapse_config["signing_key_path"] = str(restricted_key)
     synapse_config["database"]["args"]["password"] = "test_password"
     synapse_config["macaroon_secret_key"] = "test_macaroon_key"
@@ -140,7 +140,7 @@ def test_discover_appservice_registration_files(tmp_path, basic_synapse_config):
     appservice2.write_text("id: appservice2\nurl: http://localhost:8002\n")
 
     # Create config with appservice config files
-    synapse_config = basic_synapse_config.copy()
+    synapse_config = dict(basic_synapse_config)
     synapse_config["app_service_config_files"] = [str(appservice1), str(appservice2)]
     synapse_config["database"]["args"]["password"] = "test_password"
 
@@ -171,7 +171,7 @@ def test_discover_appservice_registration_files(tmp_path, basic_synapse_config):
 def test_appservice_files_missing(tmp_path, basic_synapse_config):
     """Test handling of missing appservice registration files."""
     # Create config with non-existent appservice config files
-    synapse_config = basic_synapse_config.copy()
+    synapse_config = dict(basic_synapse_config)
     synapse_config["app_service_config_files"] = ["/nonexistent/appservice1.yaml", "/nonexistent/appservice2.yaml"]
     synapse_config["database"]["args"]["password"] = "test_password"
 
@@ -195,7 +195,7 @@ def test_appservice_files_missing(tmp_path, basic_synapse_config):
 def test_appservice_files_empty_list(basic_synapse_config):
     """Test handling of empty app_service_config_files list."""
     # Create config with empty appservice config files list
-    synapse_config = basic_synapse_config.copy()
+    synapse_config = dict(basic_synapse_config)
     synapse_config["app_service_config_files"] = []
     synapse_config["database"]["args"]["password"] = "test_password"
 


### PR DESCRIPTION
- Instead of calling `deepcopy` everywhere, let's use `frozendict` 
- We also now have a single `write_config` fixture