### PR TITLE
Support configuring privileged in each container's securityContext

### DIFF
--- a/charts/matrix-stack/source/common/containersSecurityContext.json
+++ b/charts/matrix-stack/source/common/containersSecurityContext.json
@@ -3,6 +3,9 @@
     "allowPrivilegeEscalation": {
       "type": "boolean"
     },
+    "privileged": {
+      "type": "boolean"
+    },
     "capabilities": {
       "properties": {
         "add": {

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -69,6 +69,11 @@ networking:
   ## allowPrivilegeEscalation is always true when the container is run as privileged, or has CAP_SYS_ADMIN
   allowPrivilegeEscalation: false
 
+  ## Whether the container should be run in privileged mode.
+  ## Processes in privileged containers are essentially equivalent to root on the host.
+  ## Do not set to true without good reason.
+  privileged: false
+
   ## Give a process some privileges, but not all the privileges of the root user.
   capabilities:
     ## Privileges to add.

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -1279,6 +1279,9 @@
             "allowPrivilegeEscalation": {
               "type": "boolean"
             },
+            "privileged": {
+              "type": "boolean"
+            },
             "capabilities": {
               "properties": {
                 "add": {
@@ -2468,6 +2471,9 @@
         "containersSecurityContext": {
           "properties": {
             "allowPrivilegeEscalation": {
+              "type": "boolean"
+            },
+            "privileged": {
               "type": "boolean"
             },
             "capabilities": {
@@ -3937,6 +3943,9 @@
         "containersSecurityContext": {
           "properties": {
             "allowPrivilegeEscalation": {
+              "type": "boolean"
+            },
+            "privileged": {
               "type": "boolean"
             },
             "capabilities": {
@@ -5867,6 +5876,9 @@
                 "allowPrivilegeEscalation": {
                   "type": "boolean"
                 },
+                "privileged": {
+                  "type": "boolean"
+                },
                 "capabilities": {
                   "properties": {
                     "add": {
@@ -7489,6 +7501,9 @@
             "allowPrivilegeEscalation": {
               "type": "boolean"
             },
+            "privileged": {
+              "type": "boolean"
+            },
             "capabilities": {
               "properties": {
                 "add": {
@@ -8955,6 +8970,9 @@
             "allowPrivilegeEscalation": {
               "type": "boolean"
             },
+            "privileged": {
+              "type": "boolean"
+            },
             "capabilities": {
               "properties": {
                 "add": {
@@ -10334,6 +10352,9 @@
         "containersSecurityContext": {
           "properties": {
             "allowPrivilegeEscalation": {
+              "type": "boolean"
+            },
+            "privileged": {
               "type": "boolean"
             },
             "capabilities": {
@@ -12157,6 +12178,9 @@
         "containersSecurityContext": {
           "properties": {
             "allowPrivilegeEscalation": {
+              "type": "boolean"
+            },
+            "privileged": {
               "type": "boolean"
             },
             "capabilities": {
@@ -14184,6 +14208,9 @@
                 "allowPrivilegeEscalation": {
                   "type": "boolean"
                 },
+                "privileged": {
+                  "type": "boolean"
+                },
                 "capabilities": {
                   "properties": {
                     "add": {
@@ -15415,6 +15442,9 @@
         "containersSecurityContext": {
           "properties": {
             "allowPrivilegeEscalation": {
+              "type": "boolean"
+            },
+            "privileged": {
               "type": "boolean"
             },
             "capabilities": {
@@ -17061,6 +17091,9 @@
                 "allowPrivilegeEscalation": {
                   "type": "boolean"
                 },
+                "privileged": {
+                  "type": "boolean"
+                },
                 "capabilities": {
                   "properties": {
                     "add": {
@@ -17624,6 +17657,9 @@
         "containersSecurityContext": {
           "properties": {
             "allowPrivilegeEscalation": {
+              "type": "boolean"
+            },
+            "privileged": {
               "type": "boolean"
             },
             "capabilities": {
@@ -19183,6 +19219,9 @@
             "allowPrivilegeEscalation": {
               "type": "boolean"
             },
+            "privileged": {
+              "type": "boolean"
+            },
             "capabilities": {
               "properties": {
                 "add": {
@@ -20626,6 +20665,9 @@
                 "allowPrivilegeEscalation": {
                   "type": "boolean"
                 },
+                "privileged": {
+                  "type": "boolean"
+                },
                 "capabilities": {
                   "properties": {
                     "add": {
@@ -21683,6 +21725,9 @@
         "containersSecurityContext": {
           "properties": {
             "allowPrivilegeEscalation": {
+              "type": "boolean"
+            },
+            "privileged": {
               "type": "boolean"
             },
             "capabilities": {

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -223,6 +223,11 @@ initSecrets:
     ## allowPrivilegeEscalation is always true when the container is run as privileged, or has CAP_SYS_ADMIN
     allowPrivilegeEscalation: false
 
+    ## Whether the container should be run in privileged mode.
+    ## Processes in privileged containers are essentially equivalent to root on the host.
+    ## Do not set to true without good reason.
+    privileged: false
+
     ## Give a process some privileges, but not all the privileges of the root user.
     capabilities:
       ## Privileges to add.
@@ -393,6 +398,11 @@ deploymentMarkers:
     ## This bool directly controls whether the no_new_privs flag gets set on the container process.
     ## allowPrivilegeEscalation is always true when the container is run as privileged, or has CAP_SYS_ADMIN
     allowPrivilegeEscalation: false
+
+    ## Whether the container should be run in privileged mode.
+    ## Processes in privileged containers are essentially equivalent to root on the host.
+    ## Do not set to true without good reason.
+    privileged: false
 
     ## Give a process some privileges, but not all the privileges of the root user.
     capabilities:
@@ -652,6 +662,11 @@ matrixRTC:
     ## This bool directly controls whether the no_new_privs flag gets set on the container process.
     ## allowPrivilegeEscalation is always true when the container is run as privileged, or has CAP_SYS_ADMIN
     allowPrivilegeEscalation: false
+
+    ## Whether the container should be run in privileged mode.
+    ## Processes in privileged containers are essentially equivalent to root on the host.
+    ## Do not set to true without good reason.
+    privileged: false
 
     ## Give a process some privileges, but not all the privileges of the root user.
     capabilities:
@@ -1092,6 +1107,11 @@ matrixRTC:
       ## allowPrivilegeEscalation is always true when the container is run as privileged, or has CAP_SYS_ADMIN
       allowPrivilegeEscalation: false
 
+      ## Whether the container should be run in privileged mode.
+      ## Processes in privileged containers are essentially equivalent to root on the host.
+      ## Do not set to true without good reason.
+      privileged: false
+
       ## Give a process some privileges, but not all the privileges of the root user.
       capabilities:
         ## Privileges to add.
@@ -1379,6 +1399,11 @@ elementAdmin:
     ## allowPrivilegeEscalation is always true when the container is run as privileged, or has CAP_SYS_ADMIN
     allowPrivilegeEscalation: false
 
+    ## Whether the container should be run in privileged mode.
+    ## Processes in privileged containers are essentially equivalent to root on the host.
+    ## Do not set to true without good reason.
+    privileged: false
+
     ## Give a process some privileges, but not all the privileges of the root user.
     capabilities:
       ## Privileges to add.
@@ -1662,6 +1687,11 @@ elementWeb:
     ## allowPrivilegeEscalation is always true when the container is run as privileged, or has CAP_SYS_ADMIN
     allowPrivilegeEscalation: false
 
+    ## Whether the container should be run in privileged mode.
+    ## Processes in privileged containers are essentially equivalent to root on the host.
+    ## Do not set to true without good reason.
+    privileged: false
+
     ## Give a process some privileges, but not all the privileges of the root user.
     capabilities:
       ## Privileges to add.
@@ -1887,6 +1917,11 @@ haproxy:
     ## This bool directly controls whether the no_new_privs flag gets set on the container process.
     ## allowPrivilegeEscalation is always true when the container is run as privileged, or has CAP_SYS_ADMIN
     allowPrivilegeEscalation: false
+
+    ## Whether the container should be run in privileged mode.
+    ## Processes in privileged containers are essentially equivalent to root on the host.
+    ## Do not set to true without good reason.
+    privileged: false
 
     ## Give a process some privileges, but not all the privileges of the root user.
     capabilities:
@@ -2430,6 +2465,11 @@ hookshot:
     ## allowPrivilegeEscalation is always true when the container is run as privileged, or has CAP_SYS_ADMIN
     allowPrivilegeEscalation: false
 
+    ## Whether the container should be run in privileged mode.
+    ## Processes in privileged containers are essentially equivalent to root on the host.
+    ## Do not set to true without good reason.
+    privileged: false
+
     ## Give a process some privileges, but not all the privileges of the root user.
     capabilities:
       ## Privileges to add.
@@ -2871,6 +2911,11 @@ matrixAuthenticationService:
     ## allowPrivilegeEscalation is always true when the container is run as privileged, or has CAP_SYS_ADMIN
     allowPrivilegeEscalation: false
 
+    ## Whether the container should be run in privileged mode.
+    ## Processes in privileged containers are essentially equivalent to root on the host.
+    ## Do not set to true without good reason.
+    privileged: false
+
     ## Give a process some privileges, but not all the privileges of the root user.
     capabilities:
       ## Privileges to add.
@@ -3028,6 +3073,11 @@ matrixAuthenticationService:
       ## This bool directly controls whether the no_new_privs flag gets set on the container process.
       ## allowPrivilegeEscalation is always true when the container is run as privileged, or has CAP_SYS_ADMIN
       allowPrivilegeEscalation: false
+
+      ## Whether the container should be run in privileged mode.
+      ## Processes in privileged containers are essentially equivalent to root on the host.
+      ## Do not set to true without good reason.
+      privileged: false
 
       ## Give a process some privileges, but not all the privileges of the root user.
       capabilities:
@@ -3240,6 +3290,11 @@ postgres:
       ## allowPrivilegeEscalation is always true when the container is run as privileged, or has CAP_SYS_ADMIN
       allowPrivilegeEscalation: false
 
+      ## Whether the container should be run in privileged mode.
+      ## Processes in privileged containers are essentially equivalent to root on the host.
+      ## Do not set to true without good reason.
+      privileged: false
+
       ## Give a process some privileges, but not all the privileges of the root user.
       capabilities:
         ## Privileges to add.
@@ -3428,6 +3483,11 @@ postgres:
     ## This bool directly controls whether the no_new_privs flag gets set on the container process.
     ## allowPrivilegeEscalation is always true when the container is run as privileged, or has CAP_SYS_ADMIN
     allowPrivilegeEscalation: false
+
+    ## Whether the container should be run in privileged mode.
+    ## Processes in privileged containers are essentially equivalent to root on the host.
+    ## Do not set to true without good reason.
+    privileged: false
 
     ## Give a process some privileges, but not all the privileges of the root user.
     capabilities:
@@ -3672,6 +3732,11 @@ redis:
     ## This bool directly controls whether the no_new_privs flag gets set on the container process.
     ## allowPrivilegeEscalation is always true when the container is run as privileged, or has CAP_SYS_ADMIN
     allowPrivilegeEscalation: false
+
+    ## Whether the container should be run in privileged mode.
+    ## Processes in privileged containers are essentially equivalent to root on the host.
+    ## Do not set to true without good reason.
+    privileged: false
 
     ## Give a process some privileges, but not all the privileges of the root user.
     capabilities:
@@ -3934,6 +3999,11 @@ redis:
       ## This bool directly controls whether the no_new_privs flag gets set on the container process.
       ## allowPrivilegeEscalation is always true when the container is run as privileged, or has CAP_SYS_ADMIN
       allowPrivilegeEscalation: false
+
+      ## Whether the container should be run in privileged mode.
+      ## Processes in privileged containers are essentially equivalent to root on the host.
+      ## Do not set to true without good reason.
+      privileged: false
 
       ## Give a process some privileges, but not all the privileges of the root user.
       capabilities:
@@ -5624,6 +5694,11 @@ synapse:
     ## This bool directly controls whether the no_new_privs flag gets set on the container process.
     ## allowPrivilegeEscalation is always true when the container is run as privileged, or has CAP_SYS_ADMIN
     allowPrivilegeEscalation: false
+
+    ## Whether the container should be run in privileged mode.
+    ## Processes in privileged containers are essentially equivalent to root on the host.
+    ## Do not set to true without good reason.
+    privileged: false
 
     ## Give a process some privileges, but not all the privileges of the root user.
     capabilities:

--- a/newsfragments/1506.changed.md
+++ b/newsfragments/1506.changed.md
@@ -1,0 +1,3 @@
+Allow configuration of `privilege` in each container's `securityContext`.
+
+The implicit default of `false` is maintained and made explicit.

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -14,6 +14,7 @@ import pyhelm3
 class PropertyType(Enum):
     AdditionalConfig = "additional"
     Affinity = "affinity"
+    ContainersSecurityContext = "containersSecurityContext"
     Enabled = "enabled"
     Env = "extraEnv"
     ExposedServices = "exposedServices"
@@ -389,6 +390,7 @@ def make_synapse_worker_sub_component(worker_name: str, worker_type: str) -> Sub
         PropertyType.Labels: ValuesFilePath.read_elsewhere("synapse", "labels"),
         PropertyType.Affinity: ValuesFilePath.read_elsewhere("synapse", "affinity"),
         PropertyType.NodeSelector: ValuesFilePath.read_elsewhere("synapse", "nodeSelector"),
+        PropertyType.ContainersSecurityContext: ValuesFilePath.read_elsewhere("synapse", "containersSecurityContext"),
         PropertyType.PodSecurityContext: ValuesFilePath.read_elsewhere("synapse", "podSecurityContext"),
         PropertyType.PriorityClassName: ValuesFilePath.read_elsewhere("synapse", "priorityClassName"),
         PropertyType.RuntimeClassName: ValuesFilePath.read_elsewhere("synapse", "runtimeClassName"),
@@ -712,6 +714,9 @@ all_components_details = [
                     PropertyType.LivenessProbe: ValuesFilePath.not_supported(),
                     PropertyType.Affinity: ValuesFilePath.read_elsewhere("synapse", "affinity"),
                     PropertyType.NodeSelector: ValuesFilePath.read_elsewhere("synapse", "nodeSelector"),
+                    PropertyType.ContainersSecurityContext: ValuesFilePath.read_elsewhere(
+                        "synapse", "containersSecurityContext"
+                    ),
                     PropertyType.PodSecurityContext: ValuesFilePath.read_elsewhere("synapse", "podSecurityContext"),
                     PropertyType.PriorityClassName: ValuesFilePath.read_elsewhere("synapse", "priorityClassName"),
                     PropertyType.RuntimeClassName: ValuesFilePath.read_elsewhere("synapse", "runtimeClassName"),

--- a/tests/manifests/test_pod_containers_securityContext.py
+++ b/tests/manifests/test_pod_containers_securityContext.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import pytest
+
+from . import PropertyType, values_files_to_test
+from .utils import iterate_deployables_workload_parts, iterate_pod_template
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_containers_unprivileged_by_default(templates):
+    for pod_template_details in iterate_pod_template(templates):
+        for container in pod_template_details.pod_template["spec"]["containers"]:
+            id = f"{pod_template_details.manifest_id}/{container['name']}"
+            securityContext = container["securityContext"]
+
+            assert "privileged" in securityContext, f"{id} doesn't set privileged in its securityContext"
+            assert not securityContext["privileged"], (
+                f"{id} doesn't set privileged=false in its securityContext by default"
+            )
+
+            assert "allowPrivilegeEscalation" in securityContext, (
+                f"{id} doesn't set allowPrivilegeEscalation in its securityContext"
+            )
+            assert not securityContext["allowPrivilegeEscalation"], (
+                f"{id} doesn't set allowPrivilegeEscalation=false in its securityContext by default"
+            )
+
+            assert "readOnlyRootFilesystem" in securityContext, (
+                f"{id} doesn't set readOnlyRootFilesystem in its securityContext"
+            )
+            assert securityContext["readOnlyRootFilesystem"], (
+                f"{id} doesn't set readOnlyRootFilesystem=true in its securityContext by default"
+            )
+
+            assert "capabilities" in securityContext, f"{id} doesn't set capabilities in its securityContext"
+            assert securityContext["capabilities"] == {"drop": ("ALL",)}, (
+                f"{id} doesn't drop all capabilities in its securityContext by default"
+            )
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_containers_can_be_made_more_privileged(values, make_templates):
+    iterate_deployables_workload_parts(
+        lambda deployable_details: deployable_details.set_helm_values(
+            values,
+            PropertyType.ContainersSecurityContext,
+            {
+                "privileged": True,
+                "allowPrivilegeEscalation": True,
+                "readOnlyRootFilesystem": False,
+                "capabilities": {"add": ["NET_ADMIN"], "drop": []},
+            },
+        ),
+    )
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        for container in pod_template_details.pod_template["spec"]["containers"]:
+            id = f"{pod_template_details.manifest_id}/{container['name']}"
+            securityContext = container["securityContext"]
+
+            assert securityContext["privileged"], f"{id} doesn't set privileged=true in its securityContext"
+            assert securityContext["allowPrivilegeEscalation"], (
+                f"{id} doesn't set allowPrivilegeEscalation=true in its securityContext"
+            )
+            assert not securityContext["readOnlyRootFilesystem"], (
+                f"{id} doesn't set readOnlyRootFilesystem=false in its securityContext"
+            )
+            assert securityContext["capabilities"] == {"add": ("NET_ADMIN",), "drop": ()}, (
+                f"{id} doesn't respect the configured capabilities in its securityContext"
+            )


### PR DESCRIPTION
With the desirable side effect of making the implicit default of `privileged: false` explicit