### PR TITLE
Add schedulerName and runtimeClassName support to component workloads

### DIFF
--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -46,6 +46,8 @@ image:
 {{ tolerations(global=true) }}
 {{ topologySpreadConstraints(global=true) }}
 {{ priorityClassName(global=true) }}
+{{ schedulerName(global=true) }}
+{{ runtimeClassName(global=true) }}
 {{ affinity(global=true) }}
 
 ## The cluster's domain name which will be appended to URLs of internal Services (<name>.<namespace>.svc.<clusterDomain>).
@@ -228,6 +230,32 @@ networking:
 ## "system-cluster-critical" and "system-node-critical" are two special built-in classes indicating the highest priorities.
 ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
 ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+{{ key }}: ""
+{%- endmacro %}
+
+{% macro schedulerName(global=false, key='schedulerName') %}
+{%- if global %}
+## Default schedulerName applied to the pods of all components.
+## A schedulerName set on an individual component overrides this global value for that component.
+## Synapse worker pods inherit the schedulerName of the Synapse main process; per-worker schedulerName is not yet configurable.
+{%- else %}
+## If specified, the pod will be dispatched by the specified scheduler.
+{%- endif %}
+## If not specified, the pod will be dispatched by the default scheduler.
+## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+{{ key }}: ""
+{%- endmacro %}
+
+{% macro runtimeClassName(global=false, key='runtimeClassName') %}
+{%- if global %}
+## Default runtimeClassName applied to the pods of all components.
+## A runtimeClassName set on an individual component overrides this global value for that component.
+## Synapse worker pods inherit the runtimeClassName of the Synapse main process; per-worker runtimeClassName is not yet configurable.
+{%- else %}
+## If specified, refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.
+{%- endif %}
+## If not set or empty, the default RuntimeClass is used, which is equivalent to the behavior when this feature is disabled.
+## More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
 {{ key }}: ""
 {%- endmacro %}
 

--- a/charts/matrix-stack/source/deployment-markers.json
+++ b/charts/matrix-stack/source/deployment-markers.json
@@ -41,6 +41,12 @@
     "priorityClassName": {
       "type": "string"
     },
+    "schedulerName": {
+      "type": "string"
+    },
+    "runtimeClassName": {
+      "type": "string"
+    },
     "affinity": {
       "$ref": "file://common/affinity.json"
     },

--- a/charts/matrix-stack/source/deployment-markers.yaml.j2
+++ b/charts/matrix-stack/source/deployment-markers.yaml.j2
@@ -20,6 +20,8 @@ rbac:
 {{- sub_schema_values.extraInitContainers("Deployment Markers") }}
 {{- sub_schema_values.nodeSelector() -}}
 {{- sub_schema_values.priorityClassName() -}}
+{{- sub_schema_values.schedulerName() -}}
+{{- sub_schema_values.runtimeClassName() -}}
 {{- sub_schema_values.affinity() -}}
 {{- sub_schema_values.podSecurityContext(user_id='10010', group_id='10010') -}}
 {{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='200Mi') -}}

--- a/charts/matrix-stack/source/element-admin.json
+++ b/charts/matrix-stack/source/element-admin.json
@@ -43,6 +43,12 @@
     "priorityClassName": {
       "type": "string"
     },
+    "schedulerName": {
+      "type": "string"
+    },
+    "runtimeClassName": {
+      "type": "string"
+    },
     "affinity": {
       "$ref": "file://common/affinity.json"
     },

--- a/charts/matrix-stack/source/element-admin.yaml.j2
+++ b/charts/matrix-stack/source/element-admin.yaml.j2
@@ -23,6 +23,8 @@ replicas: 1
 {{- sub_schema_values.containersSecurityContext() -}}
 {{- sub_schema_values.nodeSelector() -}}
 {{- sub_schema_values.priorityClassName() -}}
+{{- sub_schema_values.schedulerName() -}}
+{{- sub_schema_values.runtimeClassName() -}}
 {{- sub_schema_values.affinity() -}}
 {{- sub_schema_values.podSecurityContext(user_id='10104', group_id='10104') -}}
 {{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='200Mi') -}}

--- a/charts/matrix-stack/source/element-web.json
+++ b/charts/matrix-stack/source/element-web.json
@@ -49,6 +49,12 @@
     "priorityClassName": {
       "type": "string"
     },
+    "schedulerName": {
+      "type": "string"
+    },
+    "runtimeClassName": {
+      "type": "string"
+    },
     "affinity": {
       "$ref": "file://common/affinity.json"
     },

--- a/charts/matrix-stack/source/element-web.yaml.j2
+++ b/charts/matrix-stack/source/element-web.yaml.j2
@@ -31,6 +31,8 @@ replicas: 1
 {{- sub_schema_values.containersSecurityContext() -}}
 {{- sub_schema_values.nodeSelector() -}}
 {{- sub_schema_values.priorityClassName() -}}
+{{- sub_schema_values.schedulerName() -}}
+{{- sub_schema_values.runtimeClassName() -}}
 {{- sub_schema_values.affinity() -}}
 {{- sub_schema_values.podSecurityContext(user_id='10004', group_id='10004') -}}
 {{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='200Mi') -}}

--- a/charts/matrix-stack/source/haproxy.json
+++ b/charts/matrix-stack/source/haproxy.json
@@ -37,6 +37,12 @@
     "priorityClassName": {
       "type": "string"
     },
