### PR TITLE
feat(matrix-stack): add priorityClassName support to component workloads

### DIFF
--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -45,6 +45,7 @@ image:
 {{ persistentVolumeClaim(key="storage", global=true)}}
 {{ tolerations(global=true) }}
 {{ topologySpreadConstraints(global=true) }}
+{{ priorityClassName(global=true) }}
 
 ## The cluster's domain name which will be appended to URLs of internal Services (<name>.<namespace>.svc.<clusterDomain>).
 ## It is unusual to need to change this but if you do need to change it,
@@ -213,6 +214,20 @@ networking:
 {% macro nodeSelector(key='nodeSelector') %}
 ## NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 {{ key }}: {}
+{%- endmacro %}
+
+{% macro priorityClassName(global=false, key='priorityClassName') %}
+{%- if global %}
+## Default priorityClassName applied to the pods of all components.
+## A priorityClassName set on an individual component overrides this global value for that component.
+## Synapse worker pods inherit the priorityClassName of the Synapse main process; per-worker priorityClassName is not yet configurable.
+{%- else %}
+## If specified, indicates the pod's priority and must reference the name of an existing PriorityClass object.
+{%- endif %}
+## "system-cluster-critical" and "system-node-critical" are two special built-in classes indicating the highest priorities.
+## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
+## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+{{ key }}: ""
 {%- endmacro %}
 
 {% macro persistentVolumeClaim(key, global=false) %}

--- a/charts/matrix-stack/source/deployment-markers.json
+++ b/charts/matrix-stack/source/deployment-markers.json
@@ -38,6 +38,9 @@
     "nodeSelector": {
       "$ref": "file://common/nodeSelector.json"
     },
+    "priorityClassName": {
+      "type": "string"
+    },
     "podSecurityContext": {
       "$ref": "file://common/podSecurityContext.json"
     },

--- a/charts/matrix-stack/source/deployment-markers.yaml.j2
+++ b/charts/matrix-stack/source/deployment-markers.yaml.j2
@@ -19,6 +19,7 @@ rbac:
 {{- sub_schema_values.extraVolumeMounts("Deployment Markers") }}
 {{- sub_schema_values.extraInitContainers("Deployment Markers") }}
 {{- sub_schema_values.nodeSelector() -}}
+{{- sub_schema_values.priorityClassName() -}}
 {{- sub_schema_values.podSecurityContext(user_id='10010', group_id='10010') -}}
 {{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='200Mi') -}}
 {{- sub_schema_values.serviceAccount() -}}

--- a/charts/matrix-stack/source/element-admin.json
+++ b/charts/matrix-stack/source/element-admin.json
@@ -40,6 +40,9 @@
     "nodeSelector": {
       "$ref": "file://common/nodeSelector.json"
     },
+    "priorityClassName": {
+      "type": "string"
+    },
     "podSecurityContext": {
       "$ref": "file://common/podSecurityContext.json"
     },

--- a/charts/matrix-stack/source/element-admin.yaml.j2
+++ b/charts/matrix-stack/source/element-admin.yaml.j2
@@ -22,6 +22,7 @@ replicas: 1
 {{- sub_schema_values.extraInitContainers("Element Admin") }}
 {{- sub_schema_values.containersSecurityContext() -}}
 {{- sub_schema_values.nodeSelector() -}}
+{{- sub_schema_values.priorityClassName() -}}
 {{- sub_schema_values.podSecurityContext(user_id='10104', group_id='10104') -}}
 {{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='200Mi') -}}
 {{- sub_schema_values.serviceAccount() -}}

--- a/charts/matrix-stack/source/element-web.json
+++ b/charts/matrix-stack/source/element-web.json
@@ -46,6 +46,9 @@
     "nodeSelector": {
       "$ref": "file://common/nodeSelector.json"
     },
+    "priorityClassName": {
+      "type": "string"
+    },
     "podSecurityContext": {
       "$ref": "file://common/podSecurityContext.json"
     },

--- a/charts/matrix-stack/source/element-web.yaml.j2
+++ b/charts/matrix-stack/source/element-web.yaml.j2
@@ -30,6 +30,7 @@ replicas: 1
 {{- sub_schema_values.extraInitContainers("Element Web") }}
 {{- sub_schema_values.containersSecurityContext() -}}
 {{- sub_schema_values.nodeSelector() -}}
