### PR TITLE
Fix portType ClusterIP not working as intended

### DIFF
--- a/charts/matrix-stack/ci/fragments/matrix-rtc-clusterip-services.yaml
+++ b/charts/matrix-stack/ci/fragments/matrix-rtc-clusterip-services.yaml
@@ -1,0 +1,19 @@
+# Copyright 2025-2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+matrixRTC:
+  sfu:
+    exposedServices:
+      rtcTcp:
+        portType: ClusterIP
+      rtcMuxedUdp:
+        portType: ClusterIP
+      turnTLS:
+        enabled: true
+        portType: ClusterIP
+        domain: turn.{{ $.Values.serverName }}
+        tlsSecret: "{{ $.Release.Name }}-turn-tls"
+      turn:
+        enabled: true
+        portType: ClusterIP

--- a/charts/matrix-stack/ci/matrix-rtc-clusterip-services-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-clusterip-services-values.yaml
@@ -1,0 +1,37 @@
+# Copyright 2025-2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# source_fragments: init-secrets-minimal.yaml matrix-rtc-clusterip-services.yaml matrix-rtc-minimal.yaml
+# DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
+
+# initSecrets, postgres don't have any required properties to be set and defaults to enabled
+deploymentMarkers:
+  enabled: false
+elementAdmin:
+  enabled: false
+elementWeb:
+  enabled: false
+matrixAuthenticationService:
+  enabled: false
+matrixRTC:
+  ingress:
+    host: mrtc.ess.localhost
+  sfu:
+    exposedServices:
+      rtcMuxedUdp:
+        portType: ClusterIP
+      rtcTcp:
+        portType: ClusterIP
+      turn:
+        enabled: true
+        portType: ClusterIP
+      turnTLS:
+        domain: turn.{{ $.Values.serverName }}
+        enabled: true
+        portType: ClusterIP
+        tlsSecret: "{{ $.Release.Name }}-turn-tls"
+synapse:
+  enabled: false
+wellKnownDelegation:
+  enabled: false

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_tcp_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_tcp_service.yaml
@@ -27,15 +27,19 @@ spec:
   externalIPs: {{ .exposedServices.rtcTcp.externalIPs | toYaml | nindent 4 }}
   {{- end }}
   internalTrafficPolicy: {{ .exposedServices.rtcTcp.internalTrafficPolicy }}
+  {{- if (ne .exposedServices.rtcTcp.portType "ClusterIP") }}
   externalTrafficPolicy: {{ .exposedServices.rtcTcp.externalTrafficPolicy }}
+  {{- end }}
   ports:
   - name: "rtc-tcp"
     protocol: "TCP"
   {{- /* port and targetPort must be the same for RTC traffic as LiveKit advertises the local port its listening on as the access port*/}}
     port: {{ .exposedServices.rtcTcp.port }}
     targetPort: {{ .exposedServices.rtcTcp.port }}
+    {{- if (ne .exposedServices.rtcTcp.portType "ClusterIP") }}
     {{- with .exposedServices.rtcTcp.nodePort }}
     nodePort: {{ tpl . (dict "context" $.Values.matrixRTC.sfu.exposedServices.rtcTcp "root" $) }}
+    {{- end }}
     {{- end }}
   selector:
     app.kubernetes.io/instance: "{{ $.Release.Name }}-matrix-rtc-sfu"

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_muxer_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_muxer_service.yaml
@@ -27,15 +27,19 @@ spec:
   {{- end }}
   ipFamilyPolicy: PreferDualStack
   internalTrafficPolicy: {{ .exposedServices.rtcMuxedUdp.internalTrafficPolicy }}
+  {{- if (ne .exposedServices.rtcMuxedUdp.portType "ClusterIP") }}
   externalTrafficPolicy: {{ .exposedServices.rtcMuxedUdp.externalTrafficPolicy }}
+  {{- end }}
   ports:
   - name: "rtc-muxed-udp"
     protocol: "UDP"
   {{- /* port and targetPort must be the same for RTC traffic as LiveKit advertises the local port its listening on as the access port*/}}
     port: {{ .exposedServices.rtcMuxedUdp.port }}
     targetPort: {{ .exposedServices.rtcMuxedUdp.port }}
+    {{- if (ne .exposedServices.rtcMuxedUdp.portType "ClusterIP") }}
     {{- with .exposedServices.rtcMuxedUdp.nodePort }}
     nodePort: {{ tpl . (dict "context" $.Values.matrixRTC.sfu.exposedServices.rtcMuxedUdp "root" $) }}
+    {{- end }}
     {{- end }}
   selector:
     app.kubernetes.io/instance: "{{ $.Release.Name }}-matrix-rtc-sfu"

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_range_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_rtc_udp_range_service.yaml
@@ -33,7 +33,9 @@ spec:
   {{- end }}
   ipFamilyPolicy: PreferDualStack
   internalTrafficPolicy: {{ $.Values.matrixRTC.sfu.exposedServices.rtcUdp.internalTrafficPolicy }}
+  {{- if (ne $.Values.matrixRTC.sfu.exposedServices.rtcUdp.portType "ClusterIP") }}
   externalTrafficPolicy: {{ $.Values.matrixRTC.sfu.exposedServices.rtcUdp.externalTrafficPolicy }}
+  {{- end }}
   ports:
 {{- $segment_start := ((add $range_start (mul 250 $port_segment)) | int) }}
 {{- $segment_end := ((min (add $range_end 1) (add $segment_start 250)) | int) }}
@@ -42,8 +44,10 @@ spec:
   {{- /* port and targetPort must be the same for RTC traffic as LiveKit advertises the local port its listening on as the access port*/}}
     port: {{ $port }}
     targetPort: {{ $port }}
