### PR TITLE
Fix secret conflict resolution duplicating data

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1393.bugfix.md
+++ b/packages/ess-migration-tool/newsfragments/1393.bugfix.md
@@ -1,0 +1,1 @@
+Fix an issue where secret conflict resolution would end up with the wrong secrets being configured in the values files, and secrets being duplicated in the secrets files.

--- a/packages/ess-migration-tool/src/ess_migration_tool/conflicts.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/conflicts.py
@@ -49,7 +49,8 @@ def prompt_for_conflict_resolution(
         Tuple of (selected_value, is_custom) where is_custom indicates user wants to enter custom value
     """
     options = []
-    for value in sorted(value_to_strategies):
+    # Sort options by strategies names
+    for value, _ in sorted(value_to_strategies.items(), key=lambda v: "".join(sorted(v[1]))):
         options.append(value)
     if enable_custom:
         options.append("Enter custom value")
@@ -194,6 +195,9 @@ class DiscoveredSecretTracking:
         owning_strategy: SecretDiscoveryStrategy | None = None
         found_precedence = False
         for source in sources:
+            if owning_strategy is None:
+                owning_strategy = source.strategy
+
             if source.takes_precedence:
                 found_precedence = True
                 # This strategy wants to own this secret
@@ -252,7 +256,7 @@ class DiscoveredSecretTracking:
             print_prompt(
                 "   Discovered by multiple strategies with different values:", style="default", logger=summary_logger
             )
-            for value, strategies in sorted(value_to_strategies.items()):
+            for value, strategies in sorted(value_to_strategies.items(), key=lambda v: "".join(sorted(v[1]))):
                 display_value = value if len(value) <= 50 else f"{value[:47]}..."
                 print_prompt(
                     f"   • {display_value} (from: {', '.join(strategies)})", style="default", logger=summary_logger
@@ -264,7 +268,7 @@ class DiscoveredSecretTracking:
 
             self.sources[secret_key] = [s for s in sources if s.value == selected_value]
 
-            print_prompt(f"   ✅ Resolved {secret_key}", style="default", logger=summary_logger)
+            print_prompt(f"   ✅ Resolved {secret_key} using {selected_value}", style="default", logger=summary_logger)
             print_prompt("", style="default", logger=summary_logger)
 
         print_separator(logger=summary_logger)

--- a/packages/ess-migration-tool/src/ess_migration_tool/engine.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/engine.py
@@ -135,6 +135,9 @@ class MigrationEngine:
         all_discovered_keys = {secret.secret_key for secret in self.discovered_secrets}
         self.init_by_ess_secrets = [key for key in self.init_by_ess_secrets if key not in all_discovered_keys]
 
+        # Resolve secret conflicts after all migrations
+        self.secret_tracking.resolve_secret_conflicts(self.summary_logger, self.global_options)
+
         # Prompt for missing secrets and validate after all strategies have resolved their secrets
         # This allows strategies to find secrets that previous strategies may have missed
         for migrator in self.migrators:
@@ -143,9 +146,6 @@ class MigrationEngine:
                 migrator.secret_discovery.validate_required_secrets()
                 # Handle any secrets that were just prompted for
                 migrator.handle_secrets_phase()
-
-        # Resolve secret conflicts after all migrations
-        self.secret_tracking.resolve_secret_conflicts(self.summary_logger, self.global_options)
 
         # Resolve value conflicts after all migrations
         resolve_value_conflicts(self.summary_logger, self.value_source_tracking, self.ess_config, self.global_options)

--- a/packages/ess-migration-tool/tests/conftest.py
+++ b/packages/ess-migration-tool/tests/conftest.py
@@ -242,7 +242,7 @@ def basic_mas_config():
             "secrets": {"encryption": "my_encryption_key"},
             "matrix": {
                 "homeserver": "test.example.com",
-                "secret": "synapse_shared_secret_abcdef",
+                "secret": "synapse_shared_secret_wrong",
                 "endpoint": "http://synapse:8008",
             },
             "policy": {

--- a/packages/ess-migration-tool/tests/test_main_e2e.py
+++ b/packages/ess-migration-tool/tests/test_main_e2e.py
@@ -248,7 +248,8 @@ def test_main_e2e_synapse_with_mas(
     ]
 
     # Mock user input for database choice (select option 1 - existing database, default)
-    side_effect = (n for n in ("",))  # Empty string for default choice (existing database)
+    side_effect = (n for n in ("", "2"))  # Empty string for default choice (existing database)
+    # 2. for Synapse secret for MAS/Synapse secret conflict
     monkeypatch.setattr(sys, "argv", test_args)
     monkeypatch.setattr("builtins.input", lambda _: next(side_effect))
     exit_code = __main__.main()
@@ -292,6 +293,11 @@ def test_main_e2e_synapse_with_mas(
     assert "matrixAuthenticationService.privateKeys.rsa" in log_output
     assert "matrixAuthenticationService.privateKeys.ecdsaPrime256v1" in log_output
     assert "ESS-INITIALIZED SECRETS" not in log_output
+
+    assert "🔐 RESOLVING SECRET CONFLICTS" in log_output
+    assert "Conflict for secret: matrixAuthenticationService.synapseSharedSecret" in log_output
+    assert "from: Synapse" in log_output
+    assert "from: Matrix Authentication Service" in log_output
 
     # Check that output files were created
     values_file = output_dir / "values.yaml"
@@ -338,7 +344,7 @@ def test_main_e2e_synapse_with_mas(
     # Verify synapseSharedSecret uses credential schema
     synapse_shared_secret_config = mas_config["synapseSharedSecret"]
     assert "secret" in synapse_shared_secret_config
-    assert synapse_shared_secret_config["secret"] == "imported-matrix-authentication-service"
+    assert synapse_shared_secret_config["secret"] == "imported-synapse"
     assert "secretKey" in synapse_shared_secret_config
     assert synapse_shared_secret_config["secretKey"] == "matrixAuthenticationService.synapseSharedSecret"
 
@@ -364,8 +370,9 @@ def test_main_e2e_synapse_with_mas(
             assert "name" in secret_content["metadata"]
             assert "data" in secret_content
             if secret_file.name == "imported-synapse-secret.yaml":
-                assert len(secret_content["data"]) == 4, (
+                assert len(secret_content["data"]) == 5, (
                     "expected 4 synapse secrets (macaroon, registration, signing, postgres password)"
+                    " + 1 Synapse/MAS shared secret"
                 )
                 assert base64.b64decode(secret_content["data"]["synapse.macaroon"]) == b"test_macaroon_secret"
                 assert (
@@ -374,16 +381,16 @@ def test_main_e2e_synapse_with_mas(
                 )
                 assert base64.b64decode(secret_content["data"]["synapse.signingKey"]) == b"test_signing_key_content"
                 assert base64.b64decode(secret_content["data"]["synapse.postgres.password"]) == b"test"
-                assert "matrixAuthenticationService.synapseSharedSecret" not in secret_content["data"], (
-                    "matrixAuthenticationService.synapseSharedSecret should be in MAS secret only"
+                assert "matrixAuthenticationService.synapseSharedSecret" in secret_content["data"], (
+                    "matrixAuthenticationService.synapseSharedSecret should be in Synapse secret only"
                 )
-
-            elif secret_file.name == "imported-matrix-authentication-service-secret.yaml":
-                assert len(secret_content["data"]) == 5, "expected 2 original + 2 keys + 1 synapse shared secret"
                 assert (
                     base64.b64decode(secret_content["data"]["matrixAuthenticationService.synapseSharedSecret"])
                     == b"synapse_shared_secret_abcdef"
                 )
+
+            elif secret_file.name == "imported-matrix-authentication-service-secret.yaml":
+                assert len(secret_content["data"]) == 4, "expected 2 original + 2 keys"
                 assert (
                     base64.b64decode(secret_content["data"]["matrixAuthenticationService.encryptionSecret"])
                     == b"my_encryption_key"
@@ -392,6 +399,10 @@ def test_main_e2e_synapse_with_mas(
                     base64.b64decode(secret_content["data"]["matrixAuthenticationService.postgres.password"])
                     == b"mas_password"
                 )
+                assert "matrixAuthenticationService.synapseSharedSecret" not in secret_content["data"], (
+                    "matrixAuthenticationService.synapseSharedSecret should be in Synapse secret only"
+                )
+
                 # Check that RSA and ECDSA keys were imported
                 assert "matrixAuthenticationService.privateKeys.rsa" in secret_content["data"]
                 assert "matrixAuthenticationService.privateKeys.ecdsaPrime256v1" in secret_content["data"]


### PR DESCRIPTION
- Fix sorting of secrets per strategy in resolve_secret_conflicts
- Fix secret owning strategy needs to be initialized to the first owning secret

The Synapse/MAS e2e test has been changed to force a secret conflict resolution.

Before:
<img width="884" height="300" alt="image" src="https://github.com/user-attachments/assets/9b298a48-870b-4365-8660-5cb90912df53" />


After :
<img width="884" height="316" alt="image" src="https://github.com/user-attachments/assets/c89eff8e-663e-4dde-8efd-8659bcda55b2" />