+{{- sub_schema_values.priorityClassName() -}}
 {{- sub_schema_values.podSecurityContext(user_id='10004', group_id='10004') -}}
 {{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='200Mi') -}}
 {{- sub_schema_values.serviceAccount() -}}

--- a/charts/matrix-stack/source/haproxy.json
+++ b/charts/matrix-stack/source/haproxy.json
@@ -34,6 +34,9 @@
     "nodeSelector": {
       "$ref": "file://common/nodeSelector.json"
     },
+    "priorityClassName": {
+      "type": "string"
+    },
     "podSecurityContext": {
       "$ref": "file://common/podSecurityContext.json"
     },

--- a/charts/matrix-stack/source/haproxy.yaml.j2
+++ b/charts/matrix-stack/source/haproxy.yaml.j2
@@ -17,6 +17,7 @@ replicas: 1
 {{- sub_schema_values.extraVolumeMounts("HAProxy") }}
 {{- sub_schema_values.extraInitContainers("HAProxy") }}
 {{- sub_schema_values.nodeSelector() }}
+{{- sub_schema_values.priorityClassName() }}
 {{- sub_schema_values.podSecurityContext(user_id='10001', group_id='10001') }}
 {{- sub_schema_values.resources(requests_memory='100Mi', requests_cpu='100m', limits_memory='200Mi') }}
 {{- sub_schema_values.serviceAccount() }}

--- a/charts/matrix-stack/source/hookshot.json
+++ b/charts/matrix-stack/source/hookshot.json
@@ -89,6 +89,9 @@
     "nodeSelector": {
       "$ref": "file://common/nodeSelector.json"
     },
+    "priorityClassName": {
+      "type": "string"
+    },
     "podSecurityContext": {
       "$ref": "file://common/podSecurityContext.json"
     },

--- a/charts/matrix-stack/source/hookshot.yaml.j2
+++ b/charts/matrix-stack/source/hookshot.yaml.j2
@@ -41,6 +41,7 @@ replicas: 1
 {{ sub_schema_values.labels() }}
 {{ sub_schema_values.serviceAccount() }}
 {{ sub_schema_values.nodeSelector() }}
+{{- sub_schema_values.priorityClassName() }}
 {{ sub_schema_values.tolerations() }}
 {{ sub_schema_values.topologySpreadConstraints() }}
 {{ sub_schema_values.podSecurityContext(user_id=10007, group_id=10007) }}

--- a/charts/matrix-stack/source/init-secrets.json
+++ b/charts/matrix-stack/source/init-secrets.json
@@ -38,6 +38,9 @@
     "nodeSelector": {
       "$ref": "file://common/nodeSelector.json"
     },
+    "priorityClassName": {
+      "type": "string"
+    },
     "podSecurityContext": {
       "$ref": "file://common/podSecurityContext.json"
     },

--- a/charts/matrix-stack/source/init-secrets.yaml.j2
+++ b/charts/matrix-stack/source/init-secrets.yaml.j2
@@ -19,6 +19,7 @@ rbac:
 {{- sub_schema_values.extraVolumeMounts("Init Secrets") }}
 {{- sub_schema_values.extraInitContainers("Init Secrets") }}
 {{- sub_schema_values.nodeSelector() -}}
+{{- sub_schema_values.priorityClassName() -}}
 {{- sub_schema_values.podSecurityContext(user_id='10010', group_id='10010') -}}
 {{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='200Mi') -}}
 {{- sub_schema_values.serviceAccount() -}}

--- a/charts/matrix-stack/source/matrix-rtc.json
+++ b/charts/matrix-stack/source/matrix-rtc.json
@@ -87,6 +87,9 @@
     "nodeSelector": {
       "$ref": "file://common/nodeSelector.json"
     },
+    "priorityClassName": {
+      "type": "string"
+    },
     "podSecurityContext": {
       "$ref": "file://common/podSecurityContext.json"
     },
