### PR TITLE
Unify Pod Spec handling in manifest tests

### DIFF
--- a/newsfragments/1462.internal.md
+++ b/newsfragments/1462.internal.md
@@ -1,0 +1,1 @@
+CI: consistently fetch the `Pod` template for workload kinds.

--- a/tests/manifests/test_annotations.py
+++ b/tests/manifests/test_annotations.py
@@ -1,5 +1,5 @@
 # Copyright 2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -7,7 +7,7 @@
 import pytest
 
 from . import values_files_to_test
-from .utils import template_id
+from .utils import ALL_WORKLOAD_KINDS, template_id
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -21,7 +21,7 @@ async def test_annotations_dont_contain_things_that_should_be_labels(templates):
             "We should consistently use labels for k8s.element.io things"
         )
 
-        if template["kind"] in ["Deployment", "Job", "StatefulSet"]:
+        if template["kind"] in ALL_WORKLOAD_KINDS:
             pod_annotations = template["metadata"].get("annotations", {})
             our_pod_annotations = [key for key in pod_annotations if "k8s.element.io" in key]
             assert len(our_pod_annotations) == 0, (

--- a/tests/manifests/test_configs.py
+++ b/tests/manifests/test_configs.py
@@ -11,7 +11,7 @@ import pytest
 import yaml
 
 from . import DeployableDetails, PropertyType, secret_values_files_to_test, values_files_to_test
-from .utils import iterate_deployables_parts, template_id, template_to_deployable_details
+from .utils import ALL_WORKLOAD_KINDS, iterate_deployables_parts, template_id, template_to_deployable_details
 
 
 @pytest.mark.parametrize(
@@ -60,11 +60,7 @@ async def test_user_provided_inline_configs_change_hashes(values, make_templates
             ):
                 hashes_by_template_id[id][label] = value
 
-        if template_to_deployable_details(template).has_additional_config and template["kind"] in [
-            "Deployment",
-            "StatefulSet",
-            "Job",
-        ]:
+        if template_to_deployable_details(template).has_additional_config and template["kind"] in ALL_WORKLOAD_KINDS:
             assert len(hashes_by_template_id[id]) > 0, (
                 f"{id} supports additional configuration but we haven't seen any hashes"
             )

--- a/tests/manifests/test_configs_consistency.py
+++ b/tests/manifests/test_configs_consistency.py
@@ -15,8 +15,7 @@ import pytest
 from . import DeployableDetails, secret_values_files_to_test, values_files_to_test
 from .utils import (
     get_or_empty,
-    template_id,
-    template_to_deployable_details,
+    iterate_pod_template,
     workload_spec_containers,
 )
 
@@ -681,19 +680,19 @@ class ValidatedContainerConfig(ValidatedConfig):
 
 
 def traverse_containers(templates, other_secrets, other_configmaps) -> Generator[ValidatedContainerConfig]:
-    workloads = [t for t in templates if t["kind"] in ("Deployment", "StatefulSet", "Job")]
-    for template in workloads:
+    for pod_template_details in iterate_pod_template(templates):
         all_workload_empty_dirs: dict[str, MountedEmptyDir] = {}
         # Gather all containers and initContainers from the template spec
-        workload_spec = template["spec"]["template"]["spec"]
+        workload_spec = pod_template_details.pod_template["spec"]
+        manifest = pod_template_details.manifest
         weight = None
-        if "pre-install,pre-upgrade" in template["metadata"].get("annotations", {}).get("helm.sh/hook", ""):
-            weight = int(template["metadata"]["annotations"].get("helm.sh/hook-weight", 0))
+        if "pre-install,pre-upgrade" in manifest["metadata"].get("annotations", {}).get("helm.sh/hook", ""):
+            weight = int(manifest["metadata"]["annotations"].get("helm.sh/hook-weight", 0))
 
         for container_spec in workload_spec_containers(workload_spec):
-            deployable_details = template_to_deployable_details(template, container_spec["name"])
+            deployable_details = pod_template_details.deployable_details(container_spec["name"])
             validated_container_config = ValidatedContainerConfig.from_container_spec(
-                template_id(template),
+                pod_template_details.manifest_id,
                 workload_spec,
                 container_spec,
                 weight,

--- a/tests/manifests/test_labels.py
+++ b/tests/manifests/test_labels.py
@@ -1,5 +1,5 @@
 # Copyright 2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -9,7 +9,7 @@ from hashlib import sha1
 import pytest
 
 from . import PropertyType, secret_values_files_to_test, values_files_to_test
-from .utils import template_id, template_to_deployable_details
+from .utils import PERSISTENT_WORKLOAD_KINDS, iterate_pod_template, template_id
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -63,53 +63,49 @@ async def test_templates_have_expected_labels(release_name, templates):
 @pytest.mark.parametrize("values_file", secret_values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_templates_have_postgres_hash_label(release_name, templates, values):
-    for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = template_id(template)
-            labels = template["spec"]["template"]["metadata"]["labels"]
-            deployable_details = template_to_deployable_details(template)
-            if not deployable_details.has_db:
-                continue
+    for pod_template_details in iterate_pod_template(templates):
+        id = pod_template_details.manifest_id
+        labels = pod_template_details.pod_template["metadata"]["labels"]
+        deployable_details = pod_template_details.deployable_details()
+        if not deployable_details.has_db:
+            continue
 
-            assert any(re.match("k8s.element.io/postgres-password-[a-z]+-hash", label) for label in labels), (
-                f"{id} does not have postgres password hash label"
-            )  # We currently assume that Postgres is for top-level components only and so there is a single segment
-            # write (or read) path
-            assert len(deployable_details.values_file_path.write_path) == 1
-            helm_key = deployable_details.values_file_path.read_path[0]
-            values_fragment = deployable_details.get_helm_values(values, PropertyType.Postgres)
-            if values_fragment.get("password", {}).get("value", None):
-                expected = values_fragment["password"]["value"]
-            elif values_fragment.get("password", {}).get("secret", None):
-                secret_name = values_fragment["password"]["secret"]
-                expected = f"{secret_name}-{values_fragment['password']['secretKey']}"
-            elif values["postgres"].get("essPasswords", {}).get(helm_key, {}).get("value", None):
-                expected = values["postgres"]["essPasswords"][helm_key]["value"]
-            elif values["postgres"].get("essPasswords", {}).get(helm_key, {}).get("secret", None):
-                secret_name = values["postgres"]["essPasswords"][helm_key]["secret"]
-                expected = f"{secret_name}-{values['postgres']['essPasswords'][helm_key]['secretKey']}"
-            else:
-                expected = f"{release_name}-generated"
-            expected = expected.replace("{{ $.Release.Name }}", release_name)
-            assert (
-                labels[f"k8s.element.io/postgres-password-{helm_key.lower()[:24]}-hash"]
-                == sha1(expected.encode()).hexdigest()
-            ), f"{id} has incorrect postgres password hash, expect {expected} hashed as sha1"
+        assert any(re.match("k8s.element.io/postgres-password-[a-z]+-hash", label) for label in labels), (
+            f"{id} does not have postgres password hash label"
+        )  # We currently assume that Postgres is for top-level components only and so there is a single segment
+        # write (or read) path
+        assert len(deployable_details.values_file_path.write_path) == 1
+        helm_key = deployable_details.values_file_path.read_path[0]
+        values_fragment = deployable_details.get_helm_values(values, PropertyType.Postgres)
+        if values_fragment.get("password", {}).get("value", None):
+            expected = values_fragment["password"]["value"]
+        elif values_fragment.get("password", {}).get("secret", None):
+            secret_name = values_fragment["password"]["secret"]
+            expected = f"{secret_name}-{values_fragment['password']['secretKey']}"
+        elif values["postgres"].get("essPasswords", {}).get(helm_key, {}).get("value", None):
+            expected = values["postgres"]["essPasswords"][helm_key]["value"]
+        elif values["postgres"].get("essPasswords", {}).get(helm_key, {}).get("secret", None):
+            secret_name = values["postgres"]["essPasswords"][helm_key]["secret"]
+            expected = f"{secret_name}-{values['postgres']['essPasswords'][helm_key]['secretKey']}"
+        else:
+            expected = f"{release_name}-generated"
+        expected = expected.replace("{{ $.Release.Name }}", release_name)
+        assert (
+            labels[f"k8s.element.io/postgres-password-{helm_key.lower()[:24]}-hash"]
+            == sha1(expected.encode()).hexdigest()
+        ), f"{id} has incorrect postgres password hash, expect {expected} hashed as sha1"
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_pod_spec_labels_are_consistent_with_parent_labels(templates):
-    for template in templates:
-        if template["kind"] not in ["Deployment", "Job", "StatefulSet"]:
-            continue
-
+    for pod_template_details in iterate_pod_template(templates):
         # Explicitly omitted from Pod labels so that they don't restart blindly on chart upgrade
-        parent_labels = template["metadata"]["labels"].delete("helm.sh/chart")
-        pod_labels = template["spec"]["template"]["metadata"]["labels"]
+        parent_labels = pod_template_details.manifest["metadata"]["labels"].delete("helm.sh/chart")
+        pod_labels = pod_template_details.pod_template["metadata"]["labels"]
 
         assert parent_labels == pod_labels, (
-            f"{template_id(template)} has differing labels between itself and the Pods it would create. "
+            f"{pod_template_details.manifest_id} has differing labels between itself and the Pods it would create. "
             f"{parent_labels=} vs {pod_labels=}"
         )
 
@@ -140,13 +136,12 @@ async def test_our_labels_are_named_consistently(templates):
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_workloads_selector_matches_labels(templates):
-    for template in templates:
-        if template["kind"] in ("Deployment", "StatefulSet"):
-            for label in template["spec"]["selector"]["matchLabels"]:
-                assert (
-                    template["spec"]["template"]["metadata"]["labels"][label]
-                    == template["spec"]["selector"]["matchLabels"][label]
-                )
+    for pod_template_details in iterate_pod_template(templates, kinds=PERSISTENT_WORKLOAD_KINDS):
+        selector_labels = pod_template_details.manifest["spec"]["selector"]
+        for label in selector_labels["matchLabels"]:
+            assert (
+                pod_template_details.pod_template["metadata"]["labels"][label] == selector_labels["matchLabels"][label]
+            )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)

--- a/tests/manifests/test_matrix_authentication_service.py
+++ b/tests/manifests/test_matrix_authentication_service.py
@@ -6,12 +6,17 @@
 import pyhelm3
 import pytest
 
+from manifests.utils import PERSISTENT_WORKLOAD_KINDS
+
 
 @pytest.mark.parametrize("values_file", ["matrix-authentication-service-minimal-values.yaml"])
 @pytest.mark.asyncio_cooperative
 async def test_matrix_authentication_service_env_overrides(values, make_templates):
     for template in await make_templates(values):
-        if "matrix-authentication-service" in template["metadata"]["name"] and template["kind"] == "Deployment":
+        if (
+            "matrix-authentication-service" in template["metadata"]["name"]
+            and template["kind"] in PERSISTENT_WORKLOAD_KINDS
+        ):
             env = {e["name"]: e["value"] for e in template["spec"]["template"]["spec"]["containers"][0]["env"]}
             assert env["MAS_CONFIG"] == "/conf/mas-config.yaml"
             break
@@ -24,7 +29,10 @@ async def test_matrix_authentication_service_env_overrides(values, make_template
     ]
 
     for template in await make_templates(values):
-        if "matrix-authentication-service" in template["metadata"]["name"] and template["kind"] == "Deployment":
+        if (
+            "matrix-authentication-service" in template["metadata"]["name"]
+            and template["kind"] in PERSISTENT_WORKLOAD_KINDS
+        ):
             env = {e["name"]: e["value"] for e in template["spec"]["template"]["spec"]["containers"][0]["env"]}
             assert env["MAS_CONFIG"] == "/conf/mas-config.yaml"
             assert env["OTHER_KEY"] == "should-exists"

--- a/tests/manifests/test_matrix_rtc.py
+++ b/tests/manifests/test_matrix_rtc.py
@@ -7,7 +7,7 @@ import pyhelm3
 import pytest
 import yaml
 
-from .utils import template_id
+from .utils import PERSISTENT_WORKLOAD_KINDS, template_id
 
 
 @pytest.mark.parametrize("values_file", ["matrix-rtc-minimal-values.yaml"])
@@ -111,7 +111,7 @@ async def test_turn_tls_external_termination(values, templates):
     turn_tls_service = None
 
     for template in templates:
-        if template["kind"] == "Deployment" and "matrix-rtc-sfu" in template["metadata"]["name"]:
+        if template["kind"] in PERSISTENT_WORKLOAD_KINDS and "matrix-rtc-sfu" in template["metadata"]["name"]:
             sfu_deployment = template
         elif template["kind"] == "ConfigMap" and "matrix-rtc-sfu" in template["metadata"]["name"]:
             sfu_configmap = template
@@ -160,7 +160,7 @@ async def test_turn_tls_external_termination_with_certmanager(values, make_templ
     sfu_configmap = None
 
     for template in await make_templates(values):
-        if template["kind"] == "Deployment" and "matrix-rtc-sfu" in template["metadata"]["name"]:
+        if template["kind"] in PERSISTENT_WORKLOAD_KINDS and "matrix-rtc-sfu" in template["metadata"]["name"]:
             sfu_deployment = template
         elif template["kind"] == "ConfigMap" and "matrix-rtc-sfu" in template["metadata"]["name"]:
             sfu_configmap = template
@@ -202,7 +202,7 @@ async def test_turn_tls_pod_termination_with_secret(values, templates):
     sfu_configmap = None
 
     for template in templates:
-        if template["kind"] == "Deployment" and "matrix-rtc-sfu" in template["metadata"]["name"]:
+        if template["kind"] in PERSISTENT_WORKLOAD_KINDS and "matrix-rtc-sfu" in template["metadata"]["name"]:
             sfu_deployment = template
         elif template["kind"] == "ConfigMap" and "matrix-rtc-sfu" in template["metadata"]["name"]:
             sfu_configmap = template

--- a/tests/manifests/test_pod_affinity.py
+++ b/tests/manifests/test_pod_affinity.py
@@ -11,8 +11,7 @@ from frozendict import deepfreeze
 from . import DeployableDetails, PropertyType, values_files_to_test
 from .utils import (
     iterate_deployables_workload_parts,
-    template_id,
-    template_to_deployable_details,
+    iterate_pod_template,
 )
 
 AFFINITY_TYPES = ["nodeAffinity", "podAffinity", "podAntiAffinity"]
@@ -88,12 +87,11 @@ def _expected_affinity(global_affinity: dict, component_affinity: dict | None) -
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_pod_has_no_affinity_by_default(templates):
-    for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            assert "affinity" not in pod_spec, (
-                f"{template_id(template)} has a default affinity when one isn't configured"
-            )
+    for pod_template_details in iterate_pod_template(templates):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "affinity" not in pod_spec, (
+            f"{pod_template_details.manifest_id} has a default affinity when one isn't configured"
+        )
 
 
 @pytest.mark.parametrize("affinity_type", AFFINITY_TYPES)
@@ -104,16 +102,17 @@ async def test_pod_gets_configured_affinity(affinity_type, values, make_template
         deployable_details.set_helm_values(values, PropertyType.Affinity, _affinity_for(affinity_type))
 
     iterate_deployables_workload_parts(set_affinity)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            assert "affinity" in pod_spec, f"{template_id(template)} doesn't have an affinity when one is configured"
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "affinity" in pod_spec, (
+            f"{pod_template_details.manifest_id} doesn't have an affinity when one is configured"
+        )
 
-            deployable_details = template_to_deployable_details(template)
-            expected_affinity = deployable_details.get_helm_values(values, PropertyType.Affinity)
-            assert pod_spec["affinity"] == deepfreeze(expected_affinity), (
-                f"{template_id(template)} has an unexpected {affinity_type}"
-            )
+        deployable_details = pod_template_details.deployable_details()
+        expected_affinity = deployable_details.get_helm_values(values, PropertyType.Affinity)
+        assert pod_spec["affinity"] == deepfreeze(expected_affinity), (
+            f"{pod_template_details.manifest_id} has an unexpected {affinity_type}"
+        )
 
 
 @pytest.mark.parametrize("affinity_type", AFFINITY_TYPES)
@@ -123,12 +122,11 @@ async def test_global_affinity_renders(affinity_type, values, make_templates):
     global_affinity = _affinity_for(affinity_type)
     values["affinity"] = global_affinity
 
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            assert pod_spec.get("affinity") == deepfreeze(global_affinity), (
-                f"{template_id(template)} doesn't inherit the global {affinity_type}"
-            )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert pod_spec.get("affinity") == deepfreeze(global_affinity), (
+            f"{pod_template_details.manifest_id} doesn't inherit the global {affinity_type}"
+        )
 
 
 @pytest.mark.parametrize("affinity_type", AFFINITY_TYPES)
@@ -145,24 +143,23 @@ async def test_component_override_is_isolated_to_its_type(affinity_type, values,
         deployable_details.set_helm_values(values, PropertyType.Affinity, component_override)
 
     iterate_deployables_workload_parts(set_affinity)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            deployable_details = template_to_deployable_details(template)
-            component_affinity = deployable_details.get_helm_values(values, PropertyType.Affinity)
-            expected_affinity = _expected_affinity(global_affinity, component_affinity)
-            assert pod_spec.get("affinity") == deepfreeze(expected_affinity), (
-                f"{template_id(template)} did not isolate the {affinity_type} override to that type"
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        deployable_details = pod_template_details.deployable_details()
+        component_affinity = deployable_details.get_helm_values(values, PropertyType.Affinity)
+        expected_affinity = _expected_affinity(global_affinity, component_affinity)
+        assert pod_spec.get("affinity") == deepfreeze(expected_affinity), (
+            f"{pod_template_details.manifest_id} did not isolate the {affinity_type} override to that type"
+        )
+        # The other affinity types must still come from the global affinity.
+        for other_type in AFFINITY_TYPES:
+            if other_type == affinity_type:
+                continue
+            if component_affinity and other_type in component_affinity:
+                continue
+            assert pod_spec["affinity"].get(other_type) == deepfreeze(global_affinity[other_type]), (
+                f"{pod_template_details.manifest_id} dropped the global {other_type} when overriding {affinity_type}"
             )
-            # The other affinity types must still come from the global affinity.
-            for other_type in AFFINITY_TYPES:
-                if other_type == affinity_type:
-                    continue
-                if component_affinity and other_type in component_affinity:
-                    continue
-                assert pod_spec["affinity"].get(other_type) == deepfreeze(global_affinity[other_type]), (
-                    f"{template_id(template)} dropped the global {other_type} when overriding {affinity_type}"
-                )
 
 
 @pytest.mark.parametrize("affinity_type", AFFINITY_TYPES)
@@ -177,17 +174,16 @@ async def test_component_can_blank_global_affinity_type(affinity_type, values, m
         deployable_details.set_helm_values(values, PropertyType.Affinity, {affinity_type: {}})
 
     iterate_deployables_workload_parts(blank_affinity)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            affinity = pod_spec.get("affinity", {})
-            assert affinity_type not in affinity, (
-                f"{template_id(template)} did not blank out the global {affinity_type}"
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        affinity = pod_spec.get("affinity", {})
+        assert affinity_type not in affinity, (
+            f"{pod_template_details.manifest_id} did not blank out the global {affinity_type}"
+        )
+        # The non-blanked affinity types must still be inherited from the global affinity.
+        for other_type in AFFINITY_TYPES:
+            if other_type == affinity_type:
+                continue
+            assert affinity.get(other_type) == deepfreeze(global_affinity[other_type]), (
+                f"{pod_template_details.manifest_id} dropped the global {other_type} when blanking {affinity_type}"
             )
-            # The non-blanked affinity types must still be inherited from the global affinity.
-            for other_type in AFFINITY_TYPES:
-                if other_type == affinity_type:
-                    continue
-                assert affinity.get(other_type) == deepfreeze(global_affinity[other_type]), (
-                    f"{template_id(template)} dropped the global {other_type} when blanking {affinity_type}"
-                )

--- a/tests/manifests/test_pod_arguments.py
+++ b/tests/manifests/test_pod_arguments.py
@@ -1,22 +1,20 @@
 # Copyright 2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import pytest
 
 from . import values_files_to_test
-from .utils import template_id, workload_spec_containers
+from .utils import iterate_pod_template, workload_spec_containers
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_matrix_tools_containers_dont_set_command(templates):
-    for template in templates:
-        if template["kind"] not in ["Deployment", "StatefulSet", "Job"]:
-            continue
-        for container in workload_spec_containers(template["spec"]["template"]["spec"]):
+    for pod_template_details in iterate_pod_template(templates):
+        for container in workload_spec_containers(pod_template_details.pod_template["spec"]):
             if "/matrix-tools:" in container["image"] or "/matrix-tools@sha256:" in container["image"]:
                 assert "command" not in container, (
-                    f"{template_id(template)}/{container['name']} has a command of {container['command']}"
+                    f"{pod_template_details.manifest_id}/{container['name']} has a command of {container['command']}"
                 )

--- a/tests/manifests/test_pod_containers_ports.py
+++ b/tests/manifests/test_pod_containers_ports.py
@@ -1,66 +1,60 @@
 # Copyright 2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import pytest
 
 from . import values_files_to_test
-from .utils import template_id
+from .utils import EPHEMERAL_WORKLOAD_KINDS, PERSISTENT_WORKLOAD_KINDS, iterate_pod_template
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_unique_ports_in_containers(templates):
-    for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet"]:
-            ports = []
-            for container in template["spec"]["template"]["spec"]["containers"]:
-                ports += [port["containerPort"] for port in container.get("ports", [])]
-            assert len(ports) == len(set(ports)), f"Ports are not unique: {template_id(template)}, {ports}"
+    for pod_template_details in iterate_pod_template(templates, kinds=PERSISTENT_WORKLOAD_KINDS):
+        ports = []
+        for container in pod_template_details.pod_template["spec"]["containers"]:
+            ports += [port["containerPort"] for port in container.get("ports", [])]
+        assert len(ports) == len(set(ports)), f"Ports are not unique: {pod_template_details.manifest_id}, {ports}"
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_ports_in_containers_are_named(templates):
-    for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet"]:
-            port_names = []
-            for container in template["spec"]["template"]["spec"]["containers"]:
-                for port in container.get("ports", []):
-                    assert "name" in port, (
-                        f"{id} has container {container['name']} which has a port without a name: {port}"
-                    )
-                    port_names.append(port["name"])
-            assert len(port_names) == len(set(port_names)), (
-                f"Port names are not unique: {template_id(template)}, {port_names}"
-            )
+    for pod_template_details in iterate_pod_template(templates, kinds=PERSISTENT_WORKLOAD_KINDS):
+        port_names = []
+        for container in pod_template_details.pod_template["spec"]["containers"]:
+            for port in container.get("ports", []):
+                assert "name" in port, f"{id} has container {container['name']} which has a port without a name: {port}"
+                port_names.append(port["name"])
+        assert len(port_names) == len(set(port_names)), (
+            f"Port names are not unique: {pod_template_details.manifest_id}, {port_names}"
+        )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_no_ports_in_jobs(templates):
-    for template in templates:
-        if template["kind"] in ["Job"]:
-            ports = []
-            for container in template["spec"]["template"]["spec"]["containers"]:
-                ports += [port["containerPort"] for port in container.get("ports", [])]
-            assert len(ports) == 0, f"Ports are present in job: {template_id(template)}, {ports}"
+    for pod_template_details in iterate_pod_template(templates, kinds=EPHEMERAL_WORKLOAD_KINDS):
+        ports = []
+        for container in pod_template_details.pod_template["spec"]["containers"]:
+            ports += [port["containerPort"] for port in container.get("ports", [])]
+        assert len(ports) == 0, f"Ports are present in job: {pod_template_details.manifest_id}, {ports}"
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_not_too_many_container_ports(templates):
-    for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet"]:
-            for container in template["spec"]["template"]["spec"]["containers"]:
-                number_of_ports = len(container.get("ports", []))
-                # This limit is fairly arbitrary. Unlike with Services (which have a limit of 250 ports),
-                # there doesn't appear to be a hard limit of number of ports on a Pod/container. However if
-                # you go wild you hit maximum document size when attempting to put the manifest into the
-                # cluster. 100 is chosen as anything more quickly makes `kubectl {describe,get}` unusable.
-                # Container ports are "just" metadata, albeit one which helps the scheduler if `hostPorts`
-                # are involved
-                assert number_of_ports < 100, (
-                    f"{template_id(template)}/{container['name']} has too many ports ({number_of_ports} >= 100)"
-                )
+    for pod_template_details in iterate_pod_template(templates, kinds=PERSISTENT_WORKLOAD_KINDS):
+        for container in pod_template_details.pod_template["spec"]["containers"]:
+            number_of_ports = len(container.get("ports", []))
+            # This limit is fairly arbitrary. Unlike with Services (which have a limit of 250 ports),
+            # there doesn't appear to be a hard limit of number of ports on a Pod/container. However if
+            # you go wild you hit maximum document size when attempting to put the manifest into the
+            # cluster. 100 is chosen as anything more quickly makes `kubectl {describe,get}` unusable.
+            # Container ports are "just" metadata, albeit one which helps the scheduler if `hostPorts`
+            # are involved
+            assert number_of_ports < 100, (
+                f"{pod_template_details.manifest_id}/{container['name']} has too many ports ({number_of_ports} >= 100)"
+            )

--- a/tests/manifests/test_pod_env.py
+++ b/tests/manifests/test_pod_env.py
@@ -1,5 +1,5 @@
 # Copyright 2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -10,8 +10,7 @@ import pytest
 from . import DeployableDetails, PropertyType, all_deployables_details, values_files_to_test
 from .utils import (
     iterate_deployables_workload_parts,
-    template_id,
-    template_to_deployable_details,
+    iterate_pod_template,
     workload_spec_containers,
 )
 
@@ -32,36 +31,35 @@ async def test_sets_extra_env(values, make_templates):
 
     iterate_deployables_workload_parts(set_extra_env)
 
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "Job", "StatefulSet"]:
-            for container in workload_spec_containers(template["spec"]["template"]["spec"]):
-                env_keys = [env["name"] for env in container.get("env", [])]
-                assert len(env_keys) == len(set(env_keys)), (
-                    f"{template_id(template)} has container {container['name']} "
-                    f"with env keys are not unique: {env_keys}"
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        for container in workload_spec_containers(pod_template_details.pod_template["spec"]):
+            env_keys = [env["name"] for env in container.get("env", [])]
+            assert len(env_keys) == len(set(env_keys)), (
+                f"{pod_template_details.manifest_id} has container {container['name']} "
+                f"with env keys are not unique: {env_keys}"
+            )
+
+            for env in container.get("env", []):
+                if "valueFrom" in env:
+                    continue
+                assert type(env["value"]) is str, (
+                    f"{pod_template_details.manifest_id} has container {container['name']} "
+                    f"which has an non-string value: {env}"
                 )
 
-                for env in container.get("env", []):
-                    if "valueFrom" in env:
-                        continue
-                    assert type(env["value"]) is str, (
-                        f"{template_id(template)} has container {container['name']} "
-                        f"which has an non-string value: {env}"
-                    )
-
-                # We only provide extraEnv to specific matrix-tools init containers
-                if "/matrix-tools:" in container["image"]:
-                    args = container.get("args") or container["command"][1:]
-                    if args[0] not in ["render-config", "syn2mas"]:
-                        continue
-                if container["name"] in ["copy-mas-cli", "syn2mas-check"]:
+            # We only provide extraEnv to specific matrix-tools init containers
+            if "/matrix-tools:" in container["image"]:
+                args = container.get("args") or container["command"][1:]
+                if args[0] not in ["render-config", "syn2mas"]:
                     continue
+            if container["name"] in ["copy-mas-cli", "syn2mas-check"]:
+                continue
 
-                for key in [extra_env["name"] for extra_env in extra_envs]:
-                    assert key in env_keys, (
-                        f"{template_id(template)} has container {container['name']} "
-                        "that is missing some of the extra env that's being injected"
-                    )
+            for key in [extra_env["name"] for extra_env in extra_envs]:
+                assert key in env_keys, (
+                    f"{pod_template_details.manifest_id} has container {container['name']} "
+                    "that is missing some of the extra env that's being injected"
+                )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -75,11 +73,10 @@ async def test_built_in_env_cant_be_overwritten(values, make_templates):
             deployable_details.get_helm_values(values, PropertyType.Env, default_value=[]).clear()
 
     # Collect the env set for each and every container
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "Job", "StatefulSet"]:
-            for container in workload_spec_containers(template["spec"]["template"]["spec"]):
-                deployable_details = template_to_deployable_details(template, container["name"])
-                built_in_env[deployable_details][container["name"]] = [env["name"] for env in container.get("env", [])]
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        for container in workload_spec_containers(pod_template_details.pod_template["spec"]):
+            deployable_details = pod_template_details.deployable_details(container["name"])
+            built_in_env[deployable_details][container["name"]] = [env["name"] for env in container.get("env", [])]
 
     def override_env(deployable_details: DeployableDetails):
         # For all env vars used across all containers for this deployable details attempt to overwrite the value
@@ -91,20 +88,19 @@ async def test_built_in_env_cant_be_overwritten(values, make_templates):
 
     iterate_deployables_workload_parts(override_env)
 
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "Job", "StatefulSet"]:
-            for container in workload_spec_containers(template["spec"]["template"]["spec"]):
-                deployable_details = template_to_deployable_details(template, container["name"])
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        for container in workload_spec_containers(pod_template_details.pod_template["spec"]):
+            deployable_details = pod_template_details.deployable_details(container["name"])
 
-                env_keys_from_chart = built_in_env[deployable_details][container["name"]]
-                for env_var in container.get("env", []):
-                    # We can't just look for the value being 'from-user' as a deployable_details may have multiple
-                    # containers each setting different env vars. We'll have provided a 'from-user' env var override
-                    # for all of those env vars and so 'from-user' will legitimately be present on some containers
-                    if env_var["name"] in env_keys_from_chart:
-                        if "valueFrom" in env_var:
-                            continue
-                        assert env_var["value"] != "from-user", (
-                            f"{template_id(template)}/{container['name']} allowed env var "
-                            f"{env_var['name']} to be overwritten"
-                        )
+            env_keys_from_chart = built_in_env[deployable_details][container["name"]]
+            for env_var in container.get("env", []):
+                # We can't just look for the value being 'from-user' as a deployable_details may have multiple
+                # containers each setting different env vars. We'll have provided a 'from-user' env var override
+                # for all of those env vars and so 'from-user' will legitimately be present on some containers
+                if env_var["name"] in env_keys_from_chart:
+                    if "valueFrom" in env_var:
+                        continue
+                    assert env_var["value"] != "from-user", (
+                        f"{pod_template_details.manifest_id}/{container['name']} allowed env var "
+                        f"{env_var['name']} to be overwritten"
+                    )

--- a/tests/manifests/test_pod_hostAliases.py
+++ b/tests/manifests/test_pod_hostAliases.py
@@ -1,5 +1,5 @@
 # Copyright 2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -9,8 +9,7 @@ from frozendict import deepfreeze
 from . import DeployableDetails, PropertyType, values_files_to_test
 from .utils import (
     iterate_deployables_parts,
-    template_id,
-    template_to_deployable_details,
+    iterate_pod_template,
 )
 
 
@@ -30,34 +29,32 @@ async def test_pod_has_hostAliases_if_appropriate(values, make_templates, releas
         deployable_details.set_helm_values(values, PropertyType.HostAliases, hostAliases)
 
     iterate_deployables_parts(set_hostAliases, lambda deployable_details: deployable_details.makes_outbound_requests)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            deployable_details = template_to_deployable_details(template)
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        deployable_details = pod_template_details.deployable_details()
 
-            if not deployable_details.makes_outbound_requests:
-                assert "hostAliases" not in pod_spec, (
-                    f"{template_id(template)} set hostAliases in its Pod when it doesn't need to"
+        if not deployable_details.makes_outbound_requests:
+            assert "hostAliases" not in pod_spec, (
+                f"{pod_template_details.manifest_id} set hostAliases in its Pod when it doesn't need to"
+            )
+            continue
+
+        assert "hostAliases" in pod_spec, f"{pod_template_details.manifest_id} doesn't set hostAliases in its Pod"
+
+        expected_hostAliases = deployable_details.get_helm_values(values, PropertyType.HostAliases)
+        expected_hostAliases = tuple(
+            [
+                deepfreeze(
+                    {
+                        "ip": alias["ip"],
+                        "hostnames": [
+                            hostname.replace("{{ $.Release.Name }}", release_name) for hostname in alias["hostnames"]
+                        ],
+                    }
                 )
-                continue
-
-            assert "hostAliases" in pod_spec, f"{template_id(template)} doesn't set hostAliases in its Pod"
-
-            expected_hostAliases = deployable_details.get_helm_values(values, PropertyType.HostAliases)
-            expected_hostAliases = tuple(
-                [
-                    deepfreeze(
-                        {
-                            "ip": alias["ip"],
-                            "hostnames": [
-                                hostname.replace("{{ $.Release.Name }}", release_name)
-                                for hostname in alias["hostnames"]
-                            ],
-                        }
-                    )
-                    for alias in expected_hostAliases
-                ]
-            )
-            assert pod_spec["hostAliases"] == expected_hostAliases, (
-                f"{template_id(template)} doesn't have the expected hostAliases"
-            )
+                for alias in expected_hostAliases
+            ]
+        )
+        assert pod_spec["hostAliases"] == expected_hostAliases, (
+            f"{pod_template_details.manifest_id} doesn't have the expected hostAliases"
+        )

--- a/tests/manifests/test_pod_images.py
+++ b/tests/manifests/test_pod_images.py
@@ -1,12 +1,16 @@
 # Copyright 2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import pytest
 
 from . import DeployableDetails, PropertyType, values_files_to_test
-from .utils import iterate_deployables_parts, template_id, template_to_deployable_details, workload_spec_containers
+from .utils import (
+    iterate_deployables_parts,
+    iterate_pod_template,
+    workload_spec_containers,
+)
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -24,40 +28,42 @@ async def test_pods_with_tags_and_no_digests(release_name, values, make_template
         deployable_details.set_helm_values(values, PropertyType.Image, {"tag": f"image-tag-{counter}", "digest": None})
 
     iterate_deployables_parts(set_tag, lambda deployable_details: deployable_details.has_image)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            deployable_details = template_to_deployable_details(template)
-            if deployable_details.has_image:
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        deployable_details = pod_template_details.deployable_details()
+        if deployable_details.has_image:
+            expected_image_values = deployable_details.get_helm_values(values, PropertyType.Image)
+        else:
+            expected_image_values = values["matrixTools"]["image"]
+        assert (
+            pod_template_details.manifest["metadata"]["labels"]["app.kubernetes.io/version"]
+            == expected_image_values["tag"]
+        ), f"{pod_template_details.manifest_id} doesn't have the expected version label on the parent"
+
+        pod_template = pod_template_details.pod_template
+        assert pod_template["metadata"]["labels"]["app.kubernetes.io/version"] == expected_image_values["tag"], (
+            f"{pod_template_details.manifest_id} doesn't have the expected version label on the pod"
+        )
+
+        for container in workload_spec_containers(pod_template["spec"]):
+            assert "image" in container, (
+                f"{pod_template_details.manifest_id} has container {container['name']} without image"
+            )
+
+            deployable_details = pod_template_details.deployable_details(container["name"])
+            container_image = container["image"]
+            if deployable_details.has_image and f"/{matrix_tools_marker}:" not in container_image:
                 expected_image_values = deployable_details.get_helm_values(values, PropertyType.Image)
             else:
                 expected_image_values = values["matrixTools"]["image"]
-            assert template["metadata"]["labels"]["app.kubernetes.io/version"] == expected_image_values["tag"], (
-                f"{template_id(template)} doesn't have the expected version label on the parent"
+
+            assert expected_image_values["tag"] == container["image"].split(":")[1], (
+                f"{pod_template_details.manifest_id} has container {container['name']} "
+                "which doesn't have the expected image tag"
             )
-
-            pod_template = template["spec"]["template"]
-            assert pod_template["metadata"]["labels"]["app.kubernetes.io/version"] == expected_image_values["tag"], (
-                f"{template_id(template)} doesn't have the expected version label on the pod"
+            assert container["imagePullPolicy"] == "Always", (
+                f"{pod_template_details.manifest_id} has container {container['name']} "
+                "which doesn't have the expected image pull policy"
             )
-
-            for container in workload_spec_containers(template["spec"]["template"]["spec"]):
-                assert "image" in container, f"{template_id(template)} has container {container['name']} without image"
-
-                deployable_details = template_to_deployable_details(template, container["name"])
-                container_image = container["image"]
-                if deployable_details.has_image and f"/{matrix_tools_marker}:" not in container_image:
-                    expected_image_values = deployable_details.get_helm_values(values, PropertyType.Image)
-                else:
-                    expected_image_values = values["matrixTools"]["image"]
-
-                assert expected_image_values["tag"] == container["image"].split(":")[1], (
-                    f"{template_id(template)} has container {container['name']} "
-                    "which doesn't have the expected image tag"
-                )
-                assert container["imagePullPolicy"] == "Always", (
-                    f"{template_id(template)} has container {container['name']} "
-                    "which doesn't have the expected image pull policy"
-                )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -81,40 +87,42 @@ async def test_pods_with_digests_and_tags(release_name, values, make_templates):
         )
 
     iterate_deployables_parts(set_tag, lambda deployable_details: deployable_details.has_image)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            deployable_details = template_to_deployable_details(template)
-            if deployable_details.has_image:
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        deployable_details = pod_template_details.deployable_details()
+        if deployable_details.has_image:
+            expected_image_values = deployable_details.get_helm_values(values, PropertyType.Image)
+        else:
+            expected_image_values = values["matrixTools"]["image"]
+        assert (
+            pod_template_details.manifest["metadata"]["labels"]["app.kubernetes.io/version"]
+            == expected_image_values["tag"]
+        ), f"{pod_template_details.manifest_id} doesn't have the expected version label on the parent"
+
+        pod_template = pod_template_details.pod_template
+        assert pod_template["metadata"]["labels"]["app.kubernetes.io/version"] == expected_image_values["tag"], (
+            f"{pod_template_details.manifest_id} doesn't have the expected version label on the pod"
+        )
+
+        for container in workload_spec_containers(pod_template["spec"]):
+            assert "image" in container, (
+                f"{pod_template_details.manifest_id} has container {container['name']} without image"
+            )
+
+            deployable_details = pod_template_details.deployable_details(container["name"])
+            container_image = container["image"]
+            if deployable_details.has_image and f"/{matrix_tools_marker}@sha256" not in container_image:
                 expected_image_values = deployable_details.get_helm_values(values, PropertyType.Image)
             else:
                 expected_image_values = values["matrixTools"]["image"]
-            assert template["metadata"]["labels"]["app.kubernetes.io/version"] == expected_image_values["tag"], (
-                f"{template_id(template)} doesn't have the expected version label on the parent"
+
+            assert expected_image_values["digest"] == container["image"].split("@")[1], (
+                f"{pod_template_details.manifest_id} has container {container['name']} "
+                "which doesn't have the expected image digest"
             )
-
-            pod_template = template["spec"]["template"]
-            assert pod_template["metadata"]["labels"]["app.kubernetes.io/version"] == expected_image_values["tag"], (
-                f"{template_id(template)} doesn't have the expected version label on the pod"
+            assert container["imagePullPolicy"] == "IfNotPresent", (
+                f"{pod_template_details.manifest_id} has container {container['name']} "
+                "which doesn't have the expected image pull policy"
             )
-
-            for container in workload_spec_containers(template["spec"]["template"]["spec"]):
-                assert "image" in container, f"{template_id(template)} has container {container['name']} without image"
-
-                deployable_details = template_to_deployable_details(template, container["name"])
-                container_image = container["image"]
-                if deployable_details.has_image and f"/{matrix_tools_marker}@sha256" not in container_image:
-                    expected_image_values = deployable_details.get_helm_values(values, PropertyType.Image)
-                else:
-                    expected_image_values = values["matrixTools"]["image"]
-
-                assert expected_image_values["digest"] == container["image"].split("@")[1], (
-                    f"{template_id(template)} has container {container['name']} "
-                    "which doesn't have the expected image digest"
-                )
-                assert container["imagePullPolicy"] == "IfNotPresent", (
-                    f"{template_id(template)} has container {container['name']} "
-                    "which doesn't have the expected image pull policy"
-                )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -138,35 +146,36 @@ async def test_pods_with_digest_and_no_tags(release_name, values, make_templates
         )
 
     iterate_deployables_parts(set_tag, lambda deployable_details: deployable_details.has_image)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            assert template["metadata"]["labels"]["app.kubernetes.io/version"] is None, (
-                f"{template_id(template)} unexpectedly has a version label on the parent"
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        assert pod_template_details.manifest["metadata"]["labels"]["app.kubernetes.io/version"] is None, (
+            f"{pod_template_details.manifest_id} unexpectedly has a version label on the parent"
+        )
+
+        pod_template = pod_template_details.pod_template
+        assert pod_template["metadata"]["labels"]["app.kubernetes.io/version"] is None, (
+            f"{pod_template_details.manifest_id} unexpectedly has a version label on the pod"
+        )
+
+        for container in workload_spec_containers(pod_template["spec"]):
+            assert "image" in container, (
+                f"{pod_template_details.manifest_id} has container {container['name']} without image"
             )
 
-            pod_template = template["spec"]["template"]
-            assert pod_template["metadata"]["labels"]["app.kubernetes.io/version"] is None, (
-                f"{template_id(template)} unexpectedly has a version label on the pod"
+            deployable_details = pod_template_details.deployable_details(container["name"])
+            container_image = container["image"]
+            if deployable_details.has_image and f"/{matrix_tools_marker}@sha256" not in container_image:
+                expected_image_values = deployable_details.get_helm_values(values, PropertyType.Image)
+            else:
+                expected_image_values = values["matrixTools"]["image"]
+
+            assert expected_image_values["digest"] == container["image"].split("@")[1], (
+                f"{pod_template_details.manifest_id} has container {container['name']} "
+                "which doesn't have the expected image digest"
             )
-
-            for container in workload_spec_containers(template["spec"]["template"]["spec"]):
-                assert "image" in container, f"{template_id(template)} has container {container['name']} without image"
-
-                deployable_details = template_to_deployable_details(template, container["name"])
-                container_image = container["image"]
-                if deployable_details.has_image and f"/{matrix_tools_marker}@sha256" not in container_image:
-                    expected_image_values = deployable_details.get_helm_values(values, PropertyType.Image)
-                else:
-                    expected_image_values = values["matrixTools"]["image"]
-
-                assert expected_image_values["digest"] == container["image"].split("@")[1], (
-                    f"{template_id(template)} has container {container['name']} "
-                    "which doesn't have the expected image digest"
-                )
-                assert container["imagePullPolicy"] == "IfNotPresent", (
-                    f"{template_id(template)} has container {container['name']} "
-                    "which doesn't have the expected image pull policy"
-                )
+            assert container["imagePullPolicy"] == "IfNotPresent", (
+                f"{pod_template_details.manifest_id} has container {container['name']} "
+                "which doesn't have the expected image pull policy"
+            )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -174,13 +183,12 @@ async def test_pods_with_digest_and_no_tags(release_name, values, make_templates
 async def test_global_pullPolicy_overrides_templateDefaults(values, make_templates):
     # We use `Never` as it isn't used as a default pullPolicy for tags or digests
     values.setdefault("image", {})["pullPolicy"] = "Never"
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            for container in workload_spec_containers(template["spec"]["template"]["spec"]):
-                assert container["imagePullPolicy"] == "Never", (
-                    f"{template_id(template)} has container {container['name']} "
-                    "which doesn't have the expected image pull policy"
-                )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        for container in workload_spec_containers(pod_template_details.pod_template["spec"]):
+            assert container["imagePullPolicy"] == "Never", (
+                f"{pod_template_details.manifest_id} has container {container['name']} "
+                "which doesn't have the expected image pull policy"
+            )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -195,10 +203,9 @@ async def test_specific_image_pullPolicy_overrides_global_pullPolicy(values, mak
         deployable_details.set_helm_values(values, PropertyType.Image, {"pullPolicy": "Never"})
 
     iterate_deployables_parts(set_pull_policy, lambda deployable_details: deployable_details.has_image)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            for container in workload_spec_containers(template["spec"]["template"]["spec"]):
-                assert container["imagePullPolicy"] == "Never", (
-                    f"{template_id(template)} has container {container['name']} "
-                    "which doesn't have the expected image pull policy"
-                )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        for container in workload_spec_containers(pod_template_details.pod_template["spec"]):
+            assert container["imagePullPolicy"] == "Never", (
+                f"{pod_template_details.manifest_id} has container {container['name']} "
+                "which doesn't have the expected image pull policy"
+            )

--- a/tests/manifests/test_pod_initContainers.py
+++ b/tests/manifests/test_pod_initContainers.py
@@ -9,19 +9,19 @@ from frozendict import deepfreeze
 from . import DeployableDetails, PropertyType, values_files_to_test
 from .utils import (
     iterate_deployables_workload_parts,
-    template_id,
-    template_to_deployable_details,
+    iterate_pod_template,
 )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_pod_gets_configured_extraInitContainers(values, make_templates, release_name):
+async def test_pod_gets_configured_extraInitContainers(values, make_templates):
     template_id_to_init_containers = {}
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            template_id_to_init_containers[template_id(template)] = deepfreeze(pod_spec.get("initContainers", []))
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        template_id_to_init_containers[pod_template_details.manifest_id] = deepfreeze(
+            pod_spec.get("initContainers", [])
+        )
 
     def set_initContainers(deployable_details: DeployableDetails):
         init_container = [
@@ -35,15 +35,17 @@ async def test_pod_gets_configured_extraInitContainers(values, make_templates, r
         deployable_details.set_helm_values(values, PropertyType.InitContainers, deepfreeze(init_container))
 
     iterate_deployables_workload_parts(set_initContainers)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            assert "initContainers" in pod_spec, (
-                f"{template_id(template)} doesn't have at least one initContainers when a custom one is configured"
-            )
-            init_containers = pod_spec["initContainers"]
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "initContainers" in pod_spec, (
+            f"{pod_template_details.manifest_id} doesn't have at least one initContainers "
+            "when a custom one is configured"
+        )
+        init_containers = pod_spec["initContainers"]
 
-            deployable_details = template_to_deployable_details(template)
-            extra_init_containers = deployable_details.get_helm_values(values, PropertyType.InitContainers)
-            # All the existing initContainers come first
-            assert (template_id_to_init_containers[template_id(template)] + extra_init_containers) == init_containers
+        deployable_details = pod_template_details.deployable_details()
+        extra_init_containers = deployable_details.get_helm_values(values, PropertyType.InitContainers)
+        # All the existing initContainers come first
+        assert (
+            template_id_to_init_containers[pod_template_details.manifest_id] + extra_init_containers
+        ) == init_containers

--- a/tests/manifests/test_pod_nodeSelector.py
+++ b/tests/manifests/test_pod_nodeSelector.py
@@ -1,5 +1,5 @@
 # Copyright 2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -11,39 +11,37 @@ import pytest
 from . import DeployableDetails, PropertyType, values_files_to_test
 from .utils import (
     iterate_deployables_workload_parts,
-    template_id,
-    template_to_deployable_details,
+    iterate_pod_template,
 )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_pod_has_no_nodeSelector_by_default(templates):
-    for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            assert "nodeSelector" not in pod_spec, (
-                f"{template_id(template)} has a default nodeSelector when one isn't configured"
-            )
+    for pod_template_details in iterate_pod_template(templates):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "nodeSelector" not in pod_spec, (
+            f"{pod_template_details.manifest_id} has a default nodeSelector when one isn't configured"
+        )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
-async def test_pod_gets_configured_nodeSelector(values, make_templates, release_name):
+async def test_pod_gets_configured_nodeSelector(values, make_templates):
     def set_nodeSelector(deployable_details: DeployableDetails):
         nodeSelector = {"k8s.element.io/testing": "".join(random.choices(string.ascii_lowercase))}
         deployable_details.set_helm_values(values, PropertyType.NodeSelector, nodeSelector)
 
     iterate_deployables_workload_parts(set_nodeSelector)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            assert "nodeSelector" in pod_spec, (
-                f"{template_id(template)} doesn't have a nodeSelector when one is configured"
-            )
 
-            deployable_details = template_to_deployable_details(template)
-            expected_nodeSelector = deployable_details.get_helm_values(values, PropertyType.NodeSelector)
-            assert pod_spec["nodeSelector"] == expected_nodeSelector, (
-                f"{template_id(template)} has an unexpected nodeSelector"
-            )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "nodeSelector" in pod_spec, (
+            f"{pod_template_details.manifest_id} doesn't have a nodeSelector when one is configured"
+        )
+
+        deployable_details = pod_template_details.deployable_details()
+        expected_nodeSelector = deployable_details.get_helm_values(values, PropertyType.NodeSelector)
+        assert pod_spec["nodeSelector"] == expected_nodeSelector, (
+            f"{pod_template_details.manifest_id} has an unexpected nodeSelector"
+        )

--- a/tests/manifests/test_pod_priorityClassName.py
+++ b/tests/manifests/test_pod_priorityClassName.py
@@ -10,20 +10,18 @@ import pytest
 from . import DeployableDetails, PropertyType, values_files_to_test
 from .utils import (
     iterate_deployables_workload_parts,
-    template_id,
-    template_to_deployable_details,
+    iterate_pod_template,
 )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_pod_has_no_priorityClassName_by_default(templates):
-    for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            assert "priorityClassName" not in pod_spec, (
-                f"{template_id(template)} has a default priorityClassName when one isn't configured"
-            )
+    for pod_template_details in iterate_pod_template(templates):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "priorityClassName" not in pod_spec, (
+            f"{pod_template_details.manifest_id} has a default priorityClassName when one isn't configured"
+        )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -34,18 +32,17 @@ async def test_pod_gets_configured_priorityClassName(values, make_templates, rel
         deployable_details.set_helm_values(values, PropertyType.PriorityClassName, priorityClassName)
 
     iterate_deployables_workload_parts(set_priorityClassName)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            assert "priorityClassName" in pod_spec, (
-                f"{template_id(template)} doesn't have a priorityClassName when one is configured"
-            )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "priorityClassName" in pod_spec, (
+            f"{pod_template_details.manifest_id} doesn't have a priorityClassName when one is configured"
+        )
 
-            deployable_details = template_to_deployable_details(template)
-            expected_priorityClassName = deployable_details.get_helm_values(values, PropertyType.PriorityClassName)
-            assert pod_spec["priorityClassName"] == expected_priorityClassName, (
-                f"{template_id(template)} has an unexpected priorityClassName"
-            )
+        deployable_details = pod_template_details.deployable_details()
+        expected_priorityClassName = deployable_details.get_helm_values(values, PropertyType.PriorityClassName)
+        assert pod_spec["priorityClassName"] == expected_priorityClassName, (
+            f"{pod_template_details.manifest_id} has an unexpected priorityClassName"
+        )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -54,12 +51,11 @@ async def test_global_priorityClassName_renders(values, make_templates):
     global_priorityClassName = "global-priority"
     values["priorityClassName"] = global_priorityClassName
 
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            assert pod_spec.get("priorityClassName") == global_priorityClassName, (
-                f"{template_id(template)} doesn't inherit the global priorityClassName"
-            )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert pod_spec.get("priorityClassName") == global_priorityClassName, (
+            f"{pod_template_details.manifest_id} doesn't inherit the global priorityClassName"
+        )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -73,14 +69,14 @@ async def test_component_priorityClassName_overrides_global(values, make_templat
         deployable_details.set_helm_values(values, PropertyType.PriorityClassName, component_priorityClassName)
 
     iterate_deployables_workload_parts(set_priorityClassName)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            deployable_details = template_to_deployable_details(template)
-            expected_priorityClassName = deployable_details.get_helm_values(values, PropertyType.PriorityClassName)
-            assert pod_spec.get("priorityClassName") == expected_priorityClassName, (
-                f"{template_id(template)} did not let its component priorityClassName override the global one"
-            )
-            assert pod_spec["priorityClassName"] != global_priorityClassName, (
-                f"{template_id(template)} rendered the global priorityClassName instead of its component override"
-            )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        deployable_details = pod_template_details.deployable_details()
+        expected_priorityClassName = deployable_details.get_helm_values(values, PropertyType.PriorityClassName)
+        assert pod_spec.get("priorityClassName") == expected_priorityClassName, (
+            f"{pod_template_details.manifest_id} did not let its component priorityClassName override the global one"
+        )
+        assert pod_spec["priorityClassName"] != global_priorityClassName, (
+            f"{pod_template_details.manifest_id} rendered the global priorityClassName "
+            "instead of its component override"
+        )

--- a/tests/manifests/test_pod_probes.py
+++ b/tests/manifests/test_pod_probes.py
@@ -1,5 +1,5 @@
 # Copyright 2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -7,79 +7,87 @@
 import pytest
 
 from . import DeployableDetails, PropertyType, values_files_to_test
-from .utils import iterate_deployables_workload_parts, template_id, template_to_deployable_details
+from .utils import (
+    EPHEMERAL_WORKLOAD_KINDS,
+    PERSISTENT_WORKLOAD_KINDS,
+    PodTemplateDetails,
+    iterate_deployables_workload_parts,
+    iterate_pod_template,
+)
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_no_probes_for_jobs(templates):
-    for template in templates:
-        if template["kind"] == "Job":
-            for container in template["spec"]["template"]["spec"]["containers"]:
-                assert "livenessProbe" not in container, (
-                    f"{template_id(template)} has container {container['name']} with a livenessProbe"
-                )
-                assert "readinessProbe" not in container, (
-                    f"{template_id(template)} has container {container['name']} with a readinessProbe"
-                )
-                assert "startupProbe" not in container, (
-                    f"{template_id(template)} has container {container['name']} with a startupProbe"
-                )
+    for pod_template_details in iterate_pod_template(templates, kinds=EPHEMERAL_WORKLOAD_KINDS):
+        for container in pod_template_details.pod_template["spec"]["containers"]:
+            assert "livenessProbe" not in container, (
+                f"{pod_template_details.manifest_id} has container {container['name']} with a livenessProbe"
+            )
+            assert "readinessProbe" not in container, (
+                f"{pod_template_details.manifest_id} has container {container['name']} with a readinessProbe"
+            )
+            assert "startupProbe" not in container, (
+                f"{pod_template_details.manifest_id} has container {container['name']} with a startupProbe"
+            )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_no_probes_for_initContainers(templates):
-    for template in templates:
-        if template["kind"] == ["Deployment", "StatefulSet"]:
-            for init_container in template["spec"]["template"]["spec"].get("initContainers", []):
-                assert "livenessProbe" not in init_container, (
-                    f"{template_id(template)} has initContainer {init_container['name']} with a livenessProbe"
-                )
-                assert "readinessProbe" not in init_container, (
-                    f"{template_id(template)} has initContainer {init_container['name']} with a readinessProbe"
-                )
-                assert "startupProbe" not in init_container, (
-                    f"{template_id(template)} has initContainer {init_container['name']} with a startupProbe"
-                )
+    for pod_template_details in iterate_pod_template(templates, kinds=PERSISTENT_WORKLOAD_KINDS):
+        for init_container in pod_template_details.pod_template["spec"].get("initContainers", []):
+            assert "livenessProbe" not in init_container, (
+                f"{pod_template_details.manifest_id} has initContainer {init_container['name']} with a livenessProbe"
+            )
+            assert "readinessProbe" not in init_container, (
+                f"{pod_template_details.manifest_id} has initContainer {init_container['name']} with a readinessProbe"
+            )
+            assert "startupProbe" not in init_container, (
+                f"{pod_template_details.manifest_id} has initContainer {init_container['name']} with a startupProbe"
+            )
 
 
-def assert_sensible_default_probe(template, probe_type):
-    for container in template["spec"]["template"]["spec"]["containers"]:
+def assert_sensible_default_probe(pod_template_details: PodTemplateDetails, probe_type):
+    for container in pod_template_details.pod_template["spec"]["containers"]:
         assert probe_type in container, (
-            f"{template_id(template)} has container {container['name']} without a {probe_type}"
+            f"{pod_template_details.manifest_id} has container {container['name']} without a {probe_type}"
         )
         probe = container[probe_type]
 
         assert "failureThreshold" in probe, (
-            f"{template_id(template)} has container {container['name']} with a {probe_type} missing a failureThreshold"
+            f"{pod_template_details.manifest_id} has container {container['name']} with a "
+            f"{probe_type} missing a failureThreshold"
         )
         assert "periodSeconds" in probe, (
-            f"{template_id(template)} has container {container['name']} with a {probe_type} missing a periodSeconds"
+            f"{pod_template_details.manifest_id} has container {container['name']} with a "
+            f"{probe_type} missing a periodSeconds"
         )
         assert "successThreshold" in probe, (
-            f"{template_id(template)} has container {container['name']} with a {probe_type} missing a successThreshold"
+            f"{pod_template_details.manifest_id} has container {container['name']} with a "
+            f"{probe_type} missing a successThreshold"
         )
         assert "timeoutSeconds" in probe, (
-            f"{template_id(template)} has container {container['name']} with a {probe_type} missing a timeoutSeconds"
+            f"{pod_template_details.manifest_id} has container {container['name']} with a "
+            f"{probe_type} missing a timeoutSeconds"
         )
 
         # We use startupProbes for this
         assert "initialDelaySeconds" not in probe, (
-            f"{template_id(template)} has container {container['name']} with {probe_type}.initialDelaySeconds set "
-            "when we should be using a startupProbe"
+            f"{pod_template_details.manifest_id} has container {container['name']} with "
+            f"{probe_type}.initialDelaySeconds set when we should be using a startupProbe"
         )
 
         assert "httpGet" in probe or "exec" in probe or "tcpSocket" in probe
         if "httpGet" in probe:
             assert "port" in probe["httpGet"], (
-                f"{template_id(template)} has container {container['name']} whose "
+                f"{pod_template_details.manifest_id} has container {container['name']} whose "
                 "{probe_type}.http which doesn't specify a port"
             )
 
             probePort = probe["httpGet"]["port"]
             assert isinstance(probePort, str), (
-                f"{template_id(template)} has container {container['name']} whose "
+                f"{pod_template_details.manifest_id} has container {container['name']} whose "
                 "{probe_type}.httpGet.port isn't a named port"
             )
 
@@ -110,13 +118,13 @@ def set_probe_details(values, probe_type):
     iterate_deployables_workload_parts(set_probe_details)
 
 
-def assert_matching_probe(template, probe_type, values):
-    for container in template["spec"]["template"]["spec"]["containers"]:
+def assert_matching_probe(pod_template_details: PodTemplateDetails, probe_type, values):
+    for container in pod_template_details.pod_template["spec"]["containers"]:
         assert probe_type in container, (
-            f"{template_id(template)} has container {container['name']} without a {probe_type}"
+            f"{pod_template_details.manifest_id} has container {container['name']} without a {probe_type}"
         )
 
-        deployable_details = template_to_deployable_details(template, container["name"])
+        deployable_details = pod_template_details.deployable_details(container["name"])
         probe_types_to_property_types = {
             "livenessProbe": PropertyType.LivenessProbe,
             "readinessProbe": PropertyType.ReadinessProbe,
@@ -128,15 +136,16 @@ def assert_matching_probe(template, probe_type, values):
         for key, value in probe_details.items():
             if value is not None:
                 assert key in probe, (
-                    f"{template_id(template)} has container {container['name']} with a {probe_type} missing a {key}"
+                    f"{pod_template_details.manifest_id} has container {container['name']} with a {probe_type} "
+                    f"missing a {key}"
                 )
                 assert value == probe[key], (
-                    f"{template_id(template)} has container {container['name']} with {probe_type}.{key} "
+                    f"{pod_template_details.manifest_id} has container {container['name']} with {probe_type}.{key} "
                     f"where {probe[key]} != {value}"
                 )
             else:
                 assert key not in probe, (
-                    f"{template_id(template)} has container {container['name']} with a {probe_type} "
+                    f"{pod_template_details.manifest_id} has container {container['name']} with a {probe_type} "
                     f"with {key} present when it should be absent"
                 )
 
@@ -144,49 +153,43 @@ def assert_matching_probe(template, probe_type, values):
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_sensible_livenessProbes_by_default(templates):
-    for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet"]:
-            assert_sensible_default_probe(template, "livenessProbe")
+    for pod_template_details in iterate_pod_template(templates, kinds=PERSISTENT_WORKLOAD_KINDS):
+        assert_sensible_default_probe(pod_template_details, "livenessProbe")
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_livenessProbes_are_configurable(values, make_templates):
     set_probe_details(values, PropertyType.LivenessProbe)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet"]:
-            assert_matching_probe(template, "livenessProbe", values)
+    for pod_template_details in iterate_pod_template(await make_templates(values), kinds=PERSISTENT_WORKLOAD_KINDS):
+        assert_matching_probe(pod_template_details, "livenessProbe", values)
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_sensible_readinessProbes_by_default(templates):
-    for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet"]:
-            assert_sensible_default_probe(template, "readinessProbe")
+    for pod_template_details in iterate_pod_template(templates, kinds=PERSISTENT_WORKLOAD_KINDS):
+        assert_sensible_default_probe(pod_template_details, "readinessProbe")
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_readinessProbes_are_configurable(values, make_templates):
     set_probe_details(values, PropertyType.ReadinessProbe)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet"]:
-            assert_matching_probe(template, "readinessProbe", values)
+    for pod_template_details in iterate_pod_template(await make_templates(values), kinds=PERSISTENT_WORKLOAD_KINDS):
+        assert_matching_probe(pod_template_details, "readinessProbe", values)
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_sensible_startupProbes_by_default(templates):
-    for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet"]:
-            assert_sensible_default_probe(template, "startupProbe")
+    for pod_template_details in iterate_pod_template(templates, kinds=PERSISTENT_WORKLOAD_KINDS):
+        assert_sensible_default_probe(pod_template_details, "startupProbe")
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_startupProbes_are_configurable(values, make_templates):
     set_probe_details(values, PropertyType.StartupProbe)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet"]:
-            assert_matching_probe(template, "startupProbe", values)
+    for pod_template_details in iterate_pod_template(await make_templates(values), kinds=PERSISTENT_WORKLOAD_KINDS):
+        assert_matching_probe(pod_template_details, "startupProbe", values)

--- a/tests/manifests/test_pod_pull_secrets.py
+++ b/tests/manifests/test_pod_pull_secrets.py
@@ -1,12 +1,12 @@
 # Copyright 2024-2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import pytest
 
 from . import PropertyType, values_files_to_test
-from .utils import iterate_deployables_parts, template_id, workload_spec_containers
+from .utils import iterate_deployables_parts, iterate_pod_template, workload_spec_containers
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -15,16 +15,16 @@ async def test_sets_global_pull_secrets(values, make_templates):
     values.setdefault("image", {})["pullSecrets"] = [
         {"name": "global-secret"},
     ]
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            assert "imagePullSecrets" in template["spec"]["template"]["spec"], f"{id} should have an imagePullSecrets"
-            assert len(template["spec"]["template"]["spec"]["imagePullSecrets"]) == 1, (
-                f"Expected {template_id(template)} to have 2 image pull secrets"
-            )
-            assert template["spec"]["template"]["spec"]["imagePullSecrets"][0]["name"] == "global-secret", (
-                f"Expected {template_id(template)} to have image pull secret "
-                f"'{values['image']['pullSecrets'][0]['name']}'"
-            )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "imagePullSecrets" in pod_spec, f"{id} should have an imagePullSecrets"
+        assert len(pod_spec["imagePullSecrets"]) == 1, (
+            f"Expected {pod_template_details.manifest_id} to have 2 image pull secrets"
+        )
+        assert pod_spec["imagePullSecrets"][0]["name"] == "global-secret", (
+            f"Expected {pod_template_details.manifest_id} to have image pull secret "
+            f"'{values['image']['pullSecrets'][0]['name']}'"
+        )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -41,48 +41,41 @@ async def test_local_pull_secrets(values, base_values, make_templates):
         lambda deployable_details: deployable_details.has_image,
     )
 
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            any_container_uses_matrix_tools_image = any(
-                [
-                    base_values["matrixTools"]["image"]["repository"] in x["image"]
-                    for x in workload_spec_containers(template["spec"]["template"]["spec"])
-                ]
-            )
-            containers_with_matrix_tools_image = [
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        any_container_uses_matrix_tools_image = any(
+            [
                 base_values["matrixTools"]["image"]["repository"] in x["image"]
-                for x in workload_spec_containers(template["spec"]["template"]["spec"])
+                for x in workload_spec_containers(pod_spec)
             ]
-            any_container_uses_matrix_tools_image = any(containers_with_matrix_tools_image)
-            containers_only_uses_matrix_tools_image = all(containers_with_matrix_tools_image)
+        )
+        containers_with_matrix_tools_image = [
+            base_values["matrixTools"]["image"]["repository"] in x["image"] for x in workload_spec_containers(pod_spec)
+        ]
+        any_container_uses_matrix_tools_image = any(containers_with_matrix_tools_image)
+        containers_only_uses_matrix_tools_image = all(containers_with_matrix_tools_image)
 
-            id = template_id(template)
-            assert "imagePullSecrets" in template["spec"]["template"]["spec"], f"{id} should have an imagePullSecrets"
+        id = pod_template_details.manifest_id
+        assert "imagePullSecrets" in pod_spec, f"{id} should have an imagePullSecrets"
 
-            secret_names = [x["name"] for x in template["spec"]["template"]["spec"]["imagePullSecrets"]]
-            if containers_only_uses_matrix_tools_image:
-                assert len(template["spec"]["template"]["spec"]["imagePullSecrets"]) == 2, (
-                    f"Expected {id} to have 3 image pull secrets"
-                )
-                assert set(secret_names) == set(["matrix-tools-secret", "global-secret"]), (
-                    f"Expected {id} to have image pull secret names: local-secret, global-secret, "
-                    f"got {','.join(secret_names)}"
-                )
+        secret_names = [x["name"] for x in pod_spec["imagePullSecrets"]]
+        if containers_only_uses_matrix_tools_image:
+            assert len(pod_spec["imagePullSecrets"]) == 2, f"Expected {id} to have 3 image pull secrets"
+            assert set(secret_names) == set(["matrix-tools-secret", "global-secret"]), (
+                f"Expected {id} to have image pull secret names: local-secret, global-secret, "
+                f"got {','.join(secret_names)}"
+            )
 
-            elif any_container_uses_matrix_tools_image:
-                assert len(template["spec"]["template"]["spec"]["imagePullSecrets"]) == 3, (
-                    f"Expected {id} to have 4 image pull secrets"
-                )
+        elif any_container_uses_matrix_tools_image:
+            assert len(pod_spec["imagePullSecrets"]) == 3, f"Expected {id} to have 4 image pull secrets"
 
-                assert set(secret_names) == set(["matrix-tools-secret", "local-secret", "global-secret"]), (
-                    f"Expected {id} to have image pull secret names: "
-                    f"local-secret, global-secret, matrix-tools-secret, got {','.join(secret_names)}"
-                )
-            else:
-                assert len(template["spec"]["template"]["spec"]["imagePullSecrets"]) == 2, (
-                    f"Expected {id} to have 3 image pull secrets"
-                )
-                assert set(secret_names) == set(["local-secret", "global-secret"]), (
-                    f"Expected {id} to have image pull secret names: local-secret, global-secret, "
-                    f"got {','.join(secret_names)}"
-                )
+            assert set(secret_names) == set(["matrix-tools-secret", "local-secret", "global-secret"]), (
+                f"Expected {id} to have image pull secret names: "
+                f"local-secret, global-secret, matrix-tools-secret, got {','.join(secret_names)}"
+            )
+        else:
+            assert len(pod_spec["imagePullSecrets"]) == 2, f"Expected {id} to have 3 image pull secrets"
+            assert set(secret_names) == set(["local-secret", "global-secret"]), (
+                f"Expected {id} to have image pull secret names: local-secret, global-secret, "
+                f"got {','.join(secret_names)}"
+            )

--- a/tests/manifests/test_pod_replicas.py
+++ b/tests/manifests/test_pod_replicas.py
@@ -7,74 +7,72 @@ import pyhelm3
 import pytest
 
 from . import DeployableDetails, PropertyType, values_files_to_test
-from .utils import iterate_deployables_parts, template_id, template_to_deployable_details
+from .utils import PERSISTENT_WORKLOAD_KINDS, iterate_deployables_parts, iterate_pod_template
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_deployments_statefulsets_have_replicas_by_default(values, templates):
-    for template in templates:
-        if template["kind"] not in ["Deployment", "StatefulSet"]:
-            continue
-
-        assert "replicas" in template["spec"], f"{template_id(template)} does not specify replicas"
+    for pod_template_details in iterate_pod_template(templates, kinds=PERSISTENT_WORKLOAD_KINDS):
+        manifest_spec = pod_template_details.manifest["spec"]
+        assert "replicas" in manifest_spec, f"{pod_template_details.manifest_id} does not specify replicas"
         # This is here as we used to set podAntiAffinity based on the value of replicas
         # Until we allow for configurable affinity, we'll assert it here
-        assert "affinity" not in template["spec"]["template"]["spec"], (
-            f"{template_id(template)} has affinity where we don't allow configuration of affinity"
+        assert "affinity" not in pod_template_details.pod_template["spec"], (
+            f"{pod_template_details.manifest_id} has affinity where we don't allow configuration of affinity"
         )
 
-        deployable_details = template_to_deployable_details(template)
+        deployable_details = pod_template_details.deployable_details()
         # Because some values files set replicas to >1
         expected_replicas = deployable_details.get_helm_values(values, PropertyType.Replicas, 1)
-        assert template["spec"]["replicas"] == expected_replicas, (
-            f"{template_id(template)} has incorrect replicas value"
+        assert manifest_spec["replicas"] == expected_replicas, (
+            f"{pod_template_details.manifest_id} has incorrect replicas value"
         )
 
-        if template["kind"] == "Deployment":
-            max_unavailable = template["spec"]["strategy"]["rollingUpdate"]["maxUnavailable"]
+        if pod_template_details.manifest["kind"] == "Deployment":
+            max_unavailable = manifest_spec["strategy"]["rollingUpdate"]["maxUnavailable"]
             if expected_replicas > 1:
                 assert max_unavailable == 1, (
-                    f"{template_id(template)} has {max_unavailable=} when it should be 1 with more than 1 replica"
+                    f"{pod_template_details.manifest_id} has {max_unavailable=} when it should be 1 "
+                    "with more than 1 replica"
                 )
             else:
                 assert max_unavailable == 0, (
-                    f"{template_id(template)} has {max_unavailable=} when it should be 0 with no replicas"
+                    f"{pod_template_details.manifest_id} has {max_unavailable=} when it should be 0 with no replicas"
                 )
-            max_surge = template["spec"]["strategy"]["rollingUpdate"]["maxSurge"]
-            assert max_surge == 2, f"{template_id(template)} has {max_surge=} when it should be 2"
+            max_surge = manifest_spec["strategy"]["rollingUpdate"]["maxSurge"]
+            assert max_surge == 2, f"{pod_template_details.manifest_id} has {max_surge=} when it should be 2"
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_deployments_statefulsets_respect_replicas(values, make_templates):
     set_replicas_details(values)
-    for template in await make_templates(values):
-        if template["kind"] not in ["Deployment", "StatefulSet"]:
-            continue
-
-        assert "replicas" in template["spec"], f"{template_id(template)} does not specify replicas"
+    for pod_template_details in iterate_pod_template(await make_templates(values), kinds=PERSISTENT_WORKLOAD_KINDS):
+        manifest_spec = pod_template_details.manifest["spec"]
+        assert "replicas" in manifest_spec, f"{pod_template_details.manifest_id} does not specify replicas"
         # This is here as we used to set podAntiAffinity based on the value of replicas
         # Until we allow for configurable affinity, we'll assert it here
-        assert "affinity" not in template["spec"]["template"]["spec"], (
-            f"{template_id(template)} has affinity where we don't allow configuration of affinity"
+        assert "affinity" not in manifest_spec["template"]["spec"], (
+            f"{pod_template_details.manifest_id} has affinity where we don't allow configuration of affinity"
         )
 
-        deployable_details = template_to_deployable_details(template)
+        deployable_details = pod_template_details.deployable_details()
         expected_replicas = deployable_details.get_helm_values(values, PropertyType.Replicas)
-        assert expected_replicas == template["spec"]["replicas"], (
-            f"{template_id(template)} has incorrect replicas value"
+        assert expected_replicas == manifest_spec["replicas"], (
+            f"{pod_template_details.manifest_id} has incorrect replicas value"
         )
 
-        if template["kind"] == "Deployment":
-            max_unavailable = template["spec"]["strategy"]["rollingUpdate"]["maxUnavailable"]
-            if template_to_deployable_details(template).is_singleton:
+        if pod_template_details.manifest["kind"] == "Deployment":
+            max_unavailable = manifest_spec["strategy"]["rollingUpdate"]["maxUnavailable"]
+            if deployable_details.is_singleton:
                 assert max_unavailable == 0, (
-                    f"{template_id(template)} has {max_unavailable=} when it should be 0 with singletons:"
+                    f"{pod_template_details.manifest_id} has {max_unavailable=} when it should be 0 with singletons:"
                 )
             else:
                 assert max_unavailable == 1, (
-                    f"{template_id(template)} has {max_unavailable=} when it should be 1 with more than 1 replica"
+                    f"{pod_template_details.manifest_id} has {max_unavailable=} when it should be 1 "
+                    "with more than 1 replica"
                 )
 
 

--- a/tests/manifests/test_pod_resources.py
+++ b/tests/manifests/test_pod_resources.py
@@ -1,12 +1,12 @@
 # Copyright 2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import pytest
 
 from . import DeployableDetails, PropertyType, values_files_to_test
-from .utils import iterate_deployables_workload_parts, template_id, template_to_deployable_details
+from .utils import iterate_deployables_workload_parts, iterate_pod_template
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -30,17 +30,16 @@ async def test_pod_resources_are_configurable(values, make_templates):
         deployable_details.set_helm_values(values, PropertyType.Resources, resources)
 
     iterate_deployables_workload_parts(set_resources)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            for container in template["spec"]["template"]["spec"]["containers"]:
-                assert "resources" in container, (
-                    f"{template_id(template)} has container {container['name']} without resources"
-                )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        for container in pod_template_details.pod_template["spec"]["containers"]:
+            assert "resources" in container, (
+                f"{pod_template_details.manifest_id} has container {container['name']} without resources"
+            )
 
-                deployable_details = template_to_deployable_details(template, container["name"])
-                expected_resources = deployable_details.get_helm_values(values, PropertyType.Resources)
+            deployable_details = pod_template_details.deployable_details(container["name"])
+            expected_resources = deployable_details.get_helm_values(values, PropertyType.Resources)
 
-                assert expected_resources == container["resources"], (
-                    f"{template_id(template)} has container {container['name']} "
-                    "which doesn't have the expected resources"
-                )
+            assert expected_resources == container["resources"], (
+                f"{pod_template_details.manifest_id} has container {container['name']} "
+                "which doesn't have the expected resources"
+            )

--- a/tests/manifests/test_pod_restartPolicy.py
+++ b/tests/manifests/test_pod_restartPolicy.py
@@ -5,25 +5,21 @@
 import pytest
 
 from . import values_files_to_test
-from .utils import template_id
+from .utils import EPHEMERAL_WORKLOAD_KINDS, iterate_pod_template
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_pod_restartPolicy_set_based_on_controller(templates):
-    for template in templates:
-        if template["kind"] not in ["Deployment", "StatefulSet", "Job"]:
-            continue
-
-        assert "restartPolicy" in template["spec"]["template"]["spec"], (
-            f"{template_id(template)} doesn't set a Pod-level restartPolicy"
-        )
-        if template["kind"] == "Job":
-            assert template["spec"]["template"]["spec"]["restartPolicy"] == "Never", (
-                f"{template_id(template)} doesn't reset the Pod-level restartPolicy to 'Never' "
+    for pod_template_details in iterate_pod_template(templates):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "restartPolicy" in pod_spec, f"{pod_template_details.manifest_id} doesn't set a Pod-level restartPolicy"
+        if pod_template_details.manifest["kind"] in EPHEMERAL_WORKLOAD_KINDS:
+            assert pod_spec["restartPolicy"] == "Never", (
+                f"{pod_template_details.manifest_id} doesn't reset the Pod-level restartPolicy to 'Never' "
                 "so failed Pods won't be kept around"
             )
         else:
-            assert template["spec"]["template"]["spec"]["restartPolicy"] == "Always", (
-                f"{template_id(template)} doesn't reset the Pod-level restartPolicy to 'Always'"
+            assert pod_spec["restartPolicy"] == "Always", (
+                f"{pod_template_details.manifest_id} doesn't reset the Pod-level restartPolicy to 'Always'"
             )

--- a/tests/manifests/test_pod_runtimeClassName.py
+++ b/tests/manifests/test_pod_runtimeClassName.py
@@ -10,20 +10,18 @@ import pytest
 from . import DeployableDetails, PropertyType, values_files_to_test
 from .utils import (
     iterate_deployables_workload_parts,
-    template_id,
-    template_to_deployable_details,
+    iterate_pod_template,
 )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_pod_has_no_runtimeClassName_by_default(templates):
-    for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            assert "runtimeClassName" not in pod_spec, (
-                f"{template_id(template)} has a default runtimeClassName when one isn't configured"
-            )
+    for pod_template_details in iterate_pod_template(templates):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "runtimeClassName" not in pod_spec, (
+            f"{pod_template_details.manifest_id} has a default runtimeClassName when one isn't configured"
+        )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -34,18 +32,17 @@ async def test_pod_gets_configured_runtimeClassName(values, make_templates, rele
         deployable_details.set_helm_values(values, PropertyType.RuntimeClassName, runtimeClassName)
 
     iterate_deployables_workload_parts(set_runtimeClassName)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            assert "runtimeClassName" in pod_spec, (
-                f"{template_id(template)} doesn't have a runtimeClassName when one is configured"
-            )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "runtimeClassName" in pod_spec, (
+            f"{pod_template_details.manifest_id} doesn't have a runtimeClassName when one is configured"
+        )
 
-            deployable_details = template_to_deployable_details(template)
-            expected_runtimeClassName = deployable_details.get_helm_values(values, PropertyType.RuntimeClassName)
-            assert pod_spec["runtimeClassName"] == expected_runtimeClassName, (
-                f"{template_id(template)} has an unexpected runtimeClassName"
-            )
+        deployable_details = pod_template_details.deployable_details()
+        expected_runtimeClassName = deployable_details.get_helm_values(values, PropertyType.RuntimeClassName)
+        assert pod_spec["runtimeClassName"] == expected_runtimeClassName, (
+            f"{pod_template_details.manifest_id} has an unexpected runtimeClassName"
+        )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -54,12 +51,11 @@ async def test_global_runtimeClassName_renders(values, make_templates):
     global_runtimeClassName = "global-runtime"
     values["runtimeClassName"] = global_runtimeClassName
 
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            assert pod_spec.get("runtimeClassName") == global_runtimeClassName, (
-                f"{template_id(template)} doesn't inherit the global runtimeClassName"
-            )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert pod_spec.get("runtimeClassName") == global_runtimeClassName, (
+            f"{pod_template_details.manifest_id} doesn't inherit the global runtimeClassName"
+        )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -73,14 +69,13 @@ async def test_component_runtimeClassName_overrides_global(values, make_template
         deployable_details.set_helm_values(values, PropertyType.RuntimeClassName, component_runtimeClassName)
 
     iterate_deployables_workload_parts(set_runtimeClassName)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            deployable_details = template_to_deployable_details(template)
-            expected_runtimeClassName = deployable_details.get_helm_values(values, PropertyType.RuntimeClassName)
-            assert pod_spec.get("runtimeClassName") == expected_runtimeClassName, (
-                f"{template_id(template)} did not let its component runtimeClassName override the global one"
-            )
-            assert pod_spec["runtimeClassName"] != global_runtimeClassName, (
-                f"{template_id(template)} rendered the global runtimeClassName instead of its component override"
-            )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        deployable_details = pod_template_details.deployable_details()
+        expected_runtimeClassName = deployable_details.get_helm_values(values, PropertyType.RuntimeClassName)
+        assert pod_spec.get("runtimeClassName") == expected_runtimeClassName, (
+            f"{pod_template_details.manifest_id} did not let its component runtimeClassName override the global one"
+        )
+        assert pod_spec["runtimeClassName"] != global_runtimeClassName, (
+            f"{pod_template_details.manifest_id} rendered the global runtimeClassName instead of its component override"
+        )

--- a/tests/manifests/test_pod_schedulerName.py
+++ b/tests/manifests/test_pod_schedulerName.py
@@ -10,20 +10,18 @@ import pytest
 from . import DeployableDetails, PropertyType, values_files_to_test
 from .utils import (
     iterate_deployables_workload_parts,
-    template_id,
-    template_to_deployable_details,
+    iterate_pod_template,
 )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_pod_has_no_schedulerName_by_default(templates):
-    for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            assert "schedulerName" not in pod_spec, (
-                f"{template_id(template)} has a default schedulerName when one isn't configured"
-            )
+    for pod_template_details in iterate_pod_template(templates):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "schedulerName" not in pod_spec, (
+            f"{pod_template_details.manifest_id} has a default schedulerName when one isn't configured"
+        )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -34,18 +32,17 @@ async def test_pod_gets_configured_schedulerName(values, make_templates, release
         deployable_details.set_helm_values(values, PropertyType.SchedulerName, schedulerName)
 
     iterate_deployables_workload_parts(set_schedulerName)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            assert "schedulerName" in pod_spec, (
-                f"{template_id(template)} doesn't have a schedulerName when one is configured"
-            )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "schedulerName" in pod_spec, (
+            f"{pod_template_details.manifest_id} doesn't have a schedulerName when one is configured"
+        )
 
-            deployable_details = template_to_deployable_details(template)
-            expected_schedulerName = deployable_details.get_helm_values(values, PropertyType.SchedulerName)
-            assert pod_spec["schedulerName"] == expected_schedulerName, (
-                f"{template_id(template)} has an unexpected schedulerName"
-            )
+        deployable_details = pod_template_details.deployable_details()
+        expected_schedulerName = deployable_details.get_helm_values(values, PropertyType.SchedulerName)
+        assert pod_spec["schedulerName"] == expected_schedulerName, (
+            f"{pod_template_details.manifest_id} has an unexpected schedulerName"
+        )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -54,12 +51,11 @@ async def test_global_schedulerName_renders(values, make_templates):
     global_schedulerName = "global-scheduler"
     values["schedulerName"] = global_schedulerName
 
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            assert pod_spec.get("schedulerName") == global_schedulerName, (
-                f"{template_id(template)} doesn't inherit the global schedulerName"
-            )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert pod_spec.get("schedulerName") == global_schedulerName, (
+            f"{pod_template_details.manifest_id} doesn't inherit the global schedulerName"
+        )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -73,14 +69,13 @@ async def test_component_schedulerName_overrides_global(values, make_templates):
         deployable_details.set_helm_values(values, PropertyType.SchedulerName, component_schedulerName)
 
     iterate_deployables_workload_parts(set_schedulerName)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_spec = template["spec"]["template"]["spec"]
-            deployable_details = template_to_deployable_details(template)
-            expected_schedulerName = deployable_details.get_helm_values(values, PropertyType.SchedulerName)
-            assert pod_spec.get("schedulerName") == expected_schedulerName, (
-                f"{template_id(template)} did not let its component schedulerName override the global one"
-            )
-            assert pod_spec["schedulerName"] != global_schedulerName, (
-                f"{template_id(template)} rendered the global schedulerName instead of its component override"
-            )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        deployable_details = pod_template_details.deployable_details()
+        expected_schedulerName = deployable_details.get_helm_values(values, PropertyType.SchedulerName)
+        assert pod_spec.get("schedulerName") == expected_schedulerName, (
+            f"{pod_template_details.manifest_id} did not let its component schedulerName override the global one"
+        )
+        assert pod_spec["schedulerName"] != global_schedulerName, (
+            f"{pod_template_details.manifest_id} rendered the global schedulerName instead of its component override"
+        )

--- a/tests/manifests/test_pod_securityContext.py
+++ b/tests/manifests/test_pod_securityContext.py
@@ -1,40 +1,39 @@
 # Copyright 2024-2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import pytest
 
 from . import PropertyType, values_files_to_test
-from .utils import iterate_deployables_workload_parts, template_id
+from .utils import iterate_deployables_workload_parts, iterate_pod_template
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_sets_nonRoot_uids_gids_in_pod_securityContext_by_default(templates):
-    for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = template_id(template)
+    for pod_template_details in iterate_pod_template(templates):
+        id = pod_template_details.manifest_id
 
-            assert "securityContext" in template["spec"]["template"]["spec"], (
-                f"Pod securityContext unexpectedly absent for {id}"
-            )
+        assert "securityContext" in pod_template_details.pod_template["spec"], (
+            f"Pod securityContext unexpectedly absent for {id}"
+        )
 
-            pod_securityContext = template["spec"]["template"]["spec"]["securityContext"]
+        pod_securityContext = pod_template_details.pod_template["spec"]["securityContext"]
 
-            for idKey in ["runAsUser", "runAsGroup", "fsGroup"]:
-                assert idKey in pod_securityContext, f"No {idKey} in {id}'s Pod securityContext"
-                assert pod_securityContext[idKey] > 1000, f"Low {idKey} in {id}'s Pod securityContext"
+        for idKey in ["runAsUser", "runAsGroup", "fsGroup"]:
+            assert idKey in pod_securityContext, f"No {idKey} in {id}'s Pod securityContext"
+            assert pod_securityContext[idKey] > 1000, f"Low {idKey} in {id}'s Pod securityContext"
 
-            assert "runAsNonRoot" in pod_securityContext, f"No runAsNonRoot in {id}'s Pod securityContext"
-            assert pod_securityContext["runAsNonRoot"], f"{id} is running as root"
+        assert "runAsNonRoot" in pod_securityContext, f"No runAsNonRoot in {id}'s Pod securityContext"
+        assert pod_securityContext["runAsNonRoot"], f"{id} is running as root"
 
-            assert pod_securityContext["runAsUser"] == pod_securityContext["runAsGroup"], (
-                f"{id} has distinct uid and gid in the Pod securityContext"
-            )
-            assert pod_securityContext["runAsGroup"] == pod_securityContext["fsGroup"], (
-                f"{id} has distinct run and FS gids in the Pod securityContext"
-            )
+        assert pod_securityContext["runAsUser"] == pod_securityContext["runAsGroup"], (
+            f"{id} has distinct uid and gid in the Pod securityContext"
+        )
+        assert pod_securityContext["runAsGroup"] == pod_securityContext["fsGroup"], (
+            f"{id} has distinct run and FS gids in the Pod securityContext"
+        )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -46,40 +45,36 @@ async def test_can_nuke_pod_securityContext_ids(values, make_templates):
         ),
     )
 
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = template_id(template)
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        id = pod_template_details.manifest_id
 
-            assert "securityContext" in template["spec"]["template"]["spec"], (
-                f"Pod securityContext unexpectedly absent for {id}"
-            )
+        assert "securityContext" in pod_template_details.pod_template["spec"], (
+            f"Pod securityContext unexpectedly absent for {id}"
+        )
 
-            pod_securityContext = template["spec"]["template"]["spec"]["securityContext"]
+        pod_securityContext = pod_template_details.pod_template["spec"]["securityContext"]
 
-            for idKey in ["runAsUser", "runAsGroup", "fsGroup"]:
-                assert idKey not in pod_securityContext, f"{idKey} set in {id}'s Pod securityContext"
+        for idKey in ["runAsUser", "runAsGroup", "fsGroup"]:
+            assert idKey not in pod_securityContext, f"{idKey} set in {id}'s Pod securityContext"
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_sets_seccompProfile_in_pod_securityContext_by_default(templates):
-    for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = template_id(template)
+    for pod_template_details in iterate_pod_template(templates):
+        id = pod_template_details.manifest_id
 
-            assert "securityContext" in template["spec"]["template"]["spec"], (
-                f"Pod securityContext unexpectedly absent for {id}"
-            )
+        assert "securityContext" in pod_template_details.pod_template["spec"], (
+            f"Pod securityContext unexpectedly absent for {id}"
+        )
 
-            pod_securityContext = template["spec"]["template"]["spec"]["securityContext"]
+        pod_securityContext = pod_template_details.pod_template["spec"]["securityContext"]
 
-            assert "seccompProfile" in pod_securityContext, f"No seccompProfile in {id}'s Pod securityContext"
-            assert "type" in pod_securityContext["seccompProfile"], (
-                f"No type in {id}'s Pod securityContext.seccompProfile"
-            )
-            assert pod_securityContext["seccompProfile"]["type"] == "RuntimeDefault", (
-                f"{id} has unexpected seccompProfile type"
-            )
+        assert "seccompProfile" in pod_securityContext, f"No seccompProfile in {id}'s Pod securityContext"
+        assert "type" in pod_securityContext["seccompProfile"], f"No type in {id}'s Pod securityContext.seccompProfile"
+        assert pod_securityContext["seccompProfile"]["type"] == "RuntimeDefault", (
+            f"{id} has unexpected seccompProfile type"
+        )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -91,14 +86,13 @@ async def test_can_nuke_pod_securityContext_seccompProfile(values, make_template
         ),
     )
 
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = template_id(template)
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        id = pod_template_details.manifest_id
 
-            assert "securityContext" in template["spec"]["template"]["spec"], (
-                f"Pod securityContext unexpectedly absent for {id}"
-            )
+        assert "securityContext" in pod_template_details.pod_template["spec"], (
+            f"Pod securityContext unexpectedly absent for {id}"
+        )
 
-            pod_securityContext = template["spec"]["template"]["spec"]["securityContext"]
+        pod_securityContext = pod_template_details.pod_template["spec"]["securityContext"]
 
-            assert "seccompProfile" not in pod_securityContext, f"seccompProfile set in {id}'s Pod securityContext"
+        assert "seccompProfile" not in pod_securityContext, f"seccompProfile set in {id}'s Pod securityContext"

--- a/tests/manifests/test_postgres.py
+++ b/tests/manifests/test_postgres.py
@@ -1,16 +1,18 @@
 # Copyright 2024 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import pytest
+
+from manifests.utils import PERSISTENT_WORKLOAD_KINDS
 
 
 @pytest.mark.parametrize("values_file", ["synapse-minimal-values.yaml"])
 @pytest.mark.asyncio_cooperative
 async def test_postgres_env_overrides(values, make_templates):
     for template in await make_templates(values):
-        if "postgres" in template["metadata"]["name"] and template["kind"] == "StatefulSet":
+        if "postgres" in template["metadata"]["name"] and template["kind"] in PERSISTENT_WORKLOAD_KINDS:
             env = {e["name"]: e["value"] for e in template["spec"]["template"]["spec"]["containers"][0]["env"]}
             assert env["PGDATA"] == "/var/lib/postgres/data/pgdata"
             break
@@ -23,7 +25,7 @@ async def test_postgres_env_overrides(values, make_templates):
     ]
 
     for template in await make_templates(values):
-        if "postgres" in template["metadata"]["name"] and template["kind"] == "StatefulSet":
+        if "postgres" in template["metadata"]["name"] and template["kind"] in PERSISTENT_WORKLOAD_KINDS:
             env = {e["name"]: e["value"] for e in template["spec"]["template"]["spec"]["containers"][0]["env"]}
             assert env["PGDATA"] == "/var/lib/postgres/data/pgdata"
             assert env["OTHER_KEY"] == "should-be-here"

--- a/tests/manifests/test_pvcs.py
+++ b/tests/manifests/test_pvcs.py
@@ -9,7 +9,7 @@ import string
 import pytest
 
 from . import DeployableDetails, PropertyType, values_files_to_test
-from .utils import iterate_deployables_parts, template_id, template_to_deployable_details
+from .utils import ALL_WORKLOAD_KINDS, iterate_deployables_parts, template_id, template_to_deployable_details
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -17,7 +17,7 @@ from .utils import iterate_deployables_parts, template_id, template_to_deployabl
 async def test_pvcs_only_present_if_expected(templates):
     deployable_details_to_seen_pvcs = {}
     for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet"]:
+        if template["kind"] in ALL_WORKLOAD_KINDS:
             deployable_details = template_to_deployable_details(template)
             deployable_details_to_seen_pvcs.setdefault(deployable_details, False)
         if template["kind"] == "PersistentVolumeClaim":

--- a/tests/manifests/test_serviceaccounts.py
+++ b/tests/manifests/test_serviceaccounts.py
@@ -1,5 +1,5 @@
 # Copyright 2024-2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -7,23 +7,23 @@ import pytest
 
 from . import DeployableDetails, PropertyType, values_files_to_test
 from .utils import (
+    ALL_WORKLOAD_KINDS,
+    PodTemplateDetails,
     iterate_deployables_parts,
     iterate_deployables_workload_parts,
+    iterate_pod_template,
     template_id,
-    template_to_deployable_details,
 )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_automount_serviceaccount_tokens_as_appropriate(templates):
-    for template in templates:
-        deployable_details = template_to_deployable_details(template)
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            assert (
-                deployable_details.has_automount_service_account_token
-                == template["spec"]["template"]["spec"]["automountServiceAccountToken"]
-            )
+    for pod_template_details in iterate_pod_template(templates):
+        assert (
+            pod_template_details.deployable_details().has_automount_service_account_token
+            == pod_template_details.pod_template["spec"]["automountServiceAccountToken"]
+        )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -33,7 +33,7 @@ async def test_uses_serviceaccount_named_as_per_pod_controller_by_default(templa
     serviceaccount_names = set()
     covered_serviceaccount_names = set()
     for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+        if template["kind"] in ALL_WORKLOAD_KINDS:
             workloads_by_id[template_id(template)] = template
         elif template["kind"] == "ServiceAccount":
             serviceaccount_names.add(template["metadata"]["name"])
@@ -75,7 +75,7 @@ async def test_uses_serviceaccount_named_as_values_if_specified(values, make_tem
     workloads_by_id = {}
     serviceaccount_names = []
     for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
+        if template["kind"] in ALL_WORKLOAD_KINDS:
             workloads_by_id[template_id(template)] = template
         elif template["kind"] == "ServiceAccount":
             serviceaccount_names.append(template["metadata"]["name"])
@@ -107,7 +107,8 @@ async def test_does_not_create_serviceaccounts_if_configured_not_to(values, make
         assert template["kind"] != "ServiceAccount", (
             f"{template_id(template)} unexpectedly exists when all ServiceAccount should be turned off"
         )
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            assert "serviceAccountName" in template["spec"]["template"]["spec"], (
-                f"{template_id(template)} does not set an explicit ServiceAccount"
+        if template["kind"] in ALL_WORKLOAD_KINDS:
+            pod_template_details = PodTemplateDetails(template)
+            assert "serviceAccountName" in pod_template_details.pod_template["spec"], (
+                f"{pod_template_details.manifest_id} does not set an explicit ServiceAccount"
             )

--- a/tests/manifests/test_services.py
+++ b/tests/manifests/test_services.py
@@ -17,7 +17,7 @@ from . import (
     services_values_files_to_test,
     values_files_to_test,
 )
-from .utils import iterate_deployables_parts, template_id, template_to_deployable_details
+from .utils import PERSISTENT_WORKLOAD_KINDS, iterate_deployables_parts, template_id, template_to_deployable_details
 
 
 @pytest.mark.parametrize("values_file", services_values_files_to_test)
@@ -105,7 +105,10 @@ async def test_exposed_services_port_and_type(values, make_templates):
                                     == template["metadata"]["annotations"]["exposed-service-port-type"]
                                 )
                         found_exposed_services[deployable_details.name].append(template)
-                if template["kind"] == "Deployment" and "exposed-service-port-type" in template["metadata"]["labels"]:
+                if (
+                    template["kind"] in PERSISTENT_WORKLOAD_KINDS
+                    and "exposed-service-port-type" in template["metadata"]["labels"]
+                ):
                     container = template["spec"]["template"]["spec"]["containers"][0]
                     for port in container["ports"]:
                         if service_mode != "HostPort":

--- a/tests/manifests/test_synapse.py
+++ b/tests/manifests/test_synapse.py
@@ -10,10 +10,10 @@ import yaml
 
 from . import DeployableDetails, PropertyType
 from .utils import (
+    PERSISTENT_WORKLOAD_KINDS,
     iterate_deployables_ingress_parts,
     iterate_deployables_parts,
-    template_id,
-    template_to_deployable_details,
+    iterate_pod_template,
 )
 
 
@@ -25,7 +25,10 @@ async def test_appservice_configmaps_are_templated(release_name, values, make_te
     )
 
     for template in await make_templates(values):
-        if template["metadata"]["name"].startswith(f"{release_name}-synapse") and template["kind"] == "StatefulSet":
+        if (
+            template["metadata"]["name"].startswith(f"{release_name}-synapse")
+            and template["kind"] in PERSISTENT_WORKLOAD_KINDS
+        ):
             for volume in template["spec"]["template"]["spec"]["volumes"]:
                 if (
                     "configMap" in volume
@@ -54,7 +57,10 @@ async def test_appservice_secrets_are_templated(release_name, values, make_templ
     )
 
     for template in await make_templates(values):
-        if template["metadata"]["name"].startswith(f"{release_name}-synapse") and template["kind"] == "StatefulSet":
+        if (
+            template["metadata"]["name"].startswith(f"{release_name}-synapse")
+            and template["kind"] in PERSISTENT_WORKLOAD_KINDS
+        ):
             for volume in template["spec"]["template"]["spec"]["volumes"]:
                 if (
                     "secret" in volume
@@ -166,20 +172,19 @@ async def test_synapse_resources_shared_by_default(values, make_templates):
             deployable_details.set_helm_values(values, PropertyType.Resources, resources)
 
     iterate_deployables_parts(set_resources, lambda deployable_details: deployable_details.is_synapse_process)
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            deployable_details = template_to_deployable_details(template)
-            if not deployable_details.is_synapse_process:
-                continue
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        deployable_details = pod_template_details.deployable_details()
+        if not deployable_details.is_synapse_process:
+            continue
 
-            for container in template["spec"]["template"]["spec"]["containers"]:
-                assert "resources" in container, (
-                    f"{template_id(template)} has container {container['name']} without resources"
-                )
-                assert resources == container["resources"], (
-                    f"{template_id(template)} has container {container['name']} "
-                    "which doesn't have the expected resources"
-                )
+        for container in pod_template_details.pod_template["spec"]["containers"]:
+            assert "resources" in container, (
+                f"{pod_template_details.manifest_id} has container {container['name']} without resources"
+            )
+            assert resources == container["resources"], (
+                f"{pod_template_details.manifest_id} has container {container['name']} "
+                "which doesn't have the expected resources"
+            )
 
 
 @pytest.mark.parametrize("values_file", ["synapse-minimal-values.yaml"])

--- a/tests/manifests/test_tolerations.py
+++ b/tests/manifests/test_tolerations.py
@@ -1,5 +1,5 @@
 # Copyright 2024-2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -7,7 +7,7 @@ import pytest
 from frozendict import frozendict
 
 from . import PropertyType, values_files_to_test
-from .utils import iterate_deployables_workload_parts, template_id
+from .utils import iterate_deployables_workload_parts, iterate_pod_template
 
 specific_toleration = frozendict(
     {
@@ -31,11 +31,10 @@ global_toleration = frozendict(
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_no_tolerations_by_default(templates):
-    for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            assert "tolerations" not in template["spec"]["template"]["spec"], (
-                f"Tolerations unexpectedly present for {template_id(template)}"
-            )
+    for pod_template_details in iterate_pod_template(templates):
+        assert "tolerations" not in pod_template_details.pod_template["spec"], (
+            f"Tolerations unexpectedly present for {pod_template_details.manifest_id}"
+        )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -47,14 +46,13 @@ async def test_all_components_and_sub_components_render_tolerations(values, make
         ),
     )
 
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = template_id(template)
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        id = pod_template_details.manifest_id
 
-            pod_spec = template["spec"]["template"]["spec"]
-            assert "tolerations" in pod_spec, f"No tolerations for {id}"
-            assert len(pod_spec["tolerations"]) == 1, f"Wrong number of tolerations for {id}"
-            assert pod_spec["tolerations"][0] == specific_toleration, f"Toleration isn't as expected for {id}"
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "tolerations" in pod_spec, f"No tolerations for {id}"
+        assert len(pod_spec["tolerations"]) == 1, f"Wrong number of tolerations for {id}"
+        assert pod_spec["tolerations"][0] == specific_toleration, f"Toleration isn't as expected for {id}"
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -62,14 +60,13 @@ async def test_all_components_and_sub_components_render_tolerations(values, make
 async def test_global_tolerations_render(values, make_templates):
     values.setdefault("tolerations", []).append(global_toleration)
 
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = template_id(template)
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        id = pod_template_details.manifest_id
 
-            pod_spec = template["spec"]["template"]["spec"]
-            assert "tolerations" in pod_spec, f"No tolerations for {id}"
-            assert len(pod_spec["tolerations"]) == 1, f"Wrong number of tolerations for {id}"
-            assert pod_spec["tolerations"][0] == global_toleration, f"Toleration isn't as expected for {id}"
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "tolerations" in pod_spec, f"No tolerations for {id}"
+        assert len(pod_spec["tolerations"]) == 1, f"Wrong number of tolerations for {id}"
+        assert pod_spec["tolerations"][0] == global_toleration, f"Toleration isn't as expected for {id}"
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -85,14 +82,13 @@ async def test_merges_global_and_specific_tolerations(values, make_templates):
     values.setdefault("tolerations", []).append(global_toleration)
     values.get("tolerations").append(global_toleration)
 
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            id = template_id(template)
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        id = pod_template_details.manifest_id
 
-            pod_spec = template["spec"]["template"]["spec"]
-            assert "tolerations" in pod_spec, f"No tolerations for {id}"
-            assert len(pod_spec["tolerations"]) == 2, f"Wrong number of tolerations for {id}"
-            assert pod_spec["tolerations"] == (
-                specific_toleration,
-                global_toleration,
-            ), f"Tolerations aren't as expected for {id}"
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "tolerations" in pod_spec, f"No tolerations for {id}"
+        assert len(pod_spec["tolerations"]) == 2, f"Wrong number of tolerations for {id}"
+        assert pod_spec["tolerations"] == (
+            specific_toleration,
+            global_toleration,
+        ), f"Tolerations aren't as expected for {id}"

--- a/tests/manifests/test_topology_spread_constraints.py
+++ b/tests/manifests/test_topology_spread_constraints.py
@@ -1,5 +1,5 @@
 # Copyright 2024-2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -7,40 +7,41 @@ import pytest
 from frozendict import frozendict
 
 from . import DeployableDetails, PropertyType, values_files_to_test
-from .utils import iterate_deployables_workload_parts, template_id
+from .utils import iterate_deployables_workload_parts, iterate_pod_template
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_sets_default_topologySpreadConstraints(templates):
-    for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            assert "topologySpreadConstraints" in template["spec"]["template"]["spec"], (
-                f"Pod topologySpreadConstraints unexpectedly absent for {template_id(template)}"
-            )
+    for pod_template_details in iterate_pod_template(templates):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "topologySpreadConstraints" in pod_spec, (
+            f"Pod topologySpreadConstraints unexpectedly absent for {pod_template_details.manifest_id}"
+        )
 
-            pod_topologySpreadConstraints = template["spec"]["template"]["spec"]["topologySpreadConstraints"]
-            assert pod_topologySpreadConstraints[0]["maxSkew"] == 1
-            assert pod_topologySpreadConstraints[0]["topologyKey"] == "kubernetes.io/hostname"
-            assert pod_topologySpreadConstraints[0]["whenUnsatisfiable"] == "ScheduleAnyway"
-            assert pod_topologySpreadConstraints[0]["labelSelector"]["matchLabels"] == {
-                "app.kubernetes.io/instance": template["metadata"]["labels"]["app.kubernetes.io/instance"]
-            }
-            if template["kind"] == "Deployment":
-                assert pod_topologySpreadConstraints[0]["matchLabelKeys"] == ("pod-template-hash",)
-            else:
-                assert pod_topologySpreadConstraints[0]["matchLabelKeys"] == tuple()
+        pod_topologySpreadConstraints = pod_spec["topologySpreadConstraints"]
+        assert pod_topologySpreadConstraints[0]["maxSkew"] == 1
+        assert pod_topologySpreadConstraints[0]["topologyKey"] == "kubernetes.io/hostname"
+        assert pod_topologySpreadConstraints[0]["whenUnsatisfiable"] == "ScheduleAnyway"
+        assert pod_topologySpreadConstraints[0]["labelSelector"]["matchLabels"] == {
+            "app.kubernetes.io/instance": pod_template_details.manifest["metadata"]["labels"][
+                "app.kubernetes.io/instance"
+            ]
+        }
+        if pod_template_details.manifest["kind"] == "Deployment":
+            assert pod_topologySpreadConstraints[0]["matchLabelKeys"] == ("pod-template-hash",)
+        else:
+            assert pod_topologySpreadConstraints[0]["matchLabelKeys"] == tuple()
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_can_unset_global_topologySpreadConstraints(values, make_templates):
     values["topologySpreadConstraints"] = []
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            assert "topologySpreadConstraints" not in template["spec"]["template"]["spec"], (
-                f"Pod securityContext unexpectedly present for {template_id(template)}"
-            )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        assert "topologySpreadConstraints" not in pod_template_details.pod_template["spec"], (
+            f"Pod securityContext unexpectedly present for {pod_template_details.manifest_id}"
+        )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -61,24 +62,25 @@ async def test_topology_spread_constraint_enriches_with_default_settings(values,
         )
 
     iterate_deployables_workload_parts(set_topology_spread_constraints)
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "topologySpreadConstraints" in pod_spec, (
+            f"Pod topologySpreadConstraints unexpectedly absent for {pod_template_details.manifest_id}"
+        )
 
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            assert "topologySpreadConstraints" in template["spec"]["template"]["spec"], (
-                f"Pod topologySpreadConstraints unexpectedly absent for {template_id(template)}"
-            )
-
-            pod_topologySpreadConstraints = template["spec"]["template"]["spec"]["topologySpreadConstraints"]
-            assert pod_topologySpreadConstraints[0]["maxSkew"] == 2
-            assert pod_topologySpreadConstraints[0]["topologyKey"] == "kubernetes.io/zone"
-            assert pod_topologySpreadConstraints[0]["whenUnsatisfiable"] == "DoNotSchedule"
-            assert pod_topologySpreadConstraints[0]["labelSelector"]["matchLabels"] == {
-                "app.kubernetes.io/instance": template["metadata"]["labels"]["app.kubernetes.io/instance"]
-            }
-            if template["kind"] == "Deployment":
-                assert pod_topologySpreadConstraints[0]["matchLabelKeys"] == ("pod-template-hash",)
-            else:
-                assert pod_topologySpreadConstraints[0]["matchLabelKeys"] == tuple()
+        pod_topologySpreadConstraints = pod_spec["topologySpreadConstraints"]
+        assert pod_topologySpreadConstraints[0]["maxSkew"] == 2
+        assert pod_topologySpreadConstraints[0]["topologyKey"] == "kubernetes.io/zone"
+        assert pod_topologySpreadConstraints[0]["whenUnsatisfiable"] == "DoNotSchedule"
+        assert pod_topologySpreadConstraints[0]["labelSelector"]["matchLabels"] == {
+            "app.kubernetes.io/instance": pod_template_details.manifest["metadata"]["labels"][
+                "app.kubernetes.io/instance"
+            ]
+        }
+        if pod_template_details.manifest["kind"] == "Deployment":
+            assert pod_topologySpreadConstraints[0]["matchLabelKeys"] == ("pod-template-hash",)
+        else:
+            assert pod_topologySpreadConstraints[0]["matchLabelKeys"] == tuple()
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -105,18 +107,17 @@ async def test_can_nuke_topology_spread_constraint_default_settings(values, make
         )
 
     iterate_deployables_workload_parts(set_topology_spread_constraints)
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+        assert "topologySpreadConstraints" in pod_spec, (
+            f"Pod topologySpreadConstraints unexpectedly absent for {pod_template_details.manifest_id}"
+        )
 
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            assert "topologySpreadConstraints" in template["spec"]["template"]["spec"], (
-                f"Pod topologySpreadConstraints unexpectedly absent for {template_id(template)}"
-            )
-
-            pod_topologySpreadConstraints = template["spec"]["template"]["spec"]["topologySpreadConstraints"]
-            assert pod_topologySpreadConstraints[0]["maxSkew"] == 1
-            assert pod_topologySpreadConstraints[0]["topologyKey"] == "kubernetes.io/hostname"
-            assert pod_topologySpreadConstraints[0]["whenUnsatisfiable"] == "DoNotSchedule"
-            assert pod_topologySpreadConstraints[0]["labelSelector"]["matchLabels"] == frozendict(
-                {"app.kubernetes.io/testlabel": "testvalue"}
-            )
-            assert pod_topologySpreadConstraints[0]["matchLabelKeys"] == ("app.kubernetes.io/testlabel",)
+        pod_topologySpreadConstraints = pod_spec["topologySpreadConstraints"]
+        assert pod_topologySpreadConstraints[0]["maxSkew"] == 1
+        assert pod_topologySpreadConstraints[0]["topologyKey"] == "kubernetes.io/hostname"
+        assert pod_topologySpreadConstraints[0]["whenUnsatisfiable"] == "DoNotSchedule"
+        assert pod_topologySpreadConstraints[0]["labelSelector"]["matchLabels"] == frozendict(
+            {"app.kubernetes.io/testlabel": "testvalue"}
+        )
+        assert pod_topologySpreadConstraints[0]["matchLabelKeys"] == ("app.kubernetes.io/testlabel",)

--- a/tests/manifests/test_volumes.py
+++ b/tests/manifests/test_volumes.py
@@ -13,25 +13,22 @@ from . import (
     secret_values_files_to_test,
     values_files_to_test,
 )
-from .utils import iterate_deployables_workload_parts, template_id, template_to_deployable_details
+from .utils import iterate_deployables_workload_parts, iterate_pod_template
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test | secret_values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_emptyDirs_are_memory(templates):
-    for template in templates:
-        if template["kind"] not in ["Deployment", "Job", "StatefulSet"]:
-            continue
-
-        for volume in template["spec"]["template"]["spec"].get("volumes", []):
+    for pod_template_details in iterate_pod_template(templates):
+        for volume in pod_template_details.pod_template["spec"].get("volumes", []):
             if "emptyDir" not in volume:
                 continue
 
             assert "medium" in volume["emptyDir"], (
-                f"{template_id(template)} has emptyDir {volume['name']} but doesn't set the medium"
+                f"{pod_template_details.manifest_id} has emptyDir {volume['name']} but doesn't set the medium"
             )
             assert volume["emptyDir"]["medium"] == "Memory", (
-                f"{template_id(template)} has emptyDir {volume['name']} that isn't Memory backed"
+                f"{pod_template_details.manifest_id} has emptyDir {volume['name']} that isn't Memory backed"
             )
 
 
@@ -120,34 +117,31 @@ async def test_extra_volumes(values, make_templates, release_name):
         return expected_volumes
 
     template_id_to_pod_volumes = {}
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            pod_volumes = deepfreeze(template["spec"]["template"]["spec"].get("volumes", []))
-            template_id_to_pod_volumes[template_id(template)] = pod_volumes
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_volumes = deepfreeze(pod_template_details.pod_template["spec"].get("volumes", []))
+        template_id_to_pod_volumes[pod_template_details.manifest_id] = pod_volumes
 
     iterate_deployables_workload_parts(set_extra_volumes)
-
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            assert "volumes" in template["spec"]["template"]["spec"], (
-                f"Pod volumes unexpectedly absent for {template_id(template)}"
-            )
-            pod_volumes = deepfreeze(template["spec"]["template"]["spec"]["volumes"])
-            deployable_details = template_to_deployable_details(template)
-            if deployable_details.has_mount_context:
-                if template["metadata"].get("annotations", {}).get("helm.sh/hook-weight"):
-                    assert set(pod_volumes) - set(template_id_to_pod_volumes[f"{template_id(template)}"]) == set(
-                        get_expected_volumes_from_values(deployable_details, with_hooks=True)
-                    ), f"Pod container {template_id(template)} volume mounts {pod_volumes}"
-                else:
-                    assert set(pod_volumes) - set(template_id_to_pod_volumes[f"{template_id(template)}"]) == set(
-                        get_expected_volumes_from_values(deployable_details, with_hooks=False)
-                    ), f"Pod container {template_id(template)} volume mounts {pod_volumes}"
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        assert "volumes" in pod_template_details.pod_template["spec"], (
+            f"Pod volumes unexpectedly absent for {pod_template_details.manifest_id}"
+        )
+        pod_volumes = deepfreeze(pod_template_details.pod_template["spec"]["volumes"])
+        deployable_details = pod_template_details.deployable_details()
+        if deployable_details.has_mount_context:
+            if pod_template_details.manifest["metadata"].get("annotations", {}).get("helm.sh/hook-weight"):
+                assert set(pod_volumes) - set(template_id_to_pod_volumes[pod_template_details.manifest_id]) == set(
+                    get_expected_volumes_from_values(deployable_details, with_hooks=True)
+                ), f"Pod container {pod_template_details.manifest_id} volume mounts {pod_volumes}"
             else:
-                assert "volumes" in template["spec"]["template"]["spec"], (
-                    f"Pod volumes unexpectedly absent for {template_id(template)}"
-                )
+                assert set(pod_volumes) - set(template_id_to_pod_volumes[pod_template_details.manifest_id]) == set(
+                    get_expected_volumes_from_values(deployable_details, with_hooks=False)
+                ), f"Pod container {pod_template_details.manifest_id} volume mounts {pod_volumes}"
+        else:
+            assert "volumes" in pod_template_details.pod_template["spec"], (
+                f"Pod volumes unexpectedly absent for {pod_template_details.manifest_id}"
+            )
 
-                assert set(pod_volumes) - set(template_id_to_pod_volumes[template_id(template)]) == set(
-                    get_expected_volumes_from_values(deployable_details, with_hooks=None)
-                ), f"Pod volumes {pod_volumes} is missing expected extra volume"
+            assert set(pod_volumes) - set(template_id_to_pod_volumes[pod_template_details.manifest_id]) == set(
+                get_expected_volumes_from_values(deployable_details, with_hooks=None)
+            ), f"Pod volumes {pod_volumes} is missing expected extra volume"

--- a/tests/manifests/test_volumes_mounts.py
+++ b/tests/manifests/test_volumes_mounts.py
@@ -16,8 +16,7 @@ from . import (
 )
 from .utils import (
     iterate_deployables_workload_parts,
-    template_id,
-    template_to_deployable_details,
+    iterate_pod_template,
     workload_spec_containers,
 )
 
@@ -33,52 +32,57 @@ async def test_volumes_mounts_exists(release_name, templates, other_secrets, oth
         + [s["metadata"]["name"] for s in other_secrets]
         + [c["spec"]["secretName"] for c in [c for c in templates if c["kind"] == "Certificate"]]
     )
-    for template in templates:
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            volumes_names = []
-            for volume in template["spec"]["template"]["spec"].get("volumes", []):
-                assert len(volume["name"]) <= 63, (
-                    f"Volume name {volume['name']} is too long: {volume['name']} in {template_id(template)}"
+    for pod_template_details in iterate_pod_template(templates):
+        volumes_names = []
+        for volume in pod_template_details.pod_template["spec"].get("volumes", []):
+            assert len(volume["name"]) <= 63, (
+                f"Volume name {volume['name']} is too long: {volume['name']} in {pod_template_details.manifest_id}"
+            )
+            assert volume["name"] not in volumes_names, (
+                f"Volume name {volume['name']} is listed multiple times in {pod_template_details.manifest_id}"
+            )
+            volumes_names.append(volume["name"])
+
+            # Volumes could be dynamic in other ways, but including $.Release.Name is the most likely
+            assert release_name not in volume["name"]
+
+            if "secret" in volume:
+                assert volume["secret"]["secretName"] in secrets_names, (
+                    f"Volume {volume['secret']['secretName']} not found in Secret names:"
+                    f"{secrets_names} for {pod_template_details.manifest_id}"
                 )
-                assert volume["name"] not in volumes_names, (
-                    f"Volume name {volume['name']} is listed multiple times in {template_id(template)}"
+                assert re.match(
+                    r"^((as)-\d+|(secret)-[a-f0-9]{12}|" + r"secret-(generated|turn-tls)|"
+                    r")$",
+                    volume["name"],
+                ), (
+                    f"{pod_template_details.manifest_id} contains a Secret mounted with an unexpected name: ",
+                    volume["name"],
                 )
-                volumes_names.append(volume["name"])
+            if "configMap" in volume:
+                assert volume["configMap"]["name"] in configmaps_names, (
+                    f"Volume {volume['configMap']['name']} not found in ConfigMap names:"
+                    f"{configmaps_names} for {pod_template_details.manifest_id}"
+                )
+                assert re.match(
+                    r"^("
+                    r"(haproxy-|nginx-|plain)?(-syn-|-mas-|-)?config|"
+                    r"(synapse|well-known)-haproxy|"
+                    r"registration-templates|"
+                    r"test-[\w-]+"
+                    r")$",
+                    volume["name"],
+                ), (
+                    f"{pod_template_details.manifest_id} contains a ConfigMap mounted with an unexpected name: ",
+                    volume["name"],
+                )
 
-                # Volumes could be dynamic in other ways, but including $.Release.Name is the most likely
-                assert release_name not in volume["name"]
-
-                if "secret" in volume:
-                    assert volume["secret"]["secretName"] in secrets_names, (
-                        f"Volume {volume['secret']['secretName']} not found in Secret names:"
-                        f"{secrets_names} for {template_id(template)}"
-                    )
-                    assert re.match(
-                        r"^((as)-\d+|(secret)-[a-f0-9]{12}|" + r"secret-(generated|turn-tls)|"
-                        r")$",
-                        volume["name"],
-                    ), f"{template_id(template)} contains a Secret mounted with an unexpected name: {volume['name']}"
-                if "configMap" in volume:
-                    assert volume["configMap"]["name"] in configmaps_names, (
-                        f"Volume {volume['configMap']['name']} not found in ConfigMap names:"
-                        f"{configmaps_names} for {template_id(template)}"
-                    )
-                    assert re.match(
-                        r"^("
-                        r"(haproxy-|nginx-|plain)?(-syn-|-mas-|-)?config|"
-                        r"(synapse|well-known)-haproxy|"
-                        r"registration-templates|"
-                        r"test-[\w-]+"
-                        r")$",
-                        volume["name"],
-                    ), f"{template_id(template)} contains a ConfigMap mounted with an unexpected name: {volume['name']}"
-
-            for container in workload_spec_containers(template["spec"]["template"]["spec"]):
-                for volume_mount in container.get("volumeMounts", []):
-                    assert volume_mount["name"] in volumes_names, (
-                        f"Volume Mount {volume_mount['name']} not found in volume names: {volumes_names} "
-                        f"for {template_id(template)}/{container['name']}"
-                    )
+        for container in workload_spec_containers(pod_template_details.pod_template["spec"]):
+            for volume_mount in container.get("volumeMounts", []):
+                assert volume_mount["name"] in volumes_names, (
+                    f"Volume Mount {volume_mount['name']} not found in volume names: {volumes_names} "
+                    f"for {pod_template_details.manifest_id}/{container['name']}"
+                )
 
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
@@ -165,47 +169,49 @@ async def test_extra_volume_mounts(values, make_templates):
         return expected_volume_mounts
 
     template_containers_volumes_mounts = {}
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            for container in workload_spec_containers(template["spec"]["template"]["spec"]):
-                volumes_mounts = deepfreeze(container.get("volumeMounts", []))
-                pod_container_volumes = volumes_mounts
-                template_containers_volumes_mounts[f"{template_id(template)}/{container['name']}"] = (
-                    pod_container_volumes
-                )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        for container in workload_spec_containers(pod_template_details.pod_template["spec"]):
+            volumes_mounts = deepfreeze(container.get("volumeMounts", []))
+            pod_container_volumes = volumes_mounts
+            template_containers_volumes_mounts[f"{pod_template_details.manifest_id}/{container['name']}"] = (
+                pod_container_volumes
+            )
 
     iterate_deployables_workload_parts(set_extra_volume_mounts)
-
-    for template in await make_templates(values):
-        if template["kind"] in ["Deployment", "StatefulSet", "Job"]:
-            for container in workload_spec_containers(template["spec"]["template"]["spec"]):
-                assert "volumeMounts" in container, (
-                    f"Pod container {template_id(template)}/{container['name']} does not have volumeMounts"
-                )
-                volumes_mounts = deepfreeze(container["volumeMounts"])
-                deployable_details = template_to_deployable_details(template)
-                container_details = deployable_details.deployable_details_for_container(container["name"])
-                if container_details.has_mount_context:
-                    if template["metadata"].get("annotations", {}).get("helm.sh/hook-weight"):
-                        assert set(volumes_mounts) - set(
-                            template_containers_volumes_mounts[f"{template_id(template)}/{container['name']}"]
-                        ) == set(
-                            get_expected_volume_mounts_from_values(
-                                deployable_details, container["name"], with_hooks=True
-                            )
-                        ), f"Pod container {template_id(template)}/{container['name']} volume mounts {volumes_mounts}"
-                    else:
-                        assert set(volumes_mounts) - set(
-                            template_containers_volumes_mounts[f"{template_id(template)}/{container['name']}"]
-                        ) == set(
-                            get_expected_volume_mounts_from_values(
-                                deployable_details, container["name"], with_hooks=False
-                            )
-                        ), f"Pod container {template_id(template)}/{container['name']} volume mounts {volumes_mounts}"
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        for container in workload_spec_containers(pod_template_details.pod_template["spec"]):
+            assert "volumeMounts" in container, (
+                f"Pod container {pod_template_details.manifest_id}/{container['name']} does not have volumeMounts"
+            )
+            volumes_mounts = deepfreeze(container["volumeMounts"])
+            deployable_details = pod_template_details.deployable_details()
+            container_details = pod_template_details.deployable_details(container["name"])
+            if container_details.has_mount_context:
+                if pod_template_details.manifest["metadata"].get("annotations", {}).get("helm.sh/hook-weight"):
+                    assert set(volumes_mounts) - set(
+                        template_containers_volumes_mounts[f"{pod_template_details.manifest_id}/{container['name']}"]
+                    ) == set(
+                        get_expected_volume_mounts_from_values(deployable_details, container["name"], with_hooks=True)
+                    ), (
+                        f"Pod container {pod_template_details.manifest_id}/{container['name']} volume mounts ",
+                        volumes_mounts,
+                    )
                 else:
                     assert set(volumes_mounts) - set(
-                        template_containers_volumes_mounts[f"{template_id(template)}/{container['name']}"]
+                        template_containers_volumes_mounts[f"{pod_template_details.manifest_id}/{container['name']}"]
                     ) == set(
-                        get_expected_volume_mounts_from_values(deployable_details, container["name"], with_hooks=None)
-                    ), f"Pod container {template_id(template)}/{container['name']} volume mounts {volumes_mounts}"
-                    " is missing expected extra volume"
+                        get_expected_volume_mounts_from_values(deployable_details, container["name"], with_hooks=False)
+                    ), (
+                        f"Pod container {pod_template_details.manifest_id}/{container['name']} volume mounts ",
+                        volumes_mounts,
+                    )
+            else:
+                assert set(volumes_mounts) - set(
+                    template_containers_volumes_mounts[f"{pod_template_details.manifest_id}/{container['name']}"]
+                ) == set(
+                    get_expected_volume_mounts_from_values(deployable_details, container["name"], with_hooks=None)
+                ), (
+                    f"Pod container {pod_template_details.manifest_id}/{container['name']} volume mounts ",
+                    volumes_mounts,
+                )
+                " is missing expected extra volume"

--- a/tests/manifests/utils.py
+++ b/tests/manifests/utils.py
@@ -11,6 +11,7 @@ import shutil
 import string
 import tempfile
 from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -369,11 +370,9 @@ def get_or_empty(d, key):
 
 def find_workload_ids_matching_selector(templates: list[dict[str, Any]], selector: dict[str, str]) -> set[str]:
     workload_ids = set[str]()
-    for template in templates:
-        if template["kind"] in ("Deployment", "StatefulSet", "Job") and selector_match(
-            template["spec"]["template"]["metadata"]["labels"], selector
-        ):
-            workload_ids.add(template_id(template))
+    for pod_template_details in iterate_pod_template(templates):
+        if selector_match(pod_template_details.pod_template["metadata"]["labels"], selector):
+            workload_ids.add(pod_template_details.manifest_id)
 
     return workload_ids
 
@@ -410,7 +409,7 @@ async def assert_covers_expected_workloads(
             f"{template_id(template)} unexpectedly exists when all {covering_kind} should be turned off"
         )
         deployable_details = template_to_deployable_details(template)
-        if template["kind"] in ["Deployment", "StatefulSet"] and if_condition(deployable_details):
+        if template["kind"] in PERSISTENT_WORKLOAD_KINDS and if_condition(deployable_details):
             workload_ids_to_cover.add(template_id(template))
 
     def enable_covering_templates(deployable_details: DeployableDetails):
@@ -443,6 +442,32 @@ async def assert_covers_expected_workloads(
         covered_workload_ids.update(new_covered_workload_ids)
 
     assert workload_ids_to_cover == covered_workload_ids, "Not all workloads we were expecting to cover were covered"
+
+
+@dataclass
+class PodTemplateDetails:
+    manifest: dict[str, Any]
+    manifest_id: str = field(init=False)
+    pod_template: dict[str, Any] = field(init=False)
+
+    def __post_init__(self):
+        self.manifest_id = template_id(self.manifest)
+        self.pod_template = self.manifest["spec"]["template"]
+
+    def deployable_details(self, container_name=None):
+        return template_to_deployable_details(self.manifest, container_name)
+
+
+PERSISTENT_WORKLOAD_KINDS = ("Deployment", "StatefulSet")
+EPHEMERAL_WORKLOAD_KINDS = ("Job",)
+ALL_WORKLOAD_KINDS = PERSISTENT_WORKLOAD_KINDS + EPHEMERAL_WORKLOAD_KINDS
+
+
+def iterate_pod_template(manifests, kinds: tuple[str, ...] = ALL_WORKLOAD_KINDS):
+    for manifest in manifests:
+        if manifest["kind"] not in kinds:
+            continue
+        yield PodTemplateDetails(manifest)
 
 
 def workload_spec_containers(workload_spec):


### PR DESCRIPTION
Unify handling of workload manifests to ensure that we don't accidentally miss a `kind` in some places.

Inside `PodTemplateDetails` we use `manifest` and `manifest_id` rather than `template` and `template_id` because we've been incorrectly naming things until now. `template` isn't a Helm template, it is a rendered Helm template which is a fully fledged manifest. `template_id`, `template_to_deployable_details`, `make_templates`, etc will be renamed separately but I've not introduced any further tech debt.

Draft as WIP but want to see what I've broken so far