+    "schedulerName": {
+      "type": "string"
+    },
+    "runtimeClassName": {
+      "type": "string"
+    },
     "affinity": {
       "$ref": "file://common/affinity.json"
     },

--- a/charts/matrix-stack/source/haproxy.yaml.j2
+++ b/charts/matrix-stack/source/haproxy.yaml.j2
@@ -18,6 +18,8 @@ replicas: 1
 {{- sub_schema_values.extraInitContainers("HAProxy") }}
 {{- sub_schema_values.nodeSelector() }}
 {{- sub_schema_values.priorityClassName() }}
+{{- sub_schema_values.schedulerName() }}
+{{- sub_schema_values.runtimeClassName() }}
 {{- sub_schema_values.affinity() }}
 {{- sub_schema_values.podSecurityContext(user_id='10001', group_id='10001') }}
 {{- sub_schema_values.resources(requests_memory='100Mi', requests_cpu='100m', limits_memory='200Mi') }}

--- a/charts/matrix-stack/source/hookshot.json
+++ b/charts/matrix-stack/source/hookshot.json
@@ -92,6 +92,12 @@
     "priorityClassName": {
       "type": "string"
     },
+    "schedulerName": {
+      "type": "string"
+    },
+    "runtimeClassName": {
+      "type": "string"
+    },
     "affinity": {
       "$ref": "file://common/affinity.json"
     },

--- a/charts/matrix-stack/source/hookshot.yaml.j2
+++ b/charts/matrix-stack/source/hookshot.yaml.j2
@@ -42,6 +42,8 @@ replicas: 1
 {{ sub_schema_values.serviceAccount() }}
 {{ sub_schema_values.nodeSelector() }}
 {{- sub_schema_values.priorityClassName() }}
+{{- sub_schema_values.schedulerName() }}
+{{- sub_schema_values.runtimeClassName() }}
 {{- sub_schema_values.affinity() }}
 {{ sub_schema_values.tolerations() }}
 {{ sub_schema_values.topologySpreadConstraints() }}

--- a/charts/matrix-stack/source/init-secrets.json
+++ b/charts/matrix-stack/source/init-secrets.json
@@ -41,6 +41,12 @@
     "priorityClassName": {
       "type": "string"
     },
+    "schedulerName": {
+      "type": "string"
+    },
+    "runtimeClassName": {
+      "type": "string"
+    },
     "affinity": {
       "$ref": "file://common/affinity.json"
     },

--- a/charts/matrix-stack/source/init-secrets.yaml.j2
+++ b/charts/matrix-stack/source/init-secrets.yaml.j2
@@ -20,6 +20,8 @@ rbac:
 {{- sub_schema_values.extraInitContainers("Init Secrets") }}
 {{- sub_schema_values.nodeSelector() -}}
 {{- sub_schema_values.priorityClassName() -}}
+{{- sub_schema_values.schedulerName() -}}
+{{- sub_schema_values.runtimeClassName() -}}
 {{- sub_schema_values.affinity() -}}
 {{- sub_schema_values.podSecurityContext(user_id='10010', group_id='10010') -}}
 {{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='200Mi') -}}

--- a/charts/matrix-stack/source/matrix-rtc.json
+++ b/charts/matrix-stack/source/matrix-rtc.json
@@ -90,6 +90,12 @@
     "priorityClassName": {
       "type": "string"
     },
+    "schedulerName": {
+      "type": "string"
+    },
+    "runtimeClassName": {
+      "type": "string"
+    },
     "affinity": {
       "$ref": "file://common/affinity.json"
     },
@@ -221,6 +227,12 @@
           "$ref": "file://common/nodeSelector.json"
         },
         "priorityClassName": {
+          "type": "string"
+        },
+        "schedulerName": {
+          "type": "string"
+        },
+        "runtimeClassName": {
           "type": "string"
         },
         "affinity": {

--- a/charts/matrix-stack/source/matrix-rtc.yaml.j2
+++ b/charts/matrix-stack/source/matrix-rtc.yaml.j2
@@ -35,6 +35,8 @@ replicas: 1
 {{- sub_schema_values.extraInitContainers("Matrix RTC") }}
 {{- sub_schema_values.nodeSelector() }}
 {{- sub_schema_values.priorityClassName() }}
+{{- sub_schema_values.schedulerName() }}
+{{- sub_schema_values.runtimeClassName() }}
 {{- sub_schema_values.affinity() }}
 {{- sub_schema_values.podSecurityContext(user_id='10033', group_id='10033') }}
 {{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='200Mi') }}
@@ -98,6 +100,8 @@ sfu:
 {{- sub_schema_values.containersSecurityContext() | indent(2) }}
 {{- sub_schema_values.nodeSelector() | indent(2) }}
 {{- sub_schema_values.priorityClassName() | indent(2) }}
+{{- sub_schema_values.schedulerName() | indent(2) }}
+{{- sub_schema_values.runtimeClassName() | indent(2) }}
 {{- sub_schema_values.affinity() | indent(2) }}
 {{- sub_schema_values.podSecurityContext(user_id='10030', group_id='10030') | indent(2) }}
 {{- sub_schema_values.resources(requests_memory='150Mi', requests_cpu='100m', limits_memory='4Gi') | indent(2) }}

