### PR TITLE
Fix calling `setup-ess-cluster` externally from the repository

### DIFF
--- a/newsfragments/1490.internal.md
+++ b/newsfragments/1490.internal.md
@@ -1,0 +1,1 @@
+Fix calling `setup-ess-cluster` externally from the repository.

--- a/tests/integration/scripts.py
+++ b/tests/integration/scripts.py
@@ -202,7 +202,7 @@ def setup_cluster():
     import pytest
 
     os.environ["PYTEST_KEEP_CLUSTER"] = "1"
-    errcode = pytest.main([str(HERE)] + ["--env-setup"])
+    errcode = pytest.main([str(HERE)] + ["test_setup.py", "--env-setup"])
     subprocess.run("k3d kubeconfig merge ess-helm -ds", shell=True, check=True)
 
     sys.exit(errcode)


### PR DESCRIPTION
When installing the integration tests as `uv tool`, `setup-ess-cluster` would fail with 
```
../../.local/share/uv/tools/ess-integration-tests/lib/python3.14/site-packages/integration/test_well_known_delegation.py:14: in <module>
    @pytest.mark.skipif(value_file_has("wellKnownDelegation.enabled", False), reason="WellKnownDelegation not deployed")
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../.local/share/uv/tools/ess-integration-tests/lib/python3.14/site-packages/integration/lib/utils.py:295: in value_file_has
    data = value_file_data(property_path)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../.local/share/uv/tools/ess-integration-tests/lib/python3.14/site-packages/integration/lib/utils.py:270: in value_file_data
    open(Path().resolve() / "charts" / "matrix-stack" / "values.yaml") as base_value_file,
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   FileNotFoundError: [Errno 2] No such file or directory:
```