### PR TITLE
Upgrade Matrix Authentication Service to v1.22.0

### DIFF
--- a/charts/matrix-stack/configs/matrix-authentication-service/config-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/matrix-authentication-service/config-overrides.yaml.tpl
@@ -49,14 +49,44 @@ Work around this by omitted the host name in the dual-stack case and MAS itself 
 
 
 database:
-{{- /* We don't attempt to use passfile and mount the Secret directly due to
-https://github.com/kubernetes/kubernetes/issues/129043 / https://github.com/kubernetes/kubernetes/issues/81089 */}}
 {{- if .postgres }}
-{{- with .postgres }}
-  uri: "postgresql://{{ .user }}:${POSTGRES_PASSWORD}@{{ tpl .host $root }}:{{ .port }}/{{ .database }}?{{ with .sslMode }}sslmode={{ . }}&{{ end }}application_name=matrix-authentication-service"
-{{- end }}
+  host: {{ tpl .postgres.host $root | quote }}
+  port: {{ .postgres.port | default 5432 }}
+  username: {{ .postgres.user | quote }}
+  password_file: /secrets/{{
+                  include "element-io.ess-library.postgres-secret-path" (
+                      dict "root" $root
+                      "context" (dict
+                        "essPassword" "matrixAuthenticationService"
+                        "initSecretKey" "POSTGRES_MATRIX_AUTHENTICATION_SERVICE_PASSWORD"
+                        "componentPasswordPath" "matrixAuthenticationService.postgres.password"
+                        "defaultSecretName" (include "element-io.matrix-authentication-service.secret-name" (dict "root" $root "context" .))
+                        "defaultSecretKey" "POSTGRES_PASSWORD"
+                        "isHook" .isHook
+                      )
+                  ) }}
+  database: {{ .postgres.database | quote }}
+  {{- with .postgres.sslMode }}
+  ssl_mode: {{ . }}
+  {{- end }}
 {{- else if $root.Values.postgres.enabled }}
-  uri: "postgresql://matrixauthenticationservice_user:${POSTGRES_PASSWORD}@{{ $root.Release.Name }}-postgres.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}:5432/matrixauthenticationservice?sslmode=prefer&application_name=matrix-authentication-service"
+  host: {{ $root.Release.Name }}-postgres.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}
+  port: 5432
+  username: matrixauthenticationservice_user
+  password_file: /secrets/{{
+                  include "element-io.ess-library.postgres-secret-path" (
+                      dict "root" $root
+                      "context" (dict
+                        "essPassword" "matrixAuthenticationService"
+                        "initSecretKey" "POSTGRES_MATRIX_AUTHENTICATION_SERVICE_PASSWORD"
+                        "componentPasswordPath" "matrixAuthenticationService.postgres.password"
+                        "defaultSecretName" (include "element-io.matrix-authentication-service.secret-name" (dict "root" $root "context" .))
+                        "defaultSecretKey" "POSTGRES_PASSWORD"
+                        "isHook" .isHook
+                      )
+                  ) }}
+  database: matrixauthenticationservice
+  ssl_mode: prefer
 {{ end }}
 
 telemetry:

--- a/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
+++ b/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 {% import "common/sub_schema_values.yaml.j2" as sub_schema_values %}
 enabled: true
-{{- sub_schema_values.image(registry='ghcr.io', repository='element-hq/matrix-authentication-service', tag='1.21.0') }}
+{{- sub_schema_values.image(registry='ghcr.io', repository='element-hq/matrix-authentication-service', tag='1.22.0') }}
 
 replicas: 1
 
@@ -67,7 +67,7 @@ syn2mas:
   enabled: false
 
   # Syn2Mas relies on the debug image to copy mas-cli to the matrix-tools container
-  {{- sub_schema_values.image(registry='ghcr.io', repository='element-hq/matrix-authentication-service', tag='1.21.0-debug') | indent(2) }}
+  {{- sub_schema_values.image(registry='ghcr.io', repository='element-hq/matrix-authentication-service', tag='1.22.0-debug') | indent(2) }}
   {{- sub_schema_values.labels() | indent(2) -}}
   {{- sub_schema_values.workloadAnnotations() | indent(2) -}}
   {{- sub_schema_values.containersSecurityContext() | indent(2) -}}

--- a/charts/matrix-stack/templates/matrix-authentication-service/_helpers.tpl
+++ b/charts/matrix-stack/templates/matrix-authentication-service/_helpers.tpl
@@ -64,7 +64,7 @@ app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .
                                                                 "essPassword" "matrixAuthenticationService"
                                                                 "componentPasswordPath" "matrixAuthenticationService.postgres.password"
                                                                 "defaultSecretName" (include "element-io.matrix-authentication-service.secret-name" (dict "root" $root "context" .))
-                                                                "isHook" false
+                                                                "isHook" .isHook
                                                                 )
                                             )
                                         ) -}}