@@ -206,6 +209,9 @@
         },
         "nodeSelector": {
           "$ref": "file://common/nodeSelector.json"
+        },
+        "priorityClassName": {
+          "type": "string"
         },
         "podSecurityContext": {
           "$ref": "file://common/podSecurityContext.json"

--- a/charts/matrix-stack/source/matrix-rtc.yaml.j2
+++ b/charts/matrix-stack/source/matrix-rtc.yaml.j2
@@ -34,6 +34,7 @@ replicas: 1
 {{- sub_schema_values.extraVolumeMounts("Matrix RTC") }}
 {{- sub_schema_values.extraInitContainers("Matrix RTC") }}
 {{- sub_schema_values.nodeSelector() }}
+{{- sub_schema_values.priorityClassName() }}
 {{- sub_schema_values.podSecurityContext(user_id='10033', group_id='10033') }}
 {{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='200Mi') }}
 {{- sub_schema_values.serviceMonitors() }}
@@ -90,6 +91,7 @@ sfu:
 {{- sub_schema_values.workloadAnnotations() | indent(2) }}
 {{- sub_schema_values.containersSecurityContext() | indent(2) }}
 {{- sub_schema_values.nodeSelector() | indent(2) }}
+{{- sub_schema_values.priorityClassName() | indent(2) }}
 {{- sub_schema_values.podSecurityContext(user_id='10030', group_id='10030') | indent(2) }}
 {{- sub_schema_values.resources(requests_memory='150Mi', requests_cpu='100m', limits_memory='4Gi') | indent(2) }}
 {{- sub_schema_values.serviceAccount() | indent(2) }}

--- a/charts/matrix-stack/source/matrixAuthenticationService.json
+++ b/charts/matrix-stack/source/matrixAuthenticationService.json
@@ -80,6 +80,9 @@
         "nodeSelector": {
           "$ref": "file://common/nodeSelector.json"
         },
+        "priorityClassName": {
+          "type": "string"
+        },
         "podSecurityContext": {
           "$ref": "file://common/podSecurityContext.json"
         },
@@ -129,6 +132,9 @@
     },
     "nodeSelector": {
       "$ref": "file://common/nodeSelector.json"
+    },
+    "priorityClassName": {
+      "type": "string"
     },
     "podSecurityContext": {
       "$ref": "file://common/podSecurityContext.json"

--- a/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
+++ b/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
@@ -31,6 +31,7 @@ privateKeys: {}
 {{ sub_schema_values.labels() }}
 {{ sub_schema_values.serviceAccount() }}
 {{ sub_schema_values.nodeSelector() }}
+{{- sub_schema_values.priorityClassName() }}
 {{ sub_schema_values.tolerations() }}
 {{ sub_schema_values.hostAliases() }}
 {{ sub_schema_values.topologySpreadConstraints() }}
@@ -68,6 +69,7 @@ syn2mas:
   {{- sub_schema_values.workloadAnnotations() | indent(2) -}}
   {{- sub_schema_values.containersSecurityContext() | indent(2) -}}
   {{- sub_schema_values.nodeSelector() | indent(2) -}}
+  {{- sub_schema_values.priorityClassName() | indent(2) -}}
   {{- sub_schema_values.podSecurityContext(user_id='10005', group_id='10005') | indent(2) -}}
   {{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='350Mi') | indent(2) -}}
   {{- sub_schema_values.serviceAccount() | indent(2) -}}

--- a/charts/matrix-stack/source/postgres.json
+++ b/charts/matrix-stack/source/postgres.json
@@ -87,6 +87,9 @@
     "nodeSelector": {
       "$ref": "file://common/nodeSelector.json"
     },
+    "priorityClassName": {
+      "type": "string"
+    },
     "podSecurityContext": {
       "$ref": "file://common/podSecurityContext.json"
     },

--- a/charts/matrix-stack/source/postgres.yaml.j2
+++ b/charts/matrix-stack/source/postgres.yaml.j2
@@ -35,6 +35,7 @@ essPasswords: {}
 {{- sub_schema_values.workloadAnnotations() }}
 {{- sub_schema_values.containersSecurityContext() }}
 {{- sub_schema_values.nodeSelector() }}