+    {{- if (ne $.Values.matrixRTC.sfu.exposedServices.rtcUdp.portType "ClusterIP") }}
     {{- with $.Values.matrixRTC.sfu.exposedServices.rtcUdp.portRange.nodePort }}
     nodePort: {{ tpl . (dict "context" (mustMergeOverwrite (dict "port" $port) ($.Values.matrixRTC.sfu.exposedServices.rtcUdp)) "root" $)  }}
+    {{- end }}
     {{- end }}
     protocol: UDP
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_turn_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_turn_service.yaml
@@ -27,15 +27,19 @@ spec:
   externalIPs: {{ .exposedServices.turn.externalIPs | toYaml | nindent 4 }}
   {{- end }}
   internalTrafficPolicy: {{ .exposedServices.turn.internalTrafficPolicy }}
+  {{- if (ne .exposedServices.turn.portType "ClusterIP") }}
   externalTrafficPolicy: {{ .exposedServices.turn.externalTrafficPolicy }}
+  {{- end }}
   ports:
   - name: "turn-udp"
     protocol: "UDP"
   {{- /* port and targetPort must be the same for Turn UDP traffic as LiveKit advertises the local port its listening on as the access port*/}}
     port: {{ .exposedServices.turn.port }}
     targetPort: {{ .exposedServices.turn.port }}
+    {{- if (ne .exposedServices.turn.portType "ClusterIP") }}
     {{- with .exposedServices.turn.nodePort }}
     nodePort: {{ tpl . (dict "context" $.Values.matrixRTC.sfu.exposedServices.turn "root" $) }}
+    {{- end }}
     {{- end }}
   selector:
     app.kubernetes.io/instance: "{{ $.Release.Name }}-matrix-rtc-sfu"

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_turn_tls_service.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_turn_tls_service.yaml
@@ -27,7 +27,9 @@ spec:
   externalIPs: {{ .exposedServices.turnTLS.externalIPs | toYaml | nindent 4 }}
   {{- end }}
   internalTrafficPolicy: {{ .exposedServices.turnTLS.internalTrafficPolicy }}
+  {{- if (ne .exposedServices.turnTLS.portType "ClusterIP") }}
   externalTrafficPolicy: {{ .exposedServices.turnTLS.externalTrafficPolicy }}
+  {{- end }}
   ports:
   - name: "turn-tls-tcp"
     protocol: "TCP"
@@ -35,8 +37,10 @@ spec:
   {{- /* LiveKit will advertise the port 443 regardless of the port configured.
     We hardcode it to 5349 and rely on Kubernetes routing to expose a port of 443 using a LoadBalancer service */}}
     targetPort: 5349
+    {{- if  (ne .exposedServices.turnTLS.portType "ClusterIP") }}
     {{- with .exposedServices.turnTLS.nodePort }}
     nodePort: {{ tpl . (dict "context" $.Values.matrixRTC.sfu.exposedServices.turnTLS "root" $) }}
+    {{- end }}
     {{- end }}
   selector:
     app.kubernetes.io/instance: "{{ $.Release.Name }}-matrix-rtc-sfu"

--- a/newsfragments/1475.fixed.md
+++ b/newsfragments/1475.fixed.md
@@ -1,0 +1,1 @@
+Fix `matrixRTC.sfu.exposedServices.*.portType` wrongfully keeping `nodePort` and `externalTrafficPolicy` when set to `ClusterIP`.

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -789,6 +789,7 @@ _extra_services_values_files_to_test = [
     "matrix-rtc-exposed-services-tls-values.yaml",
     "matrix-rtc-exposed-services-cert-manager-values.yaml",
     "matrix-rtc-turn-tls-external-values.yaml",
+    "matrix-rtc-clusterip-services-values.yaml",
 ]
 
 secret_values_files_to_test = set(

--- a/tests/manifests/test_services.py
+++ b/tests/manifests/test_services.py
@@ -361,10 +361,13 @@ async def test_exposed_services_traffic_policy(values, make_templates):
                         template["spec"].get("internalTrafficPolicy")
                         == template["metadata"]["annotations"]["exposed-service-internal"]
                     )
-                    assert (
-                        template["spec"].get("externalTrafficPolicy")
-                        == template["metadata"]["annotations"]["exposed-service-external"]
-                    )
+                    if template["spec"]["type"] != "ClusterIP":
+                        assert (
+                            template["spec"].get("externalTrafficPolicy")
+                            == template["metadata"]["annotations"]["exposed-service-external"]
+                        )
+                    else:
+                        assert "externalTrafficPolicy" not in template["spec"]
         for deployable_details in all_deployables_details:
             assert (
                 len(found_exposed_services[deployable_details.name])
@@ -588,6 +591,11 @@ async def test_services_specify_type_by_default(templates):
                     f"{template_id(template)} has externalTrafficPolicy defined for ClusterIP service. "
                     f"externalTrafficPolicy is only valid for NodePort/LoadBalancer services."
                 )
+                for port in template["spec"]["ports"]:
+                    assert "nodePort" not in port, (
+                        f"{template_id(template)} has nodePort set on a ClusterIP service port. "
+                        f"nodePort is only valid for NodePort/LoadBalancer services."
+                    )
             else:
                 assert "clusterIP" not in template["spec"], (
                     f"{template_id(template)} has clusterIP defined for NodePort service. "


### PR DESCRIPTION
Following https://github.com/element-hq/ess-helm/pull/1465

I noticed some errors when trying to use it. I've gated the `externalTrafficPolicy` and `nodePort` and written some tests to prevent this from happening again.

cc @benbz 