@@ -109,27 +109,7 @@ env:
         Environment variables values found in the config file as ${VARNAME} are parsed through go template engine before being replaced in the target file.
 */}}
 {{- define "element-io.matrix-authentication-service.renderConfigOverrideEnv" }}
-{{- $root := .root -}}
-{{- with required "element-io.matrix-authentication-service.renderConfigOverrideEnv missing context" .context -}}
-env:
-- name: POSTGRES_PASSWORD
-  value: >-
-    {{
-      printf "{{ readfile \"/secrets/%s\" | urlencode }}" (
-          include "element-io.ess-library.postgres-secret-path" (
-              dict "root" $root
-              "context" (dict
-                "essPassword" "matrixAuthenticationService"
-                "initSecretKey" "POSTGRES_MATRIX_AUTHENTICATION_SERVICE_PASSWORD"
-                "componentPasswordPath" "matrixAuthenticationService.postgres.password"
-                "defaultSecretName" (include "element-io.matrix-authentication-service.secret-name" (dict "root" $root "context" .))
-                "defaultSecretKey" "POSTGRES_PASSWORD"
-                "isHook" false
-              )
-          )
-        )
-    }}
-{{- end }}
+env: []
 {{- end }}
 
 

--- a/charts/matrix-stack/templates/matrix-authentication-service/_helpers.tpl
+++ b/charts/matrix-stack/templates/matrix-authentication-service/_helpers.tpl
@@ -238,17 +238,6 @@ mas-config-overrides.yaml: |
 {{- end }}
 {{- end }}
 
