### PR TITLE
Allow escaping of `render-config` replacements

### DIFF
--- a/charts/matrix-stack/ci/fragments/hookshot-additional-in-helm.yaml
+++ b/charts/matrix-stack/ci/fragments/hookshot-additional-in-helm.yaml
@@ -7,3 +7,4 @@ hookshot:
     example-value:
       config: |
         example: value
+        escaped_config: Some message \${NOT_REPLACED_WITH_ENV_VAR}

--- a/charts/matrix-stack/ci/hookshot-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/hookshot-secrets-in-helm-values.yaml
@@ -17,6 +17,7 @@ hookshot:
     example-value:
       config: |
         example: value
+        escaped_config: Some message \${NOT_REPLACED_WITH_ENV_VAR}
   appserviceRegistration:
     value: |
       rate_limited: false

--- a/charts/matrix-stack/ci/synapse-hookshot-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/synapse-hookshot-secrets-in-helm-values.yaml
@@ -18,6 +18,7 @@ hookshot:
     example-value:
       config: |
         example: value
+        escaped_config: Some message \${NOT_REPLACED_WITH_ENV_VAR}
   appserviceRegistration:
     value: |
       rate_limited: false

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -14,7 +14,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 ## The matrix-tools image, used in multiple components
 matrixTools:
-{{ image(registry="ghcr.io", repository="element-hq/ess-helm/matrix-tools", tag="0.8.0") | indent(2) }}
+{{ image(registry="ghcr.io", repository="element-hq/ess-helm/matrix-tools", tag="0.8.1") | indent(2) }}
 
 ## CertManager Issuer to configure by default automatically on all ingresses
 ## If configured, the chart will automatically generate the tlsSecret name for all ingresses

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -21,7 +21,7 @@ matrixTools:
 
     ## The tag of the container image to use.
     ## One of tag or digest must be provided.
-    tag: "0.8.0"
+    tag: "0.8.1"
 
     ## Container digest to use. Used to pull the image instead of the image tag if set
     ## The tag will still be set as the app.kubernetes.io/version label

--- a/matrix-tools/internal/pkg/renderer/renderer.go
+++ b/matrix-tools/internal/pkg/renderer/renderer.go
@@ -130,7 +130,7 @@ func RenderConfig(sourceConfigs []io.Reader, arrayOverwriteKeys []string) (map[s
 
 			// We need to capture any (non-escaping) character before the env var so that we can
 			// re-add it into replacementValue below or it gets lost as it was part of the regex so gets replaced
-			nonEscapedEnvVarsRe := regexp.MustCompile(`([^\\]|$)\$\{` + envVar + `\}`)
+			nonEscapedEnvVarsRe := regexp.MustCompile(`([^\\]|^)\$\{` + envVar + `\}`)
 			replacementValue = []byte("${1}" + buffer.String())
 			fileContent = nonEscapedEnvVarsRe.ReplaceAll(fileContent, replacementValue)
 		}
@@ -157,7 +157,7 @@ func RenderConfig(sourceConfigs []io.Reader, arrayOverwriteKeys []string) (map[s
 
 func extractEnvVarNames(fileContent string) []string {
 	var envVars []string
-	re := regexp.MustCompile(`[^\\]\$\{([^\}]+)\}`)
+	re := regexp.MustCompile(`(?:[^\\]|^)\$\{([^\}]+)\}`)
 	matches := re.FindAllStringSubmatch(fileContent, -1)
 	for _, match := range matches {
 		if len(match) > 1 {

--- a/matrix-tools/internal/pkg/renderer/renderer.go
+++ b/matrix-tools/internal/pkg/renderer/renderer.go
@@ -127,9 +127,17 @@ func RenderConfig(sourceConfigs []io.Reader, arrayOverwriteKeys []string) (map[s
 			if err != nil {
 				return nil, fmt.Errorf("failed to render template for env var %s: %w", envVar, err)
 			}
-			replacementValue = buffer.Bytes()
-			fileContent = bytes.ReplaceAll(fileContent, []byte("${"+envVar+"}"), replacementValue)
+
+			// We need to capture any (non-escaping) character before the env var so that we can
+			// re-add it into replacementValue below or it gets lost as it was part of the regex so gets replaced
+			nonEscapedEnvVarsRe := regexp.MustCompile(`([^\\]|$)\$\{` + envVar + `\}`)
+			replacementValue = []byte("${1}" + buffer.String())
+			fileContent = nonEscapedEnvVarsRe.ReplaceAll(fileContent, replacementValue)
 		}
+
+		// De-escape any remaining env-var looking things
+		escapedEnvVarsRe := regexp.MustCompile(`\\(\$\{([^\}]+)\})`)
+		fileContent = escapedEnvVarsRe.ReplaceAll(fileContent, []byte("$1"))
 
 		var data map[string]any
 		if err := yaml.Unmarshal(fileContent, &data); err != nil {
@@ -149,7 +157,7 @@ func RenderConfig(sourceConfigs []io.Reader, arrayOverwriteKeys []string) (map[s
 
 func extractEnvVarNames(fileContent string) []string {
 	var envVars []string
-	re := regexp.MustCompile(`\$\{([^\}]+)\}`)
+	re := regexp.MustCompile(`[^\\]\$\{([^\}]+)\}`)
 	matches := re.FindAllStringSubmatch(fileContent, -1)
 	for _, match := range matches {
 		if len(match) > 1 {

--- a/matrix-tools/internal/pkg/renderer/renderer_test.go
+++ b/matrix-tools/internal/pkg/renderer/renderer_test.go
@@ -161,6 +161,23 @@ anotherKey:
 			},
 			err: false,
 		},
+		{
+			name: "Escaping Test",
+			readers: []io.Reader{
+				bytes.NewBuffer([]byte(`
+replacedKey: ${REPLACE_WITH}
+escapedKey: \${REPLACE_WITH}
+`)),
+			},
+			env: map[string]string{
+				"REPLACE_WITH": "replaced",
+			},
+			expected: map[string]any{
+				"replacedKey": "replaced",
+				"escapedKey":  "${REPLACE_WITH}",
+			},
+			err: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/matrix-tools/internal/pkg/renderer/renderer_test.go
+++ b/matrix-tools/internal/pkg/renderer/renderer_test.go
@@ -178,6 +178,20 @@ escapedKey: \${REPLACE_WITH}
 			},
 			err: false,
 		},
+		{
+			name: "Keys Replaced Test",
+			readers: []io.Reader{
+				bytes.NewBuffer([]byte(`${LIVEKIT_KEY}: ${LIVEKIT_SECRET}`)),
+			},
+			env: map[string]string{
+				"LIVEKIT_KEY":    "key",
+				"LIVEKIT_SECRET": "secret",
+			},
+			expected: map[string]any{
+				"key": "secret",
+			},
+			err: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/newsfragments/1509.changed.md
+++ b/newsfragments/1509.changed.md
@@ -1,0 +1,4 @@
+Allow `${NAME}` literals in the rendered configuration by escaping.
+
+e.g. `\${NAME}` would render to `${NAME}` rather than looking for
+an environment variable named `NAME` to replace with.


### PR DESCRIPTION
So that additional config can include things that render down to `${NAME}` where there's no replacement happening with an env var named `NAME`.