### PR TITLE
Don't attempt to update workspace dependency from PyPI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,9 @@ updates:
       - "/"
       - "/tests"
       - "/packages/*"
+    # Workaround https://github.com/dependabot/dependabot-core/issues/14004
+    ignore:
+      - dependency-name: ess-community-integration-tests
     schedule:
       interval: "weekly"
     cooldown:

--- a/newsfragments/1381.internal.md
+++ b/newsfragments/1381.internal.md
@@ -1,0 +1,1 @@
+Have Dependabot manage more directories.


### PR DESCRIPTION
In e.g. https://github.com/element-hq/ess-helm/actions/runs/27006408491/job/79698972837 we're seeing it attempting to update `ess-community-integration-tests` from PyPI when it is workspace project. This appears to be https://github.com/dependabot/dependabot-core/issues/14004, so ignore it