### PR TITLE
Go back to just managing the root directory for Python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,10 +20,7 @@ updates:
           - "minor"
           - "patch"
   - package-ecosystem: "uv"
-    directories:
-      - "/"
-      - "/tests"
-      - "/packages/*"
+    directory: "/"
     # Workaround https://github.com/dependabot/dependabot-core/issues/14004
     ignore:
       - dependency-name: ess-community-integration-tests

--- a/newsfragments/1496.internal.md
+++ b/newsfragments/1496.internal.md
@@ -1,0 +1,1 @@
+Simplify Dependabot Python configuration.


### PR DESCRIPTION
Reverts https://github.com/element-hq/ess-helm/pull/1375. 

This was trying to workaround https://github.com/dependabot/dependabot-core/issues/14937. This was properly fixed in https://github.com/dependabot/dependabot-core/pull/15142 created e.g. #1494 

Let's revert as this sometimes causes odd PRs