--- a/charts/matrix-stack/source/matrixAuthenticationService.json
+++ b/charts/matrix-stack/source/matrixAuthenticationService.json
@@ -83,6 +83,12 @@
         "priorityClassName": {
           "type": "string"
         },
+        "schedulerName": {
+          "type": "string"
+        },
+        "runtimeClassName": {
+          "type": "string"
+        },
         "affinity": {
           "$ref": "file://common/affinity.json"
         },
@@ -137,6 +143,12 @@
       "$ref": "file://common/nodeSelector.json"
     },
     "priorityClassName": {
+      "type": "string"
+    },
+    "schedulerName": {
+      "type": "string"
+    },
+    "runtimeClassName": {
       "type": "string"
     },
     "affinity": {

--- a/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
+++ b/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
@@ -32,6 +32,8 @@ privateKeys: {}
 {{ sub_schema_values.serviceAccount() }}
 {{ sub_schema_values.nodeSelector() }}
 {{- sub_schema_values.priorityClassName() }}
+{{- sub_schema_values.schedulerName() }}
+{{- sub_schema_values.runtimeClassName() }}
 {{- sub_schema_values.affinity() }}
 {{ sub_schema_values.tolerations() }}
 {{ sub_schema_values.hostAliases() }}
@@ -71,6 +73,8 @@ syn2mas:
   {{- sub_schema_values.containersSecurityContext() | indent(2) -}}
   {{- sub_schema_values.nodeSelector() | indent(2) -}}
   {{- sub_schema_values.priorityClassName() | indent(2) -}}
+  {{- sub_schema_values.schedulerName() | indent(2) -}}
+  {{- sub_schema_values.runtimeClassName() | indent(2) -}}
   {{- sub_schema_values.affinity() | indent(2) -}}
   {{- sub_schema_values.podSecurityContext(user_id='10005', group_id='10005') | indent(2) -}}
   {{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='350Mi') | indent(2) -}}

--- a/charts/matrix-stack/source/postgres.json
+++ b/charts/matrix-stack/source/postgres.json
@@ -90,6 +90,12 @@
     "priorityClassName": {
       "type": "string"
     },
+    "schedulerName": {
+      "type": "string"
+    },
+    "runtimeClassName": {
+      "type": "string"
+    },
     "affinity": {
       "$ref": "file://common/affinity.json"
     },

--- a/charts/matrix-stack/source/postgres.yaml.j2
+++ b/charts/matrix-stack/source/postgres.yaml.j2
@@ -36,6 +36,8 @@ essPasswords: {}
 {{- sub_schema_values.containersSecurityContext() }}
 {{- sub_schema_values.nodeSelector() }}
 {{- sub_schema_values.priorityClassName() }}
+{{- sub_schema_values.schedulerName() }}
+{{- sub_schema_values.runtimeClassName() }}
 {{- sub_schema_values.affinity() }}
 {{- sub_schema_values.podSecurityContext(user_id='10091', group_id='10091') }}
 {{- sub_schema_values.resources(requests_memory='100Mi', requests_cpu='100m', limits_memory='4Gi') }}

--- a/charts/matrix-stack/source/redis.json
+++ b/charts/matrix-stack/source/redis.json
@@ -54,6 +54,12 @@
     "priorityClassName": {
       "type": "string"
     },
+    "schedulerName": {
+      "type": "string"
+    },
+    "runtimeClassName": {
+      "type": "string"
+    },
     "affinity": {
       "$ref": "file://common/affinity.json"
     },

--- a/charts/matrix-stack/source/redis.yaml.j2
+++ b/charts/matrix-stack/source/redis.yaml.j2
@@ -22,6 +22,8 @@ replicas: 1
 {{- sub_schema_values.extraInitContainers("Redis") }}
 {{- sub_schema_values.nodeSelector() }}
 {{- sub_schema_values.priorityClassName() }}
+{{- sub_schema_values.schedulerName() }}
+{{- sub_schema_values.runtimeClassName() }}
 {{- sub_schema_values.affinity() }}
 {{- sub_schema_values.podSecurityContext(user_id='10002', group_id='10002') }}
 {{- sub_schema_values.resources(requests_memory='50Mi', requests_cpu='50m', limits_memory='50Mi') }}

--- a/charts/matrix-stack/source/synapse.json
+++ b/charts/matrix-stack/source/synapse.json
@@ -168,6 +168,12 @@
     "priorityClassName": {
       "type": "string"
     },
+    "schedulerName": {
+      "type": "string"
+    },
+    "runtimeClassName": {
+      "type": "string"
+    },
     "affinity": {
       "$ref": "file://common/affinity.json"
     },

--- a/charts/matrix-stack/source/synapse.yaml.j2
+++ b/charts/matrix-stack/source/synapse.yaml.j2
@@ -102,6 +102,8 @@ replicas: 1
 {{- sub_schema_values.hostAliases() }}
 {{- sub_schema_values.nodeSelector() }}
 {{- sub_schema_values.priorityClassName() }}
+{{- sub_schema_values.schedulerName() }}
+{{- sub_schema_values.runtimeClassName() }}
 {{- sub_schema_values.affinity() }}
 {{- sub_schema_values.podSecurityContext(user_id='10091', group_id='10091') }}
 {{- sub_schema_values.resources(requests_memory='100Mi', requests_cpu='100m', limits_memory='4Gi') }}