+{{- sub_schema_values.priorityClassName() }}
 {{- sub_schema_values.podSecurityContext(user_id='10091', group_id='10091') }}
 {{- sub_schema_values.resources(requests_memory='100Mi', requests_cpu='100m', limits_memory='4Gi') }}
 {{- sub_schema_values.serviceAccount() }}

--- a/charts/matrix-stack/source/redis.json
+++ b/charts/matrix-stack/source/redis.json
@@ -51,6 +51,9 @@
     "nodeSelector": {
       "$ref": "file://common/nodeSelector.json"
     },
+    "priorityClassName": {
+      "type": "string"
+    },
     "podSecurityContext": {
       "$ref": "file://common/podSecurityContext.json"
     },

--- a/charts/matrix-stack/source/redis.yaml.j2
+++ b/charts/matrix-stack/source/redis.yaml.j2
@@ -21,6 +21,7 @@ replicas: 1
 {{- sub_schema_values.extraVolumeMounts(name) }}
 {{- sub_schema_values.extraInitContainers("Redis") }}
 {{- sub_schema_values.nodeSelector() }}
+{{- sub_schema_values.priorityClassName() }}
 {{- sub_schema_values.podSecurityContext(user_id='10002', group_id='10002') }}
 {{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='50Mi') }}
 {{- sub_schema_values.serviceAccount() }}

--- a/charts/matrix-stack/source/synapse.json
+++ b/charts/matrix-stack/source/synapse.json
@@ -165,6 +165,9 @@
     "nodeSelector": {
       "$ref": "file://common/nodeSelector.json"
     },
+    "priorityClassName": {
+      "type": "string"
+    },
     "extraVolumes": {
       "$ref": "file://common/extraVolumesWithContext.json"
     },

--- a/charts/matrix-stack/source/synapse.yaml.j2
+++ b/charts/matrix-stack/source/synapse.yaml.j2
@@ -101,6 +101,7 @@ replicas: 1
 {{- sub_schema_values.extraEnv() }}
 {{- sub_schema_values.hostAliases() }}
 {{- sub_schema_values.nodeSelector() }}
+{{- sub_schema_values.priorityClassName() }}
 {{- sub_schema_values.podSecurityContext(user_id='10091', group_id='10091') }}
 {{- sub_schema_values.resources(requests_memory='100Mi', requests_cpu='100m', limits_memory='4Gi') }}
 {{- sub_schema_values.serviceAccount() }}

--- a/charts/matrix-stack/source/values.schema.json
+++ b/charts/matrix-stack/source/values.schema.json
@@ -88,6 +88,9 @@
     "topologySpreadConstraints": {
       "$ref": "file://common/topologySpreadConstraints.json"
     },
+    "priorityClassName": {
+      "type": "string"
+    },
     "clusterDomain": {
       "type": "string"
     },

--- a/charts/matrix-stack/templates/ess-library/_pods.tpl
+++ b/charts/matrix-stack/templates/ess-library/_pods.tpl
@@ -28,6 +28,9 @@ securityContext:
 nodeSelector:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with (coalesce .priorityClassName $root.Values.priorityClassName) }}
+priorityClassName: {{ . }}
+{{- end }}
 restartPolicy: {{ (eq $kind "Job") | ternary "Never" "Always" }}
 {{- include "element-io.ess-library.pods.tolerations" (dict "root" $root "context" .tolerations) }}
 {{- include "element-io.ess-library.pods.topologySpreadConstraints" (dict "root" $root "context" (dict "instanceSuffix" $instanceSuffix "deployment" (eq $kind "Deployment") "topologySpreadConstraints" .topologySpreadConstraints)) }}

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -372,6 +372,9 @@
         "additionalProperties": false
       }
     },
+    "priorityClassName": {
+      "type": "string"
+    },
     "clusterDomain": {
       "type": "string"
     },
