### PR TITLE
Fix cspell-action version comment

### DIFF
--- a/.github/workflows/scripts-linting.yml
+++ b/.github/workflows/scripts-linting.yml
@@ -69,4 +69,4 @@ jobs:
       with:
         persist-credentials: false
 
-    - uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2  # v8.0.3
+    - uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2  # v8.4.0

--- a/newsfragments/1521.internal.md
+++ b/newsfragments/1521.internal.md
@@ -1,0 +1,1 @@
+Fix dependency pin for `cspell-action`.


### PR DESCRIPTION
The [pinned commit](https://github.com/streetsidesoftware/cspell-action/commit/de2a73e963e7443969755b648a1008f77033c5b2) is v8.4.0.

This resolves `action's hash pin has mismatched or missing version comment: points to unknown ref` / https://github.com/element-hq/ess-helm/security/code-scanning/98