### PR TITLE
Set MAS session limits

### DIFF
--- a/charts/matrix-stack/configs/matrix-authentication-service/config-underrides.yaml.tpl
+++ b/charts/matrix-stack/configs/matrix-authentication-service/config-underrides.yaml.tpl
@@ -1,6 +1,6 @@
 {{- /*
 Copyright 2025 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -15,4 +15,8 @@ policy:
       allow_host_mismatch: false
       allow_insecure_uris: false
 
+experimental:
+  session_limit:
+    soft_limit: 50
+    hard_limit: 50
 {{- end -}}

--- a/newsfragments/1440.changed.md
+++ b/newsfragments/1440.changed.md
@@ -1,0 +1,28 @@
+Add session limits to Matrix Authentication Service by default.
+
+Configure Matrix Authentication Services with soft and hard limits of 50 sessions by default.
+This applies to both interactive and non-interactive sessions.
+
+The defaults can be raised, to e.g. 75, with
+
+```yaml
+matrixAuthenticationService:
+  additional:
+    session-limits:
+      config: |
+        experimental:
+          session_limit:
+            soft_limit: 75
+            hard_limit: 75
+```
+
+The limits can be removed with
+
+```yaml
+matrixAuthenticationService:
+  additional:
+    session-limits:
+      config: |
+        experimental:
+          session_limit: null
+```


### PR DESCRIPTION
Got missed off of https://github.com/element-hq/ess-helm/pull/1372

As a side note the "unsetting" additional config explicitly renders null:
```sh
$ kubectl -n ess logs ess-matrix-authentication-service-59d697d595-ztz88 render-config 
Rendering config to file: /conf/mas-config.yaml
...
experimental:
    session_limit: null
...
```