@@ -565,6 +568,9 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "priorityClassName": {
+          "type": "string"
         },
         "podSecurityContext": {
           "properties": {
@@ -995,6 +1001,9 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "priorityClassName": {
+          "type": "string"
         },
         "podSecurityContext": {
           "properties": {
@@ -1712,6 +1721,9 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "priorityClassName": {
+          "type": "string"
         },
         "podSecurityContext": {
           "properties": {
@@ -2709,6 +2721,9 @@
                 "type": "string"
               }
             },
+            "priorityClassName": {
+              "type": "string"
+            },
             "podSecurityContext": {
               "properties": {
                 "fsGroup": {
@@ -3420,6 +3435,9 @@
             "type": "string"
           }
         },
+        "priorityClassName": {
+          "type": "string"
+        },
         "podSecurityContext": {
           "properties": {
             "fsGroup": {
@@ -4125,6 +4143,9 @@
             "type": "string"
           }
         },
+        "priorityClassName": {
+          "type": "string"
+        },
         "podSecurityContext": {
           "properties": {
             "fsGroup": {
@@ -4744,6 +4765,9 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "priorityClassName": {
+          "type": "string"
         },
         "podSecurityContext": {
           "properties": {
@@ -5767,6 +5791,9 @@
             "type": "string"
           }
         },
+        "priorityClassName": {
+          "type": "string"
+        },
         "podSecurityContext": {
           "properties": {
             "fsGroup": {
@@ -6771,6 +6798,9 @@
                 "type": "string"
               }
             },
+            "priorityClassName": {
+              "type": "string"
+            },
             "podSecurityContext": {
               "properties": {
                 "fsGroup": {
@@ -7352,6 +7382,9 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "priorityClassName": {
+          "type": "string"
         },
         "podSecurityContext": {
           "properties": {
@@ -8541,6 +8574,9 @@
             "type": "string"
           }
         },
+        "priorityClassName": {
+          "type": "string"
+        },
         "podSecurityContext": {
           "properties": {
             "fsGroup": {
@@ -9186,6 +9222,9 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "priorityClassName": {
+          "type": "string"
         },
         "podSecurityContext": {
           "properties": {
@@ -10814,6 +10853,9 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "priorityClassName": {
+          "type": "string"
         },
         "extraVolumes": {
           "type": "array",

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -136,6 +136,14 @@ topologySpreadConstraints:
   topologyKey: kubernetes.io/hostname
   whenUnsatisfiable: ScheduleAnyway
 
+## Default priorityClassName applied to the pods of all components.
+## A priorityClassName set on an individual component overrides this global value for that component.
+## Synapse worker pods inherit the priorityClassName of the Synapse main process; per-worker priorityClassName is not yet configurable.
+## "system-cluster-critical" and "system-node-critical" are two special built-in classes indicating the highest priorities.
+## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
+## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+priorityClassName: ""
+
 ## The cluster's domain name which will be appended to URLs of internal Services (<name>.<namespace>.svc.<clusterDomain>).
 ## It is unusual to need to change this but if you do need to change it,
 ## strongly consider having a trailing dot to prevent multiple search domains being queried.
@@ -197,6 +205,11 @@ initSecrets:
 
   ## NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   nodeSelector: {}
+  ## If specified, indicates the pod's priority and must reference the name of an existing PriorityClass object.
+  ## "system-cluster-critical" and "system-node-critical" are two special built-in classes indicating the highest priorities.
+  ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+  priorityClassName: ""
   ## A subset of PodSecurityContext. PodSecurityContext holds pod-level security attributes and common container settings
   podSecurityContext:
     ## A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to
@@ -347,6 +360,11 @@ deploymentMarkers:
 
   ## NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   nodeSelector: {}
+  ## If specified, indicates the pod's priority and must reference the name of an existing PriorityClass object.
+  ## "system-cluster-critical" and "system-node-critical" are two special built-in classes indicating the highest priorities.
+  ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+  priorityClassName: ""
   ## A subset of PodSecurityContext. PodSecurityContext holds pod-level security attributes and common container settings
   podSecurityContext:
     ## A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to
@@ -597,6 +615,11 @@ matrixRTC:
 
   ## NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   nodeSelector: {}
+  ## If specified, indicates the pod's priority and must reference the name of an existing PriorityClass object.
+  ## "system-cluster-critical" and "system-node-critical" are two special built-in classes indicating the highest priorities.
+  ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+  priorityClassName: ""
   ## A subset of PodSecurityContext. PodSecurityContext holds pod-level security attributes and common container settings
   podSecurityContext:
     ## A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to
@@ -974,6 +997,11 @@ matrixRTC:
       #  type: RuntimeDefault
     ## NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
     nodeSelector: {}
+    ## If specified, indicates the pod's priority and must reference the name of an existing PriorityClass object.
+    ## "system-cluster-critical" and "system-node-critical" are two special built-in classes indicating the highest priorities.
+    ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
+    ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+    priorityClassName: ""
     ## A subset of PodSecurityContext. PodSecurityContext holds pod-level security attributes and common container settings
     podSecurityContext:
       ## A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to
@@ -1232,6 +1260,11 @@ elementAdmin:
     #  type: RuntimeDefault
   ## NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   nodeSelector: {}
+  ## If specified, indicates the pod's priority and must reference the name of an existing PriorityClass object.
+  ## "system-cluster-critical" and "system-node-critical" are two special built-in classes indicating the highest priorities.
+  ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+  priorityClassName: ""
   ## A subset of PodSecurityContext. PodSecurityContext holds pod-level security attributes and common container settings
   podSecurityContext:
     ## A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to
@@ -1494,6 +1527,11 @@ elementWeb:
     #  type: RuntimeDefault
   ## NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   nodeSelector: {}
+  ## If specified, indicates the pod's priority and must reference the name of an existing PriorityClass object.
+  ## "system-cluster-critical" and "system-node-critical" are two special built-in classes indicating the highest priorities.
+  ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+  priorityClassName: ""
   ## A subset of PodSecurityContext. PodSecurityContext holds pod-level security attributes and common container settings
   podSecurityContext:
     ## A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to
@@ -1715,6 +1753,11 @@ haproxy:
 
   ## NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   nodeSelector: {}
+  ## If specified, indicates the pod's priority and must reference the name of an existing PriorityClass object.
+  ## "system-cluster-critical" and "system-node-critical" are two special built-in classes indicating the highest priorities.
+  ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+  priorityClassName: ""
   ## A subset of PodSecurityContext. PodSecurityContext holds pod-level security attributes and common container settings
   podSecurityContext:
     ## A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to
@@ -2083,6 +2126,11 @@ hookshot:
 
   ## NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   nodeSelector: {}
+  ## If specified, indicates the pod's priority and must reference the name of an existing PriorityClass object.
+  ## "system-cluster-critical" and "system-node-critical" are two special built-in classes indicating the highest priorities.
+  ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+  priorityClassName: ""
 
   ## Workload tolerations allows Pods that are part of this (sub)component to 'tolerate' any taint that matches the triple <key,value,effect> using the matching operator <operator>.
   ##
@@ -2482,6 +2530,11 @@ matrixAuthenticationService:
 
   ## NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   nodeSelector: {}
+  ## If specified, indicates the pod's priority and must reference the name of an existing PriorityClass object.
+  ## "system-cluster-critical" and "system-node-critical" are two special built-in classes indicating the highest priorities.
+  ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+  priorityClassName: ""
 
   ## Workload tolerations allows Pods that are part of this (sub)component to 'tolerate' any taint that matches the triple <key,value,effect> using the matching operator <operator>.
   ##
@@ -2753,6 +2806,11 @@ matrixAuthenticationService:
       #  type: RuntimeDefault
     ## NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
     nodeSelector: {}
+    ## If specified, indicates the pod's priority and must reference the name of an existing PriorityClass object.
+    ## "system-cluster-critical" and "system-node-critical" are two special built-in classes indicating the highest priorities.
+    ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
+    ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+    priorityClassName: ""
     ## A subset of PodSecurityContext. PodSecurityContext holds pod-level security attributes and common container settings
     podSecurityContext:
       ## A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to
@@ -3132,6 +3190,11 @@ postgres:
     #  type: RuntimeDefault
   ## NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   nodeSelector: {}
+  ## If specified, indicates the pod's priority and must reference the name of an existing PriorityClass object.
+  ## "system-cluster-critical" and "system-node-critical" are two special built-in classes indicating the highest priorities.
+  ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+  priorityClassName: ""
   ## A subset of PodSecurityContext. PodSecurityContext holds pod-level security attributes and common container settings
   podSecurityContext:
     ## A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to
@@ -3363,6 +3426,11 @@ redis:
 
   ## NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   nodeSelector: {}
+  ## If specified, indicates the pod's priority and must reference the name of an existing PriorityClass object.
+  ## "system-cluster-critical" and "system-node-critical" are two special built-in classes indicating the highest priorities.
+  ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+  priorityClassName: ""
   ## A subset of PodSecurityContext. PodSecurityContext holds pod-level security attributes and common container settings
   podSecurityContext:
     ## A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to
@@ -5288,6 +5356,11 @@ synapse:
   hostAliases: []
   ## NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   nodeSelector: {}
+  ## If specified, indicates the pod's priority and must reference the name of an existing PriorityClass object.
+  ## "system-cluster-critical" and "system-node-critical" are two special built-in classes indicating the highest priorities.
+  ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+  priorityClassName: ""
   ## A subset of PodSecurityContext. PodSecurityContext holds pod-level security attributes and common container settings
   podSecurityContext:
     ## A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to

--- a/newsfragments/1438.added.md
+++ b/newsfragments/1438.added.md
@@ -1,0 +1,1 @@
+Add support for configuring the `priorityClassName` on component workloads, along with a global `priorityClassName` applied to all components (a per-component value overrides the global one).

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -25,6 +25,7 @@ class PropertyType(Enum):
     NodeSelector = "nodeSelector"
     PodSecurityContext = "podSecurityContext"
     Postgres = "postgres"
+    PriorityClassName = "priorityClassName"
     Replicas = "replicas"
     ReadinessProbe = "readinessProbe"
     Resources = "resources"
@@ -254,6 +255,7 @@ class SidecarDetails(DeployableDetails):
             PropertyType.InitContainers: ValuesFilePath.not_supported(),
             PropertyType.NodeSelector: ValuesFilePath.not_supported(),
             PropertyType.PodSecurityContext: ValuesFilePath.not_supported(),
+            PropertyType.PriorityClassName: ValuesFilePath.not_supported(),
             PropertyType.ServiceAccount: ValuesFilePath.not_supported(),
             PropertyType.Tolerations: ValuesFilePath.not_supported(),
             PropertyType.TopologySpreadConstraints: ValuesFilePath.not_supported(),
@@ -381,6 +383,7 @@ def make_synapse_worker_sub_component(worker_name: str, worker_type: str) -> Sub
         PropertyType.Labels: ValuesFilePath.read_elsewhere("synapse", "labels"),
         PropertyType.NodeSelector: ValuesFilePath.read_elsewhere("synapse", "nodeSelector"),
         PropertyType.PodSecurityContext: ValuesFilePath.read_elsewhere("synapse", "podSecurityContext"),
+        PropertyType.PriorityClassName: ValuesFilePath.read_elsewhere("synapse", "priorityClassName"),
         PropertyType.ServiceAccount: ValuesFilePath.read_elsewhere("synapse", "serviceAccount"),
         PropertyType.ServiceMonitor: ValuesFilePath.read_elsewhere("synapse", "serviceMonitor"),
         PropertyType.Tolerations: ValuesFilePath.read_elsewhere("synapse", "tolerations"),
@@ -700,6 +703,7 @@ all_components_details = [
                     PropertyType.LivenessProbe: ValuesFilePath.not_supported(),
                     PropertyType.NodeSelector: ValuesFilePath.read_elsewhere("synapse", "nodeSelector"),
                     PropertyType.PodSecurityContext: ValuesFilePath.read_elsewhere("synapse", "podSecurityContext"),
+                    PropertyType.PriorityClassName: ValuesFilePath.read_elsewhere("synapse", "priorityClassName"),
                     # Job so no readinessProbe
                     PropertyType.ReadinessProbe: ValuesFilePath.not_supported(),
                     PropertyType.ServiceMonitor: ValuesFilePath.read_elsewhere("synapse", "serviceMonitor"),

--- a/tests/manifests/test_pod_priorityClassName.py
+++ b/tests/manifests/test_pod_priorityClassName.py
@@ -1,0 +1,87 @@
+# Copyright 2025 New Vector Ltd
+# Copyright 2025-2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import random
+import string
+
+import pytest
+
+from . import DeployableDetails, PropertyType, values_files_to_test
+from .utils import (
+    iterate_deployables_workload_parts,
+    template_id,
+    template_to_deployable_details,
+)
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_pod_has_no_priorityClassName_by_default(templates):
+    for template in templates:
+        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+            pod_spec = template["spec"]["template"]["spec"]
+            assert "priorityClassName" not in pod_spec, (
+                f"{template_id(template)} has a default priorityClassName when one isn't configured"
+            )
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_pod_gets_configured_priorityClassName(values, make_templates, release_name):
+    def set_priorityClassName(deployable_details: DeployableDetails):
+        priorityClassName = "".join(random.choices(string.ascii_lowercase))
+        deployable_details.set_helm_values(values, PropertyType.PriorityClassName, priorityClassName)
+
+    iterate_deployables_workload_parts(set_priorityClassName)
+    for template in await make_templates(values):
+        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+            pod_spec = template["spec"]["template"]["spec"]
+            assert "priorityClassName" in pod_spec, (
+                f"{template_id(template)} doesn't have a priorityClassName when one is configured"
+            )
+
+            deployable_details = template_to_deployable_details(template)
+            expected_priorityClassName = deployable_details.get_helm_values(values, PropertyType.PriorityClassName)
+            assert pod_spec["priorityClassName"] == expected_priorityClassName, (
+                f"{template_id(template)} has an unexpected priorityClassName"
+            )
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_global_priorityClassName_renders(values, make_templates):
+    global_priorityClassName = "global-priority"
+    values["priorityClassName"] = global_priorityClassName
+
+    for template in await make_templates(values):
+        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+            pod_spec = template["spec"]["template"]["spec"]
+            assert pod_spec.get("priorityClassName") == global_priorityClassName, (
+                f"{template_id(template)} doesn't inherit the global priorityClassName"
+            )
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_component_priorityClassName_overrides_global(values, make_templates):
+    global_priorityClassName = "global-priority"
+    values["priorityClassName"] = global_priorityClassName
+
+    def set_priorityClassName(deployable_details: DeployableDetails):
+        component_priorityClassName = "".join(random.choices(string.ascii_lowercase))
+        deployable_details.set_helm_values(values, PropertyType.PriorityClassName, component_priorityClassName)
+
+    iterate_deployables_workload_parts(set_priorityClassName)
+    for template in await make_templates(values):
+        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+            pod_spec = template["spec"]["template"]["spec"]
+            deployable_details = template_to_deployable_details(template)
+            expected_priorityClassName = deployable_details.get_helm_values(values, PropertyType.PriorityClassName)
+            assert pod_spec.get("priorityClassName") == expected_priorityClassName, (
+                f"{template_id(template)} did not let its component priorityClassName override the global one"
+            )
+            assert pod_spec["priorityClassName"] != global_priorityClassName, (
+                f"{template_id(template)} rendered the global priorityClassName instead of its component override"
+            )

--- a/tests/manifests/test_pod_priorityClassName.py
+++ b/tests/manifests/test_pod_priorityClassName.py
@@ -1,5 +1,5 @@
 # Copyright 2025 New Vector Ltd
-# Copyright 2025-2026 Element Creations Ltd
+# Copyright 2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/tests/manifests/test_pod_priorityClassName.py
+++ b/tests/manifests/test_pod_priorityClassName.py
@@ -1,4 +1,3 @@
-# Copyright 2025 New Vector Ltd
 # Copyright 2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only


### PR DESCRIPTION
Adds an optional `priorityClassName` value to every matrix-stack component workload, mirroring the existing `nodeSelector` pattern. Default is unset so rendered output is unchanged for existing users. Resolves #1422.

Validation (run locally against the repo's own tooling):
- `helm lint` clean; `helm template` renders `priorityClassName` when set, byte-identical to `main` when unset
- Full `pytest tests/manifests` passes (2377 passed), including a new `test_pod_priorityClassName.py` mirroring `test_pod_nodeSelector.py`
- `reuse lint` compliant, `ruff` clean, the assemble scripts reproduce with no drift

This is a per-component knob (like `nodeSelector`). If you'd prefer a global default with per-component overrides (like `tolerations`/`topologySpreadConstraints`), happy to switch.