--- a/charts/matrix-stack/source/values.schema.json
+++ b/charts/matrix-stack/source/values.schema.json
@@ -91,6 +91,12 @@
     "priorityClassName": {
       "type": "string"
     },
+    "schedulerName": {
+      "type": "string"
+    },
+    "runtimeClassName": {
+      "type": "string"
+    },
     "affinity": {
       "$ref": "file://common/affinity.json"
     },

--- a/charts/matrix-stack/templates/ess-library/_pods.tpl
+++ b/charts/matrix-stack/templates/ess-library/_pods.tpl
@@ -31,6 +31,12 @@ nodeSelector:
 {{- with (coalesce .priorityClassName $root.Values.priorityClassName) }}
 priorityClassName: {{ . }}
 {{- end }}
+{{- with (coalesce .schedulerName $root.Values.schedulerName) }}
+schedulerName: {{ . }}
+{{- end }}
+{{- with (coalesce .runtimeClassName $root.Values.runtimeClassName) }}
+runtimeClassName: {{ . }}
+{{- end }}
 {{- include "element-io.ess-library.pods.affinity" (dict "root" $root "context" (dict "affinity" .affinity)) }}
 restartPolicy: {{ (eq $kind "Job") | ternary "Never" "Always" }}
 {{- include "element-io.ess-library.pods.tolerations" (dict "root" $root "context" .tolerations) }}

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -375,6 +375,12 @@
     "priorityClassName": {
       "type": "string"
     },
