### PR TITLE
Have dependabot manage all the Python directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,10 @@ updates:
           - "minor"
           - "patch"
   - package-ecosystem: "uv"
-    directory: "/"
+    directories:
+      - "/"
+      - "/tests"
+      - "/packages/*"
     schedule:
       interval: "weekly"
     cooldown:

--- a/newsfragments/1375.internal.md
+++ b/newsfragments/1375.internal.md
@@ -1,0 +1,1 @@
+Have Dependabot manage more directories.


### PR DESCRIPTION
e.g #1374 didn't touch the `pyproject.toml` in `./packages/ess-migration-tool/pyproject.toml`.

Syntax as per https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files