### PR TITLE
Allow customizing the well-known delegation response headers

### DIFF
--- a/charts/matrix-stack/configs/well-known/partial-haproxy.cfg.tpl
+++ b/charts/matrix-stack/configs/well-known/partial-haproxy.cfg.tpl
@@ -1,6 +1,6 @@
 {{- /*
 Copyright 2024-2025 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}

--- a/charts/matrix-stack/configs/well-known/partial-haproxy.cfg.tpl
+++ b/charts/matrix-stack/configs/well-known/partial-haproxy.cfg.tpl
@@ -47,15 +47,9 @@ frontend well-known-in
 backend well-known-static
   mode http
 
-  http-after-response set-header X-Frame-Options SAMEORIGIN
-  http-after-response set-header X-Content-Type-Options nosniff
-  http-after-response set-header X-XSS-Protection "1; mode=block"
-  http-after-response set-header Content-Security-Policy "frame-ancestors 'self'"
-  http-after-response set-header X-Robots-Tag "noindex, nofollow, noarchive, noimageindex"
-
-  http-after-response set-header Access-Control-Allow-Origin *
-  http-after-response set-header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS"
-  http-after-response set-header Access-Control-Allow-Headers "X-Requested-With, Content-Type, Authorization"
+{{- range $name, $value := .headers }}
+  http-after-response set-header {{ $name }} {{ $value | quote }}
+{{- end }}
 
   http-request return status 200 content-type "application/json" file "/well-known/server" if { path /.well-known/matrix/server }
   http-request return status 200 content-type "application/json" file "/well-known/client" if { path /.well-known/matrix/client }

--- a/charts/matrix-stack/source/wellKnownDelegation.json
+++ b/charts/matrix-stack/source/wellKnownDelegation.json
@@ -36,6 +36,12 @@
           "type": "string"
         }
       }
+    },
+    "headers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
     }
   }
 }

--- a/charts/matrix-stack/source/wellKnownDelegation.yaml.j2
+++ b/charts/matrix-stack/source/wellKnownDelegation.yaml.j2
@@ -1,6 +1,6 @@
 {#
 Copyright 2024-2025 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 #}

--- a/charts/matrix-stack/source/wellKnownDelegation.yaml.j2
+++ b/charts/matrix-stack/source/wellKnownDelegation.yaml.j2
@@ -24,3 +24,17 @@ additional:
   client: "{}"
   server: "{}"
   support: "{}"
+
+## Headers to return on the /.well-known/matrix/* responses
+## Additional headers can be added and the default headers can be
+## modified or removed (by setting their value to null)
+headers:
+  Access-Control-Allow-Headers: "X-Requested-With, Content-Type, Authorization"
+  Access-Control-Allow-Methods: "GET, POST, PUT, DELETE, OPTIONS"
+  Access-Control-Allow-Origin: "*"
+  Cache-Control: "public, max-age=3600"
+  Content-Security-Policy: "frame-ancestors 'self'"
+  X-Content-Type-Options: "nosniff"
+  X-Frame-Options: "SAMEORIGIN"
+  X-Robots-Tag: "noindex, nofollow, noarchive, noimageindex"
+  X-XSS-Protection: "1; mode=block"

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -27283,6 +27283,12 @@
             }
           },
           "additionalProperties": false
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -5709,3 +5709,17 @@ wellKnownDelegation:
     client: "{}"
     server: "{}"
     support: "{}"
+
+  ## Headers to return on the /.well-known/matrix/* responses
+  ## Additional headers can be added and the default headers can be
+  ## modified or removed (by setting their value to null)
+  headers:
+    Access-Control-Allow-Headers: "X-Requested-With, Content-Type, Authorization"
+    Access-Control-Allow-Methods: "GET, POST, PUT, DELETE, OPTIONS"
+    Access-Control-Allow-Origin: "*"
+    Cache-Control: "public, max-age=3600"
+    Content-Security-Policy: "frame-ancestors 'self'"
+    X-Content-Type-Options: "nosniff"
+    X-Frame-Options: "SAMEORIGIN"
+    X-Robots-Tag: "noindex, nofollow, noarchive, noimageindex"
+    X-XSS-Protection: "1; mode=block"

--- a/newsfragments/1452.added.md
+++ b/newsfragments/1452.added.md
@@ -1,0 +1,1 @@
+Allow customising the response headers of the `/.well-known/matrix/*` endpoints via `wellKnownDelegation.headers`. The well-known responses now return `Cache-Control: public, max-age=3600` by default.


### PR DESCRIPTION
Closes [#1450](https://github.com/element-hq/ess-helm/issues/1450), implementing what was proposed in https://github.com/element-hq/ess-helm/issues/1450#issuecomment-4955761438.

Adds wellKnownDelegation.headers, applied to all /.well-known/matrix/* responses.
Defaults to the previously hardcoded headers plus Cache-Control: "public, max-age=3600".
Entries can be modified, added, or removed (key: null).

Default render matches the previous output (plus Cache-Control); modify/add/remove verified