+    "schedulerName": {
+      "type": "string"
+    },
+    "runtimeClassName": {
+      "type": "string"
+    },
     "affinity": {
       "type": "object",
       "properties": {
@@ -1322,6 +1328,12 @@
           }
         },
         "priorityClassName": {
+          "type": "string"
+        },
+        "schedulerName": {
+          "type": "string"
+        },
+        "runtimeClassName": {
           "type": "string"
         },
         "affinity": {
@@ -2507,6 +2519,12 @@
           }
         },
         "priorityClassName": {
+          "type": "string"
+        },
+        "schedulerName": {
+          "type": "string"
+        },
+        "runtimeClassName": {
           "type": "string"
         },
         "affinity": {
@@ -3979,6 +3997,12 @@
           }
         },
         "priorityClassName": {
+          "type": "string"
+        },
+        "schedulerName": {
+          "type": "string"
+        },
+        "runtimeClassName": {
           "type": "string"
         },
         "affinity": {
@@ -5739,6 +5763,12 @@
             "priorityClassName": {
               "type": "string"
             },
+            "schedulerName": {
+              "type": "string"
+            },
+            "runtimeClassName": {
+              "type": "string"
+            },
             "affinity": {
               "type": "object",
               "properties": {
@@ -7205,6 +7235,12 @@
         "priorityClassName": {
           "type": "string"
         },
+        "schedulerName": {
+          "type": "string"
+        },
+        "runtimeClassName": {
+          "type": "string"
+        },
         "affinity": {
           "type": "object",
           "properties": {
@@ -8665,6 +8701,12 @@
         "priorityClassName": {
           "type": "string"
         },
+        "schedulerName": {
+          "type": "string"
+        },
+        "runtimeClassName": {
+          "type": "string"
+        },
         "affinity": {
           "type": "object",
           "properties": {
@@ -10038,6 +10080,12 @@
           }
         },
         "priorityClassName": {
+          "type": "string"
+        },
+        "schedulerName": {
+          "type": "string"
+        },
+        "runtimeClassName": {
           "type": "string"
         },
         "affinity": {
@@ -11817,6 +11865,12 @@
         "priorityClassName": {
           "type": "string"
         },
+        "schedulerName": {
+          "type": "string"
+        },
+        "runtimeClassName": {
+          "type": "string"
+        },
         "affinity": {
           "type": "object",
           "properties": {
@@ -13576,6 +13630,12 @@
             "priorityClassName": {
               "type": "string"
             },
+            "schedulerName": {
+              "type": "string"
+            },
+            "runtimeClassName": {
+              "type": "string"
+            },
             "affinity": {
               "type": "object",
               "properties": {
@@ -14911,6 +14971,12 @@
           }
         },
         "priorityClassName": {
+          "type": "string"
+        },
+        "schedulerName": {
+          "type": "string"
+        },
+        "runtimeClassName": {
           "type": "string"
         },
         "affinity": {
@@ -16856,6 +16922,12 @@
         "priorityClassName": {
           "type": "string"
         },
+        "schedulerName": {
+          "type": "string"
+        },
+        "runtimeClassName": {
+          "type": "string"
+        },
         "affinity": {
           "type": "object",
           "properties": {
@@ -18255,6 +18327,12 @@
           }
         },
         "priorityClassName": {
+          "type": "string"
+        },
+        "schedulerName": {
+          "type": "string"
+        },
+        "runtimeClassName": {
           "type": "string"
         },
         "affinity": {
@@ -20638,6 +20716,12 @@
           }
         },
         "priorityClassName": {
+          "type": "string"
+        },
+        "schedulerName": {
+          "type": "string"
+        },
+        "runtimeClassName": {
           "type": "string"
         },
         "affinity": {

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -144,6 +144,20 @@ topologySpreadConstraints:
 ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
 priorityClassName: ""
 
+## Default schedulerName applied to the pods of all components.
+## A schedulerName set on an individual component overrides this global value for that component.
+## Synapse worker pods inherit the schedulerName of the Synapse main process; per-worker schedulerName is not yet configurable.
+## If not specified, the pod will be dispatched by the default scheduler.
+## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+schedulerName: ""
+
+## Default runtimeClassName applied to the pods of all components.
+## A runtimeClassName set on an individual component overrides this global value for that component.
+## Synapse worker pods inherit the runtimeClassName of the Synapse main process; per-worker runtimeClassName is not yet configurable.
+## If not set or empty, the default RuntimeClass is used, which is equivalent to the behavior when this feature is disabled.
+## More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
+runtimeClassName: ""
+
 ## Default affinity rules applied to the pods of all components.
 ## Configured independently per affinity type (nodeAffinity, podAffinity, podAntiAffinity).
 ## A component that sets one of these affinity types overrides only that type for that component; the other types are still inherited from here.
@@ -248,6 +262,14 @@ initSecrets:
   ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
   ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
   priorityClassName: ""
+  ## If specified, the pod will be dispatched by the specified scheduler.
+  ## If not specified, the pod will be dispatched by the default scheduler.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+  schedulerName: ""
+  ## If specified, refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.
+  ## If not set or empty, the default RuntimeClass is used, which is equivalent to the behavior when this feature is disabled.
+  ## More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
+  runtimeClassName: ""
   ## If specified, the pod's scheduling constraints, configured independently per affinity type.
   ## Each affinity type set here overrides only the matching global affinity type for this component; the other types are still inherited from the global affinity.
   ## A type is inherited from the global affinity while left unset here; set a type to {} to blank out the inherited global value for that type, e.g.:
@@ -411,6 +433,14 @@ deploymentMarkers:
   ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
   ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
   priorityClassName: ""
+  ## If specified, the pod will be dispatched by the specified scheduler.
+  ## If not specified, the pod will be dispatched by the default scheduler.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+  schedulerName: ""
+  ## If specified, refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.
+  ## If not set or empty, the default RuntimeClass is used, which is equivalent to the behavior when this feature is disabled.
+  ## More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
+  runtimeClassName: ""
   ## If specified, the pod's scheduling constraints, configured independently per affinity type.
   ## Each affinity type set here overrides only the matching global affinity type for this component; the other types are still inherited from the global affinity.
   ## A type is inherited from the global affinity while left unset here; set a type to {} to blank out the inherited global value for that type, e.g.:
@@ -674,6 +704,14 @@ matrixRTC:
   ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
   ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
   priorityClassName: ""
+  ## If specified, the pod will be dispatched by the specified scheduler.
+  ## If not specified, the pod will be dispatched by the default scheduler.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+  schedulerName: ""
+  ## If specified, refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.
+  ## If not set or empty, the default RuntimeClass is used, which is equivalent to the behavior when this feature is disabled.
+  ## More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
+  runtimeClassName: ""
   ## If specified, the pod's scheduling constraints, configured independently per affinity type.
   ## Each affinity type set here overrides only the matching global affinity type for this component; the other types are still inherited from the global affinity.
   ## A type is inherited from the global affinity while left unset here; set a type to {} to blank out the inherited global value for that type, e.g.:
@@ -1069,6 +1107,14 @@ matrixRTC:
     ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
     ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
     priorityClassName: ""
+    ## If specified, the pod will be dispatched by the specified scheduler.
+    ## If not specified, the pod will be dispatched by the default scheduler.
+    ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+    schedulerName: ""
+    ## If specified, refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.
+    ## If not set or empty, the default RuntimeClass is used, which is equivalent to the behavior when this feature is disabled.
+    ## More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
+    runtimeClassName: ""
     ## If specified, the pod's scheduling constraints, configured independently per affinity type.
     ## Each affinity type set here overrides only the matching global affinity type for this component; the other types are still inherited from the global affinity.
     ## A type is inherited from the global affinity while left unset here; set a type to {} to blank out the inherited global value for that type, e.g.:
@@ -1340,6 +1386,14 @@ elementAdmin:
   ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
   ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
   priorityClassName: ""
+  ## If specified, the pod will be dispatched by the specified scheduler.
+  ## If not specified, the pod will be dispatched by the default scheduler.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+  schedulerName: ""
+  ## If specified, refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.
+  ## If not set or empty, the default RuntimeClass is used, which is equivalent to the behavior when this feature is disabled.
+  ## More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
+  runtimeClassName: ""
   ## If specified, the pod's scheduling constraints, configured independently per affinity type.
   ## Each affinity type set here overrides only the matching global affinity type for this component; the other types are still inherited from the global affinity.
   ## A type is inherited from the global affinity while left unset here; set a type to {} to blank out the inherited global value for that type, e.g.:
@@ -1615,6 +1669,14 @@ elementWeb:
   ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
   ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
   priorityClassName: ""
+  ## If specified, the pod will be dispatched by the specified scheduler.
+  ## If not specified, the pod will be dispatched by the default scheduler.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+  schedulerName: ""
+  ## If specified, refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.
+  ## If not set or empty, the default RuntimeClass is used, which is equivalent to the behavior when this feature is disabled.
+  ## More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
+  runtimeClassName: ""
   ## If specified, the pod's scheduling constraints, configured independently per affinity type.
   ## Each affinity type set here overrides only the matching global affinity type for this component; the other types are still inherited from the global affinity.
   ## A type is inherited from the global affinity while left unset here; set a type to {} to blank out the inherited global value for that type, e.g.:
@@ -1849,6 +1911,14 @@ haproxy:
   ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
   ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
   priorityClassName: ""
+  ## If specified, the pod will be dispatched by the specified scheduler.
+  ## If not specified, the pod will be dispatched by the default scheduler.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+  schedulerName: ""
+  ## If specified, refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.
+  ## If not set or empty, the default RuntimeClass is used, which is equivalent to the behavior when this feature is disabled.
+  ## More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
+  runtimeClassName: ""
   ## If specified, the pod's scheduling constraints, configured independently per affinity type.
   ## Each affinity type set here overrides only the matching global affinity type for this component; the other types are still inherited from the global affinity.
   ## A type is inherited from the global affinity while left unset here; set a type to {} to blank out the inherited global value for that type, e.g.:
@@ -2230,6 +2300,14 @@ hookshot:
   ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
   ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
   priorityClassName: ""
+  ## If specified, the pod will be dispatched by the specified scheduler.
+  ## If not specified, the pod will be dispatched by the default scheduler.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+  schedulerName: ""
+  ## If specified, refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.
+  ## If not set or empty, the default RuntimeClass is used, which is equivalent to the behavior when this feature is disabled.
+  ## More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
+  runtimeClassName: ""
   ## If specified, the pod's scheduling constraints, configured independently per affinity type.
   ## Each affinity type set here overrides only the matching global affinity type for this component; the other types are still inherited from the global affinity.
   ## A type is inherited from the global affinity while left unset here; set a type to {} to blank out the inherited global value for that type, e.g.:
@@ -2642,6 +2720,14 @@ matrixAuthenticationService:
   ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
   ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
   priorityClassName: ""
+  ## If specified, the pod will be dispatched by the specified scheduler.
+  ## If not specified, the pod will be dispatched by the default scheduler.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+  schedulerName: ""
+  ## If specified, refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.
+  ## If not set or empty, the default RuntimeClass is used, which is equivalent to the behavior when this feature is disabled.
+  ## More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
+  runtimeClassName: ""
   ## If specified, the pod's scheduling constraints, configured independently per affinity type.
   ## Each affinity type set here overrides only the matching global affinity type for this component; the other types are still inherited from the global affinity.
   ## A type is inherited from the global affinity while left unset here; set a type to {} to blank out the inherited global value for that type, e.g.:
@@ -2926,6 +3012,14 @@ matrixAuthenticationService:
     ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
     ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
     priorityClassName: ""
+    ## If specified, the pod will be dispatched by the specified scheduler.
+    ## If not specified, the pod will be dispatched by the default scheduler.
+    ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+    schedulerName: ""
+    ## If specified, refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.
+    ## If not set or empty, the default RuntimeClass is used, which is equivalent to the behavior when this feature is disabled.
+    ## More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
+    runtimeClassName: ""
     ## If specified, the pod's scheduling constraints, configured independently per affinity type.
     ## Each affinity type set here overrides only the matching global affinity type for this component; the other types are still inherited from the global affinity.
     ## A type is inherited from the global affinity while left unset here; set a type to {} to blank out the inherited global value for that type, e.g.:
@@ -3318,6 +3412,14 @@ postgres:
   ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
   ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
   priorityClassName: ""
+  ## If specified, the pod will be dispatched by the specified scheduler.
+  ## If not specified, the pod will be dispatched by the default scheduler.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+  schedulerName: ""
+  ## If specified, refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.
+  ## If not set or empty, the default RuntimeClass is used, which is equivalent to the behavior when this feature is disabled.
+  ## More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
+  runtimeClassName: ""
   ## If specified, the pod's scheduling constraints, configured independently per affinity type.
   ## Each affinity type set here overrides only the matching global affinity type for this component; the other types are still inherited from the global affinity.
   ## A type is inherited from the global affinity while left unset here; set a type to {} to blank out the inherited global value for that type, e.g.:
@@ -3562,6 +3664,14 @@ redis:
   ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
   ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
   priorityClassName: ""
+  ## If specified, the pod will be dispatched by the specified scheduler.
+  ## If not specified, the pod will be dispatched by the default scheduler.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+  schedulerName: ""
+  ## If specified, refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.
+  ## If not set or empty, the default RuntimeClass is used, which is equivalent to the behavior when this feature is disabled.
+  ## More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
+  runtimeClassName: ""
   ## If specified, the pod's scheduling constraints, configured independently per affinity type.
   ## Each affinity type set here overrides only the matching global affinity type for this component; the other types are still inherited from the global affinity.
   ## A type is inherited from the global affinity while left unset here; set a type to {} to blank out the inherited global value for that type, e.g.:
@@ -5500,6 +5610,14 @@ synapse:
   ## If not set (empty), the pod's priority defaults to the cluster's globalDefault PriorityClass or zero.
   ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
   priorityClassName: ""
+  ## If specified, the pod will be dispatched by the specified scheduler.
+  ## If not specified, the pod will be dispatched by the default scheduler.
+  ## More info: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+  schedulerName: ""
+  ## If specified, refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.
+  ## If not set or empty, the default RuntimeClass is used, which is equivalent to the behavior when this feature is disabled.
+  ## More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
+  runtimeClassName: ""
   ## If specified, the pod's scheduling constraints, configured independently per affinity type.
   ## Each affinity type set here overrides only the matching global affinity type for this component; the other types are still inherited from the global affinity.
   ## A type is inherited from the global affinity while left unset here; set a type to {} to blank out the inherited global value for that type, e.g.:

--- a/newsfragments/1461.added.md
+++ b/newsfragments/1461.added.md
@@ -1,0 +1,1 @@
+Add support for configuring `schedulerName` and `runtimeClassName` on component workloads, along with global `schedulerName` and `runtimeClassName` values applied to all components (a per-component value overrides the global one).

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -27,6 +27,8 @@ class PropertyType(Enum):
     PodSecurityContext = "podSecurityContext"
     Postgres = "postgres"
     PriorityClassName = "priorityClassName"
+    RuntimeClassName = "runtimeClassName"
+    SchedulerName = "schedulerName"
     Replicas = "replicas"
     ReadinessProbe = "readinessProbe"
     Resources = "resources"
@@ -258,6 +260,8 @@ class SidecarDetails(DeployableDetails):
             PropertyType.NodeSelector: ValuesFilePath.not_supported(),
             PropertyType.PodSecurityContext: ValuesFilePath.not_supported(),
             PropertyType.PriorityClassName: ValuesFilePath.not_supported(),
+            PropertyType.RuntimeClassName: ValuesFilePath.not_supported(),
+            PropertyType.SchedulerName: ValuesFilePath.not_supported(),
             PropertyType.ServiceAccount: ValuesFilePath.not_supported(),
             PropertyType.Tolerations: ValuesFilePath.not_supported(),
             PropertyType.TopologySpreadConstraints: ValuesFilePath.not_supported(),
@@ -387,6 +391,8 @@ def make_synapse_worker_sub_component(worker_name: str, worker_type: str) -> Sub
         PropertyType.NodeSelector: ValuesFilePath.read_elsewhere("synapse", "nodeSelector"),
         PropertyType.PodSecurityContext: ValuesFilePath.read_elsewhere("synapse", "podSecurityContext"),
         PropertyType.PriorityClassName: ValuesFilePath.read_elsewhere("synapse", "priorityClassName"),
+        PropertyType.RuntimeClassName: ValuesFilePath.read_elsewhere("synapse", "runtimeClassName"),
+        PropertyType.SchedulerName: ValuesFilePath.read_elsewhere("synapse", "schedulerName"),
         PropertyType.ServiceAccount: ValuesFilePath.read_elsewhere("synapse", "serviceAccount"),
         PropertyType.ServiceMonitor: ValuesFilePath.read_elsewhere("synapse", "serviceMonitor"),
         PropertyType.Tolerations: ValuesFilePath.read_elsewhere("synapse", "tolerations"),
@@ -708,6 +714,8 @@ all_components_details = [
                     PropertyType.NodeSelector: ValuesFilePath.read_elsewhere("synapse", "nodeSelector"),
                     PropertyType.PodSecurityContext: ValuesFilePath.read_elsewhere("synapse", "podSecurityContext"),
                     PropertyType.PriorityClassName: ValuesFilePath.read_elsewhere("synapse", "priorityClassName"),
+                    PropertyType.RuntimeClassName: ValuesFilePath.read_elsewhere("synapse", "runtimeClassName"),
+                    PropertyType.SchedulerName: ValuesFilePath.read_elsewhere("synapse", "schedulerName"),
                     # Job so no readinessProbe
                     PropertyType.ReadinessProbe: ValuesFilePath.not_supported(),
                     PropertyType.ServiceMonitor: ValuesFilePath.read_elsewhere("synapse", "serviceMonitor"),

--- a/tests/manifests/test_pod_runtimeClassName.py
+++ b/tests/manifests/test_pod_runtimeClassName.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import random
+import string
+
+import pytest
+
+from . import DeployableDetails, PropertyType, values_files_to_test
+from .utils import (
+    iterate_deployables_workload_parts,
+    template_id,
+    template_to_deployable_details,
+)
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_pod_has_no_runtimeClassName_by_default(templates):
+    for template in templates:
+        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+            pod_spec = template["spec"]["template"]["spec"]
+            assert "runtimeClassName" not in pod_spec, (
+                f"{template_id(template)} has a default runtimeClassName when one isn't configured"
+            )
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_pod_gets_configured_runtimeClassName(values, make_templates, release_name):
+    def set_runtimeClassName(deployable_details: DeployableDetails):
+        runtimeClassName = "".join(random.choices(string.ascii_lowercase))
+        deployable_details.set_helm_values(values, PropertyType.RuntimeClassName, runtimeClassName)
+
+    iterate_deployables_workload_parts(set_runtimeClassName)
+    for template in await make_templates(values):
+        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+            pod_spec = template["spec"]["template"]["spec"]
+            assert "runtimeClassName" in pod_spec, (
+                f"{template_id(template)} doesn't have a runtimeClassName when one is configured"
+            )
+
+            deployable_details = template_to_deployable_details(template)
+            expected_runtimeClassName = deployable_details.get_helm_values(values, PropertyType.RuntimeClassName)
+            assert pod_spec["runtimeClassName"] == expected_runtimeClassName, (
+                f"{template_id(template)} has an unexpected runtimeClassName"
+            )
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_global_runtimeClassName_renders(values, make_templates):
+    global_runtimeClassName = "global-runtime"
+    values["runtimeClassName"] = global_runtimeClassName
+
+    for template in await make_templates(values):
+        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+            pod_spec = template["spec"]["template"]["spec"]
+            assert pod_spec.get("runtimeClassName") == global_runtimeClassName, (
+                f"{template_id(template)} doesn't inherit the global runtimeClassName"
+            )
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_component_runtimeClassName_overrides_global(values, make_templates):
+    global_runtimeClassName = "global-runtime"
+    values["runtimeClassName"] = global_runtimeClassName
+
+    def set_runtimeClassName(deployable_details: DeployableDetails):
+        component_runtimeClassName = "".join(random.choices(string.ascii_lowercase))
+        deployable_details.set_helm_values(values, PropertyType.RuntimeClassName, component_runtimeClassName)
+
+    iterate_deployables_workload_parts(set_runtimeClassName)
+    for template in await make_templates(values):
+        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+            pod_spec = template["spec"]["template"]["spec"]
+            deployable_details = template_to_deployable_details(template)
+            expected_runtimeClassName = deployable_details.get_helm_values(values, PropertyType.RuntimeClassName)
+            assert pod_spec.get("runtimeClassName") == expected_runtimeClassName, (
+                f"{template_id(template)} did not let its component runtimeClassName override the global one"
+            )
+            assert pod_spec["runtimeClassName"] != global_runtimeClassName, (
+                f"{template_id(template)} rendered the global runtimeClassName instead of its component override"
+            )

--- a/tests/manifests/test_pod_schedulerName.py
+++ b/tests/manifests/test_pod_schedulerName.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import random
+import string
+
+import pytest
+
+from . import DeployableDetails, PropertyType, values_files_to_test
+from .utils import (
+    iterate_deployables_workload_parts,
+    template_id,
+    template_to_deployable_details,
+)
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_pod_has_no_schedulerName_by_default(templates):
+    for template in templates:
+        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+            pod_spec = template["spec"]["template"]["spec"]
+            assert "schedulerName" not in pod_spec, (
+                f"{template_id(template)} has a default schedulerName when one isn't configured"
+            )
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_pod_gets_configured_schedulerName(values, make_templates, release_name):
+    def set_schedulerName(deployable_details: DeployableDetails):
+        schedulerName = "".join(random.choices(string.ascii_lowercase))
+        deployable_details.set_helm_values(values, PropertyType.SchedulerName, schedulerName)
+
+    iterate_deployables_workload_parts(set_schedulerName)
+    for template in await make_templates(values):
+        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+            pod_spec = template["spec"]["template"]["spec"]
+            assert "schedulerName" in pod_spec, (
+                f"{template_id(template)} doesn't have a schedulerName when one is configured"
+            )
+
+            deployable_details = template_to_deployable_details(template)
+            expected_schedulerName = deployable_details.get_helm_values(values, PropertyType.SchedulerName)
+            assert pod_spec["schedulerName"] == expected_schedulerName, (
+                f"{template_id(template)} has an unexpected schedulerName"
+            )
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_global_schedulerName_renders(values, make_templates):
+    global_schedulerName = "global-scheduler"
+    values["schedulerName"] = global_schedulerName
+
+    for template in await make_templates(values):
+        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+            pod_spec = template["spec"]["template"]["spec"]
+            assert pod_spec.get("schedulerName") == global_schedulerName, (
+                f"{template_id(template)} doesn't inherit the global schedulerName"
+            )
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_component_schedulerName_overrides_global(values, make_templates):
+    global_schedulerName = "global-scheduler"
+    values["schedulerName"] = global_schedulerName
+
+    def set_schedulerName(deployable_details: DeployableDetails):
+        component_schedulerName = "".join(random.choices(string.ascii_lowercase))
+        deployable_details.set_helm_values(values, PropertyType.SchedulerName, component_schedulerName)
+
+    iterate_deployables_workload_parts(set_schedulerName)
+    for template in await make_templates(values):
+        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+            pod_spec = template["spec"]["template"]["spec"]
+            deployable_details = template_to_deployable_details(template)
+            expected_schedulerName = deployable_details.get_helm_values(values, PropertyType.SchedulerName)
+            assert pod_spec.get("schedulerName") == expected_schedulerName, (
+                f"{template_id(template)} did not let its component schedulerName override the global one"
+            )
+            assert pod_spec["schedulerName"] != global_schedulerName, (
+                f"{template_id(template)} rendered the global schedulerName instead of its component override"
+            )


### PR DESCRIPTION
Adds `schedulerName` and `runtimeClassName` as pod-scheduling knobs on every
component workload, plus matching global values applied to all components
(a per-component value overrides the global one).

This mirrors the existing `priorityClassName` (#1438) and `affinity` (#1442)
support, filling out the remaining common pod-spec scheduling fields. Both are
plain string scalars rendered via the same coalesce(component, global) pattern
in _pods.tpl.

Validation (local):
- Regenerated values.yaml + values.schema.json from source fragments
  (scripts/assemble_helm_charts_from_fragments.sh); git diff clean.
- New manifest tests test_pod_schedulerName.py + test_pod_runtimeClassName.py
  pass (full pytest run: 144 passed).
- reuse lint: 656/656 files compliant.

A newsfragment will be added once the PR number is assigned.