### PR TITLE
Allow RTC services to be of type ClusterIP

### DIFF
--- a/charts/matrix-stack/source/common/exposedServicePort.json
+++ b/charts/matrix-stack/source/common/exposedServicePort.json
@@ -18,6 +18,7 @@
     "portType": {
       "type": "string",
       "enum": [
+        "ClusterIP",
         "NodePort",
         "HostPort",
         "LoadBalancer"

--- a/charts/matrix-stack/source/common/exposedServicePortRange.json
+++ b/charts/matrix-stack/source/common/exposedServicePortRange.json
@@ -18,6 +18,7 @@
     "portType": {
       "type": "string",
       "enum": [
+        "ClusterIP",
         "NodePort",
         "HostPort",
         "LoadBalancer"

--- a/charts/matrix-stack/source/common/exposedServicePortWithTLS.json
+++ b/charts/matrix-stack/source/common/exposedServicePortWithTLS.json
@@ -18,6 +18,7 @@
     "portType": {
       "type": "string",
       "enum": [
+        "ClusterIP",
         "NodePort",
         "HostPort",
         "LoadBalancer"

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -616,7 +616,7 @@ extraInitContainers: []
   # This is unused if the portType is `HostPort` as the pod port
   # is exposed directly on the node running it, so no service is created.
   annotations: {}
-  # Either a NodePort, HostPort or LoadBalancer
+  # Either a ClusterIP, NodePort, HostPort or LoadBalancer
   # If the port is a HostPort, no Service will be created.
   portType: {{ portType }}
   # External IPs addresses of this service.
@@ -647,7 +647,7 @@ extraInitContainers: []
   # This is unused if the portType is `HostPort` as the pod port
   # is exposed directly on the node running it, so no service is created.
   annotations: {}
-  # Either a NodePort, HostPort or LoadBalancer
+  # Either a ClusterIP, NodePort, HostPort or LoadBalancer
   # If the port is a HostPort, no Service will be created.
   portType: {{ portType }}
   # External IPs addresses of this service.

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -5432,6 +5432,7 @@
                     "portType": {
                       "type": "string",
                       "enum": [
+                        "ClusterIP",
                         "NodePort",
                         "HostPort",
                         "LoadBalancer"
@@ -5486,6 +5487,7 @@
                     "portType": {
                       "type": "string",
                       "enum": [
+                        "ClusterIP",
                         "NodePort",
                         "HostPort",
                         "LoadBalancer"
@@ -5540,6 +5542,7 @@
                     "portType": {
                       "type": "string",
                       "enum": [
+                        "ClusterIP",
                         "NodePort",
                         "HostPort",
                         "LoadBalancer"
@@ -5607,6 +5610,7 @@
                     "portType": {
                       "type": "string",
                       "enum": [
+                        "ClusterIP",
                         "NodePort",
                         "HostPort",
                         "LoadBalancer"
@@ -5670,6 +5674,7 @@
                     "portType": {
                       "type": "string",
                       "enum": [
+                        "ClusterIP",
                         "NodePort",
                         "HostPort",
                         "LoadBalancer"

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -925,7 +925,7 @@ matrixRTC:
         # This is unused if the portType is `HostPort` as the pod port
         # is exposed directly on the node running it, so no service is created.
         annotations: {}
-        # Either a NodePort, HostPort or LoadBalancer
+        # Either a ClusterIP, NodePort, HostPort or LoadBalancer
         # If the port is a HostPort, no Service will be created.
         portType: NodePort
         # External IPs addresses of this service.
@@ -944,7 +944,7 @@ matrixRTC:
         # This is unused if the portType is `HostPort` as the pod port
         # is exposed directly on the node running it, so no service is created.
         annotations: {}
-        # Either a NodePort, HostPort or LoadBalancer
+        # Either a ClusterIP, NodePort, HostPort or LoadBalancer
         # If the port is a HostPort, no Service will be created.
         portType: NodePort
         # External IPs addresses of this service.
@@ -963,7 +963,7 @@ matrixRTC:
         # This is unused if the portType is `HostPort` as the pod port
         # is exposed directly on the node running it, so no service is created.
         annotations: {}
-        # Either a NodePort, HostPort or LoadBalancer
+        # Either a ClusterIP, NodePort, HostPort or LoadBalancer
         # If the port is a HostPort, no Service will be created.
         portType: NodePort
         # External IPs addresses of this service.
@@ -990,7 +990,7 @@ matrixRTC:
         # This is unused if the portType is `HostPort` as the pod port
         # is exposed directly on the node running it, so no service is created.
         annotations: {}
-        # Either a NodePort, HostPort or LoadBalancer
+        # Either a ClusterIP, NodePort, HostPort or LoadBalancer
         # If the port is a HostPort, no Service will be created.
         portType: NodePort
         # External IPs addresses of this service.
@@ -1018,7 +1018,7 @@ matrixRTC:
         # This is unused if the portType is `HostPort` as the pod port
         # is exposed directly on the node running it, so no service is created.
         annotations: {}
-        # Either a NodePort, HostPort or LoadBalancer
+        # Either a ClusterIP, NodePort, HostPort or LoadBalancer
         # If the port is a HostPort, no Service will be created.
         portType: NodePort
         # External IPs addresses of this service.

--- a/newsfragments/1465.added.md
+++ b/newsfragments/1465.added.md
@@ -1,1 +1,1 @@
-Add support for setting `portType` in `matrixRTC.sfu.exposedServices` to `ClusterIP`
+Add support for setting `portType` in `matrixRTC.sfu.exposedServices` to `ClusterIP`.

--- a/newsfragments/1465.added.md
+++ b/newsfragments/1465.added.md
@@ -1,0 +1,1 @@
+Add support for setting `portType` in `matrixRTC.sfu.exposedServices` to `ClusterIP`

--- a/tests/manifests/test_services.py
+++ b/tests/manifests/test_services.py
@@ -30,6 +30,7 @@ async def test_exposed_services_port_and_type(values, make_templates):
     - NodePort: Services must have type=NodePort with valid nodePort integers
     - HostPort: Deployments must have hostPort configured, no Service exposure
     - LoadBalancer: Services must have type=LoadBalancer
+    - ClusterIP: Services must have type=ClusterIP
     - DynamicNodePort: Services must have type=NodePort with empty nodePort for dynamic allocation
     """
     num_of_expected_ports = {}
@@ -68,7 +69,7 @@ async def test_exposed_services_port_and_type(values, make_templates):
 
     found_exposed_services = {}
     found_services = {}
-    for service_mode in ("NodePort", "HostPort", "LoadBalancer", "DynamicNodePort"):
+    for service_mode in ("NodePort", "HostPort", "LoadBalancer", "ClusterIP", "DynamicNodePort"):
         for deployable_details in all_deployables_details:
             num_of_expected_ports[deployable_details.name] = 0
             num_of_expected_exposed_services[deployable_details.name] = 0


### PR DESCRIPTION
Let a user choose `ClusterIP` as the service type when they don't need to be exposed directly.

Fixes #1464