### PR TITLE
Allow selecting the downward API field for the SFU NODE_IP

### DIFF
--- a/charts/matrix-stack/ci/fragments/matrix-rtc-pod-ip.yaml
+++ b/charts/matrix-stack/ci/fragments/matrix-rtc-pod-ip.yaml
@@ -1,0 +1,8 @@
+# Copyright 2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+matrixRTC:
+  sfu:
+    useStunToDiscoverPublicIP: false
+    nodeIPSource: podIP

--- a/charts/matrix-stack/ci/matrix-rtc-no-stun-pod-ip-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-no-stun-pod-ip-values.yaml
@@ -1,0 +1,26 @@
+# Copyright 2025-2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# source_fragments: matrix-rtc-minimal.yaml matrix-rtc-pod-ip.yaml
+# DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
+
+# initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
+elementAdmin:
+  enabled: false
+elementWeb:
+  enabled: false
+matrixAuthenticationService:
+  enabled: false
+matrixRTC:
+  ingress:
+    host: mrtc.ess.localhost
+  sfu:
+    nodeIPSource: podIP
+    useStunToDiscoverPublicIP: false
+synapse:
+  enabled: false
+wellKnownDelegation:
+  enabled: false

--- a/charts/matrix-stack/source/matrix-rtc.json
+++ b/charts/matrix-stack/source/matrix-rtc.json
@@ -158,6 +158,13 @@
         "manualIP": {
           "type": "string"
         },
+        "nodeIPSource": {
+          "type": "string",
+          "enum": [
+            "hostIP",
+            "podIP"
+          ]
+        },
         "additional": {
           "$ref": "file://common/additional.json"
         },

--- a/charts/matrix-stack/source/matrix-rtc.yaml.j2
+++ b/charts/matrix-stack/source/matrix-rtc.yaml.j2
@@ -55,6 +55,11 @@ sfu:
   # Specify a manual IP address for the server public IP
   manualIP: ""
 
+  # The Kubernetes downward API field used to populate the server public IP
+  # when useStunToDiscoverPublicIP is false and manualIP is empty
+  # Valid values: hostIP, podIP
+  nodeIPSource: hostIP
+
   # LiveKit Logging level
   logging:
     # log level, valid values: debug, info, warn, error

--- a/charts/matrix-stack/templates/matrix-rtc/_sfu_helpers.tpl
+++ b/charts/matrix-stack/templates/matrix-rtc/_sfu_helpers.tpl
@@ -32,7 +32,7 @@ env:
 - name: NODE_IP
   valueFrom:
     fieldRef:
-      fieldPath: status.hostIP
+      fieldPath: status.{{ $root.Values.matrixRTC.sfu.nodeIPSource }}
 {{- end }}
 - name: "LIVEKIT_KEY"
   value: "{{ ($root.Values.matrixRTC.livekitAuth).key | default "matrix-rtc" }}"

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -5308,6 +5308,13 @@
             "manualIP": {
               "type": "string"
             },
+            "nodeIPSource": {
+              "type": "string",
+              "enum": [
+                "hostIP",
+                "podIP"
+              ]
+            },
             "additional": {
               "type": "object",
               "additionalProperties": {

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -843,6 +843,11 @@ matrixRTC:
     # Specify a manual IP address for the server public IP
     manualIP: ""
 
+    # The Kubernetes downward API field used to populate the server public IP
+    # when useStunToDiscoverPublicIP is false and manualIP is empty
+    # Valid values: hostIP, podIP
+    nodeIPSource: hostIP
+
     # LiveKit Logging level
     logging:
       # log level, valid values: debug, info, warn, error

--- a/newsfragments/1460.added.md
+++ b/newsfragments/1460.added.md
@@ -1,0 +1,1 @@
+Add `matrixRTC.sfu.nodeIPSource` to select which Kubernetes downward API field populates the SFU public IP (`NODE_IP`) when `useStunToDiscoverPublicIP` is `false` and no `manualIP` is provided. Valid values: `hostIP` (default, previous behaviour) and `podIP`.


### PR DESCRIPTION
Closes https://github.com/element-hq/ess-helm/issues/1449, implemeting what was suggested by https://github.com/element-hq/ess-helm/issues/1449#issuecomment-4955839906

Adds matrixRTC.sfu.nodeIPSource, selecting the downward API field that populates NODE_IP when useStunToDiscoverPublicIP is false and no manualIP is provided.

Setting it to podIP makes the chart compatible with private clusters running a media gateway (e.g. [STUNner](https://github.com/l7mp/stunner)) in front of LiveKit.

Default render is unchanged (status.hostIP).

Adds a chart-testing case for the podIP variant

