### PR TITLE
fix MAS pointing to Synapse main

### DIFF
--- a/charts/matrix-stack/configs/hookshot/config-override.yaml.tpl
+++ b/charts/matrix-stack/configs/hookshot/config-override.yaml.tpl
@@ -10,7 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 bridge:
   domain: "{{ tpl $root.Values.serverName $root }}"
 {{- if $root.Values.synapse.enabled }}
-  url: "http://{{ include "element-io.synapse.internal-hostport" (dict "root" $root "context" (dict "targetProcessType" "")) }}"
+  url: "http://{{ include "element-io.synapse.internal-hostport" (dict "root" $root) }}"
 {{- end }}
   port: 9993
   {{- /* We can only bind to 1 and so in the dual-stack case we bind :: and rely on the lack of IPV6_V6ONLY on the socket options */}}

--- a/charts/matrix-stack/configs/matrix-authentication-service/config-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/matrix-authentication-service/config-overrides.yaml.tpl
@@ -82,7 +82,7 @@ matrix:
                         "defaultSecretKey" "SYNAPSE_SHARED_SECRET"
                       )
                   ) }}
-  endpoint: "http://{{ include "element-io.synapse.internal-hostport" (dict "root" $root "context" (dict "targetProcessType" "main")) }}"
+  endpoint: "http://{{ include "element-io.synapse.internal-hostport" (dict "root" $root "context" (dict "targetProcessType" "")) }}"
 {{- /* When in syn2mas dryRun mode, migration has not run yet
 We don't want MAS to change data in Synapse
 */}}

--- a/charts/matrix-stack/configs/matrix-authentication-service/config-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/matrix-authentication-service/config-overrides.yaml.tpl
@@ -82,7 +82,7 @@ matrix:
                         "defaultSecretKey" "SYNAPSE_SHARED_SECRET"
                       )
                   ) }}
-  endpoint: "http://{{ include "element-io.synapse.internal-hostport" (dict "root" $root "context" (dict "targetProcessType" "")) }}"
+  endpoint: "http://{{ include "element-io.synapse.internal-hostport" (dict "root" $root) }}"
 {{- /* When in syn2mas dryRun mode, migration has not run yet
 We don't want MAS to change data in Synapse
 */}}

--- a/charts/matrix-stack/templates/hookshot/hookshot_statefulset.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_statefulset.yaml
@@ -66,7 +66,7 @@ spec:
         args:
         - tcpwait
         - -address
-        - "{{ include "element-io.synapse.internal-hostport" (dict "root" $ "context" (dict "targetProcessType" "")) }}"
+        - "{{ include "element-io.synapse.internal-hostport" (dict "root" $) }}"
 {{- with .resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/charts/matrix-stack/templates/synapse/_helpers.tpl
+++ b/charts/matrix-stack/templates/synapse/_helpers.tpl
@@ -326,11 +326,5 @@ ess-version.json: |
 
 {{- define "element-io.synapse.internal-hostport" -}}
 {{- $root := .root -}}
-{{- with required "element-io.synapse.internal-hostport missing context" .context -}}
-{{- $root.Release.Name }}-synapse
-{{- with .targetProcessType -}}
--{{ . }}
-{{- end -}}
-.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}:8008
-{{- end -}}
+{{- $root.Release.Name }}-synapse.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}:8008
 {{- end -}}

--- a/newsfragments/1456.changed.md
+++ b/newsfragments/1456.changed.md
@@ -1,0 +1,1 @@
+Configure Matrix Authentication Service to communicate with any Synapse worker, not only the main process.


### PR DESCRIPTION
Nowadays the `mas-helper` worker exists, and we should profit from it.