### PR TITLE
Log rich steps in summary log file

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1392.bugfix.md
+++ b/packages/ess-migration-tool/newsfragments/1392.bugfix.md
@@ -1,0 +1,1 @@
+Fix missing step logging in migration summary log file.

--- a/packages/ess-migration-tool/src/ess_migration_tool/rich_output.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/rich_output.py
@@ -289,6 +289,7 @@ class ProgressReporter:
                 (step_name, "bold white"),
             )
             get_console().print(step_msg_rich)
+            self.summary_logger.info(f"Step {self.current_step + 1}/{len(self.all_steps)}")
         else:
             # Fallback to plain text for non-Rich environments
             step_msg_plain = f"📦 Step {self.current_step + 1}/{len(self.all_steps)} ({progress:.0f}%): {step_name}"


### PR DESCRIPTION
This was causing some double `Press enter to continue` logs in the summary log file, despite steps moving forward in-between.

Before :

```
2026-05-26 16:53:51,472 - INFO - 🚀 Starting ESS Migration
2026-05-26 16:53:51,473 - INFO -       Press Enter to continue...
2026-05-26 16:53:54,223 - INFO -       Press Enter to continue...
```

After : 

```
2026-06-10 10:05:54,158 - INFO - 🚀 Starting ESS Migration
2026-06-10 10:05:54,159 - INFO - Step 1/4
2026-06-10 10:05:54,159 - INFO -       Press Enter to continue...
2026-06-10 10:05:54,975 - INFO - Step 2/4
2026-06-10 10:05:54,975 - INFO -       Press Enter to continue...

```