### PR TITLE
Give k8s.element.io/synapse-instance to Synapse's Ingress too

### DIFF
--- a/charts/matrix-stack/templates/synapse/_helpers.tpl
+++ b/charts/matrix-stack/templates/synapse/_helpers.tpl
@@ -75,6 +75,7 @@ app.kubernetes.io/instance: {{ $root.Release.Name }}-synapse
 k8s.element.io/target-name: haproxy
 k8s.element.io/target-instance: {{ $root.Release.Name }}-haproxy
 app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .image.tag }}
+k8s.element.io/synapse-instance: {{ $root.Release.Name }}-synapse
 {{- end }}
 {{- end }}
 

--- a/newsfragments/1495.changed.md
+++ b/newsfragments/1495.changed.md
@@ -1,0 +1,1 @@
+Ensure Synapse `Ingresses` have the `k8s.element.io/synapse-instance` like other kinds.


### PR DESCRIPTION
There's no reason I'm aware of that this should be missing, so add it for consistency