### PR TITLE
replace Syntax with command highlighting

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1412.bugfix.md
+++ b/packages/ess-migration-tool/newsfragments/1412.bugfix.md
@@ -1,0 +1,1 @@
+Fix issue with commands outputs being padded with whitespaces, making it hard to copy paste multi-line commands.

--- a/packages/ess-migration-tool/src/ess_migration_tool/rich_output.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/rich_output.py
@@ -16,7 +16,6 @@ from typing import Any
 from rich import box
 from rich.console import Console
 from rich.panel import Panel
-from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 from rich.tree import Tree
@@ -157,7 +156,16 @@ def log_command(
     logger.info(f"   {command}")
 
     # Rich is enabled - use syntax highlighting
-    syntax = Syntax(command, "bash", theme="monokai", word_wrap=True)
+    syntax = Text()
+    syntax.append(Text("     $> ", style="bold"))
+    highlight_command = Text(command)
+    # highlight the command called
+    highlight_command.highlight_regex(r"^\w+", style="bold blue")
+    # highlight the command arguments
+    highlight_command.highlight_regex(r"\s-+\w+", style="green")
+    # highlight strings
+    highlight_command.highlight_regex(r"\".+\"", style="yellow")
+    syntax.append(highlight_command)
     get_console().print(syntax)
 
 


### PR DESCRIPTION
Renders like this : 

<img width="1184" height="290" alt="image" src="https://github.com/user-attachments/assets/15edeb28-f918-4872-b761-fac119e46d92" />


It does not render whitespaces anymore : 
<img width="1184" height="290" alt="image" src="https://github.com/user-attachments/assets/7e78f3c4-8cba-499f-9709-f1db15c7a612" />
