### PR TITLE
Allow disabling of QR code login

### DIFF
--- a/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
@@ -19,6 +19,10 @@ federation_client_minimum_tls_version: '1.2'
 experimental_features:
   msc4028_push_encrypted_events: true
   msc4452_enabled: true
+{{- if (include "element-io.matrix-authentication-service.readyToHandleAuth" (dict "root" $root)) }}
+  # QR Code Login. Requires MAS
+  msc4108_enabled: true
+{{- end }}
 
 url_preview_enabled: true
 # Both these lists are append only. If there are specific ranges within the denylist

--- a/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
@@ -102,7 +102,7 @@ matrix_authentication_service:
   force_http2: true
 {{- end }}
 
-{{- if or (include "element-io.matrix-authentication-service.readyToHandleAuth" (dict "root" $root)) $root.Values.matrixRTC.enabled $root.Values.hookshot.enabled }}
+{{- if or $root.Values.matrixRTC.enabled $root.Values.hookshot.enabled }}
 experimental_features:
 {{- if $root.Values.matrixRTC.enabled }}
   # MSC4143: Matrix RTC Transport using Livekit Backend. This enables a client-server API for discovery of Matrix RTC backends
@@ -118,14 +118,13 @@ experimental_features:
   msc3202_device_masquerading: true
   msc3202_transaction_extensions: true
 {{- end }}
+{{- end }}
 
 {{- if (include "element-io.matrix-authentication-service.readyToHandleAuth" (dict "root" $root)) }}
-  # QR Code Login. Requires MAS
-  msc4108_enabled: true
+
 password_config:
   localdb_enabled: false
   enabled: false
-{{- end }}
 {{- end }}
 {{- if $root.Values.matrixRTC.enabled }}
 

--- a/newsfragments/1383.changed.md
+++ b/newsfragments/1383.changed.md
@@ -1,0 +1,12 @@
+Allow turning off of QR code login on deployments with Matrix Authentication Service.
+
+Synapse additional configuration turning off the experimental feature is required:
+
+```yaml
+synapse:
+  additional:
+    disable-qr-code-login.yaml:
+      config: |
+        experimental_features:
+          msc4108_enabled: false
+```


### PR DESCRIPTION
This simply allows overriding via the additional config mechanism. It does not switch off the `OPTIONS` request handling on `/_matrix/client/unstable/org.matrix.msc4108/rendezvous` and `/_synapse/client/rendezvous`

cc @sandhose 