### PR TITLE
Revert "Fix test_setup.py"

### DIFF
--- a/newsfragments/1490.internal.md
+++ b/newsfragments/1490.internal.md
@@ -1,1 +1,0 @@
-Fix calling `setup-ess-cluster` externally from the repository.

--- a/tests/integration/scripts.py
+++ b/tests/integration/scripts.py
@@ -202,7 +202,7 @@ def setup_cluster():
     import pytest
 
     os.environ["PYTEST_KEEP_CLUSTER"] = "1"
-    errcode = pytest.main([str(HERE)] + ["test_setup.py", "--env-setup"])
+    errcode = pytest.main([str(HERE)] + ["--env-setup"])
     subprocess.run("k3d kubeconfig merge ess-helm -ds", shell=True, check=True)
 
     sys.exit(errcode)


### PR DESCRIPTION
This reverts commit 627a91cf7c4c5a28291b029212a2514a20d59d7b / #1490 as it breaks MAS CI.

No changelog fragment of its own as this isn't in a release yet