### PR TITLE
package-mode isn't something 'uv' understands

### DIFF
--- a/newsfragments/1502.internal.md
+++ b/newsfragments/1502.internal.md
@@ -1,0 +1,1 @@
+Remove invalid setting from `pyproject.toml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ description = ""
 version = "0.1.0"
 license = "AGPL-3.0-Only, Element Commercial"
 readme = "README.md"
-package-mode = false
 requires-python = ">=3.11,<4.0"
 dependencies = []
 


### PR DESCRIPTION
Left over from converting from `poetry`. Not something `uv` understands ( https://github.com/astral-sh/uv/issues/6434 )