-
-{{- define "element-io.matrix-authentication-service.syn2masConfigSecrets" -}}
-{{- $root := .root -}}
-{{- with required "element-io.matrix-authentication-service.syn2masConfigSecrets missing context" .context -}}
-{{- $masSecrets := include "element-io.matrix-authentication-service.configSecrets" (dict "root" $root "context" .masContext) | fromJsonArray }}
-{{- $synapseSecrets := include "element-io.synapse.configSecrets" (dict "root" $root "context" .synapseContext) | fromJsonArray }}
-{{- $syn2masSecrets := concat $masSecrets $synapseSecrets | uniq | sortAlpha }}
-{{- $syn2masSecrets | toJson -}}
-{{- end -}}
-{{- end -}}
-
 {{- define "element-io.matrix-authentication-service.readyToHandleAuth" -}}
 {{- $root := .root -}}
 {{- /*

--- a/charts/matrix-stack/templates/matrix-authentication-service/configmap.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/configmap.yaml
@@ -1,20 +1,21 @@
 {{- /*
 Copyright 2025 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 
 {{- with .Values.matrixAuthenticationService -}}
 {{- if .enabled -}}
+{{- $masContext := (mustMergeOverwrite ($.Values.matrixAuthenticationService | deepCopy) (dict "isHook" false)) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "element-io.matrix-authentication-service.configmap-name" (dict "root" $ "context"  (dict "isHook" false)) }}
+  name: {{ include "element-io.matrix-authentication-service.configmap-name" (dict "root" $ "context" (dict "isHook" false)) }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "element-io.matrix-authentication-service.labels" (dict "root" $ "context" .) | nindent 4 }}
+    {{- include "element-io.matrix-authentication-service.labels" (dict "root" $ "context" $masContext) | nindent 4 }}
 data:
-  {{- include "element-io.matrix-authentication-service.configmap-data" (dict "root" $ "context" .) | nindent 2 -}}
+  {{- include "element-io.matrix-authentication-service.configmap-data" (dict "root" $ "context" $masContext) | nindent 2 -}}
 {{ end -}}
 {{- end -}}

--- a/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
@@ -5,7 +5,7 @@ Copyright 2025-2026 Element Creations Ltd
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 
-{{- with .Values.matrixAuthenticationService -}}
+{{- with (mustMergeOverwrite ($.Values.matrixAuthenticationService | deepCopy) (dict "isHook" false)) -}}
 {{- if .enabled -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -49,7 +49,7 @@ spec:
 {{- end }}
 {{- include "element-io.ess-library.pods.commonSpec" (dict "root" $ "context" (dict "componentValues" . "instanceSuffix" "matrix-authentication-service" "kind" "Deployment" "usesMatrixTools" true)) | nindent 6 }}
       initContainers:
-      {{ include "element-io.matrix-authentication-service.render-config-container" (dict "root" $ "context" (mustMergeOverwrite . (dict "isHook" false))) | nindent 6 }}
+      {{ include "element-io.matrix-authentication-service.render-config-container" (dict "root" $ "context" .) | nindent 6 }}
       - name: db-wait
         {{- include "element-io.ess-library.pods.image" (dict "root" $ "context" $.Values.matrixTools.image) | nindent 8 }}
 {{- with .containersSecurityContext }}

--- a/charts/matrix-stack/templates/matrix-authentication-service/secret.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/secret.yaml
@@ -1,21 +1,22 @@
 {{- /*
 Copyright 2025 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
 
 {{- with .Values.matrixAuthenticationService -}}
 {{- if .enabled -}}
+{{- $masContext := (mustMergeOverwrite ($.Values.matrixAuthenticationService | deepCopy) (dict "isHook" false)) -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "element-io.matrix-authentication-service.secret-name" (dict "root" $ "context"  (dict "isHook" false)) }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "element-io.matrix-authentication-service.labels" (dict "root" $ "context" .) | nindent 4 }}
+    {{- include "element-io.matrix-authentication-service.labels" (dict "root" $ "context" $masContext) | nindent 4 }}
 type: Opaque
 data:
-{{- include "element-io.matrix-authentication-service.secret-data" (dict "root" $ "context" .) | nindent 2 }}
+{{- include "element-io.matrix-authentication-service.secret-data" (dict "root" $ "context" $masContext) | nindent 2 }}
 {{- end -}}
 {{- end -}}

--- a/charts/matrix-stack/templates/matrix-authentication-service/syn2mas_job.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/syn2mas_job.yaml
@@ -167,7 +167,7 @@ spec:
 {{- range .extraVolumeMounts }}
         - {{ (. | toYaml) | nindent 10 }}
 {{- end }}
-{{- range $secret := include "element-io.matrix-authentication-service.syn2masConfigSecrets" (dict "root" $ "context" (dict "synapseContext" $synapseContext "masContext" $masContext)) | fromJsonArray }}
+{{- range $secret := include "element-io.syn2mas.configSecrets" (dict "root" $ "context" (dict "synapseContext" $synapseContext "masContext" $masContext)) | fromJsonArray }}
 {{- with (tpl $secret $) }}
         - mountPath: /secrets/{{ . }}
           name: "secret-{{ . | sha256sum | trunc 12 }}"
@@ -202,7 +202,7 @@ spec:
         - mountPath: "/tmp-mas-cli"
           name: tmp-mas-cli
           readOnly: true
-{{- range $secret := include "element-io.matrix-authentication-service.syn2masConfigSecrets" (dict "root" $ "context" (dict "synapseContext" $synapseContext "masContext" $masContext)) | fromJsonArray }}
+{{- range $secret := include "element-io.syn2mas.configSecrets" (dict "root" $ "context" (dict "synapseContext" $synapseContext "masContext" $masContext)) | fromJsonArray }}
 {{- with (tpl $secret $) }}
         - mountPath: /secrets/{{ . }}
           name: "secret-{{ . | sha256sum | trunc 12 }}"
@@ -220,7 +220,7 @@ spec:
       - name: plain-mas-config
         configMap:
           name: {{ include "element-io.matrix-authentication-service.configmap-name" (dict "root" $ "context" (dict "isHook" $isHook)) }}
-{{- range $_, $secret := include "element-io.matrix-authentication-service.syn2masConfigSecrets" (dict "root" $ "context" (dict "synapseContext" $synapseContext "masContext" $masContext)) | fromJsonArray }}
+{{- range $_, $secret := include "element-io.syn2mas.configSecrets" (dict "root" $ "context" (dict "synapseContext" $synapseContext "masContext" $masContext)) | fromJsonArray }}
 {{- with tpl $secret $ }}
       - secret:
           secretName: {{ . }}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -2547,7 +2547,7 @@ matrixAuthenticationService:
 
     ## The tag of the container image to use.
     ## One of tag or digest must be provided.
-    tag: "1.21.0"
+    tag: "1.22.0"
 
     ## Container digest to use. Used to pull the image instead of the image tag if set
     ## The tag will still be set as the app.kubernetes.io/version label
@@ -3003,7 +3003,7 @@ matrixAuthenticationService:
 
       ## The tag of the container image to use.
       ## One of tag or digest must be provided.
-      tag: "1.21.0-debug"
+      tag: "1.22.0-debug"
 
       ## Container digest to use. Used to pull the image instead of the image tag if set
       ## The tag will still be set as the app.kubernetes.io/version label

--- a/newsfragments/1488.changed.md
+++ b/newsfragments/1488.changed.md
@@ -1,0 +1,9 @@
+Upgrade Matrix Authentication Service to v1.22.0.
+
+Highlights:
+- Accept `[` and `~` in OAuth 2.0 scope tokens
+- Keep the auth action context when changing accounts
+
+
+Full Changelogs:
+- [v1.22.0](https://github.com/element-hq/matrix-authentication-service/releases/tag/v1.22.0)


### PR DESCRIPTION
Draft as RC. Changelog written as per release.

Uses https://github.com/element-hq/matrix-authentication-service/pull/5449. `application_name` is no longer set however `matrix-authentication-service` is the default as per https://github.com/networkException/matrix-authentication-service/blob/v1.21.0/crates/cli/src/util.rs#L298 so no change here