### PR TITLE
Dont crop and ignore overflow for logged commands

### DIFF
--- a/packages/ess-migration-tool/newsfragments/1414.bugfix.md
+++ b/packages/ess-migration-tool/newsfragments/1414.bugfix.md
@@ -1,0 +1,1 @@
+Fix logged commands have wrong line-breaks making it hard to copy paste.

--- a/packages/ess-migration-tool/src/ess_migration_tool/rich_output.py
+++ b/packages/ess-migration-tool/src/ess_migration_tool/rich_output.py
@@ -166,7 +166,7 @@ def log_command(
     # highlight strings
     highlight_command.highlight_regex(r"\".+\"", style="yellow")
     syntax.append(highlight_command)
-    get_console().print(syntax)
+    get_console().print(syntax, crop=False, overflow="ignore")
 
 
 def print_prompt(


### PR DESCRIPTION
Before : 
<img width="418" height="191" alt="image" src="https://github.com/user-attachments/assets/896b5d9a-eaaf-4765-96d9-ddc6c0296625" />
Which would result in the following copy-paste :
<img width="817" height="46" alt="image" src="https://github.com/user-attachments/assets/c3c2944f-c1b7-4788-b96d-47308fcd5674" />


After :
<img width="418" height="191" alt="image" src="https://github.com/user-attachments/assets/0168cba3-d9ce-4131-a701-470132fb4094" />
Now results in a usable copy-paste : 
<img width="1070" height="52" alt="image" src="https://github.com/user-attachments/assets/fdacc776-566c-4e3d-9e9d-172585d9d31c" />


