### PR TITLE
Upgrade Hookshot to v7.4.2

### DIFF
--- a/charts/matrix-stack/source/hookshot.yaml.j2
+++ b/charts/matrix-stack/source/hookshot.yaml.j2
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {% import "common/sub_schema_values.yaml.j2" as sub_schema_values %}
 
 enabled: false
-{{- sub_schema_values.image(registry='ghcr.io', repository='matrix-org/matrix-hookshot', tag='7.3.3') }}
+{{- sub_schema_values.image(registry='ghcr.io', repository='matrix-org/matrix-hookshot', tag='7.4.2') }}
 
 # Hookshot encryption support is experimental. You can enable it by setting `enableEncryption` to `true`.
 enableEncryption: false

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -1879,7 +1879,7 @@ hookshot:
 
     ## The tag of the container image to use.
     ## One of tag or digest must be provided.
-    tag: "7.3.3"
+    tag: "7.4.2"
 
     ## Container digest to use. Used to pull the image instead of the image tag if set
     ## The tag will still be set as the app.kubernetes.io/version label

--- a/newsfragments/1404.changed.md
+++ b/newsfragments/1404.changed.md
@@ -1,0 +1,9 @@
+Upgrade Hookshot to v7.4.2.
+
+Highlights:
+- You can now add hints to Hookshot messages to disable URL previews on clients. Uses [MSC4095](https://github.com/matrix-org/matrix-spec-proposals/pull/4095).
+
+Full Changelogs:
+- [v7.4.0](https://github.com/matrix-org/matrix-hookshot/releases/tag/7.4.0)
+- [v7.4.1](https://github.com/matrix-org/matrix-hookshot/releases/tag/7.4.1)
+- [v7.4.2](https://github.com/matrix-org/matrix-hookshot/releases/tag/7.4.2)


### PR DESCRIPTION
https://github.com/matrix-org/matrix-hookshot/releases/tag/7.4.0.

7.4.1 & 7.4.2 are regression fixing releases