### PR TITLE
Turn on MAU metrics calculations

### DIFF
--- a/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-01-shared-underrides.yaml.tpl
@@ -12,6 +12,8 @@ web_client_location: https://{{ $root.Values.elementWeb.ingress.host }}/
 
 report_stats: false
 
+mau_stats_only: true
+
 require_auth_for_profile_requests: true
 
 federation_client_minimum_tls_version: '1.2'

--- a/newsfragments/1399.changed.md
+++ b/newsfragments/1399.changed.md
@@ -1,0 +1,1 @@
+Have Synapse calculate MAU metrics.


### PR DESCRIPTION
[`mau_stats_only`](https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#mau_stats_only) turns on calculations of metrics used in the Synapse Grafana dashboard.

Does not do any limiting.