### PR TITLE
Matrix-tools: Introduce a new randbytes generator

### DIFF
--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -14,7 +14,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 ## The matrix-tools image, used in multiple components
 matrixTools:
-{{ image(registry="ghcr.io", repository="element-hq/ess-helm/matrix-tools", tag="0.8.1") | indent(2) }}
+{{ image(registry="ghcr.io", repository="element-hq/ess-helm/matrix-tools", tag="0.9.0") | indent(2) }}
 
 ## CertManager Issuer to configure by default automatically on all ingresses
 ## If configured, the chart will automatically generate the tlsSecret name for all ingresses

--- a/charts/matrix-stack/templates/init-secrets/_helpers.tpl
+++ b/charts/matrix-stack/templates/init-secrets/_helpers.tpl
@@ -70,7 +70,7 @@ app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" $
 {{- end -}}
 {{- end -}}
 {{- if not .encryptionSecret }}
-- {{ (printf "%s-generated" $root.Release.Name) }}:MAS_ENCRYPTION_SECRET:hex32
+- {{ (printf "%s-generated" $root.Release.Name) }}:MAS_ENCRYPTION_SECRET:randbytes:32:hex
 {{- end -}}
 {{- if not (.privateKeys).rsa }}
 - {{ (printf "%s-generated" $root.Release.Name) }}:MAS_RSA_PRIVATE_KEY:rsa:4096:der

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -21,7 +21,7 @@ matrixTools:
 
     ## The tag of the container image to use.
     ## One of tag or digest must be provided.
-    tag: "0.8.1"
+    tag: "0.9.0"
 
     ## Container digest to use. Used to pull the image instead of the image tag if set
     ## The tag will still be set as the app.kubernetes.io/version label

--- a/matrix-tools/internal/cmd/generate-secrets/args.go
+++ b/matrix-tools/internal/cmd/generate-secrets/args.go
@@ -36,8 +36,8 @@ func parseSecretType(value string) (secret.SecretType, error) {
 		return secret.Rand32, nil
 	case "signingkey":
 		return secret.SigningKey, nil
-	case "hex32":
-		return secret.Hex32, nil
+	case "randbytes":
+		return secret.RandBytes, nil
 	case "rsa":
 		return secret.RSA, nil
 	case "ecdsaprime256v1":
@@ -56,7 +56,7 @@ func ParseArgs(args []string) (*GenerateSecretsOptions, error) {
 	var options GenerateSecretsOptions
 
 	generateSecretsSet := flag.NewFlagSet("generate-secrets", flag.ExitOnError)
-	secrets := generateSecretsSet.String("secrets", "", "Comma-separated list of secrets to generate, in the format of `name:key:type:args if required`, where `type` is one of: rand32, signingkey, hex32, rsa:<bits>:<der or pem>, ecdsaprime256v1")
+	secrets := generateSecretsSet.String("secrets", "", "Comma-separated list of secrets to generate, in the format of `name:key:type:args if required`, where `type` is one of: rand32, signingkey, randbytes:<length>:<encoding>, rsa:<bits>:<der or pem>, ecdsaprime256v1")
 	secretsLabels := generateSecretsSet.String("labels", "", "Comma-separated list of labels for generated secrets, in the format of `key=value`")
 
 	err := generateSecretsSet.Parse(args)

--- a/matrix-tools/internal/pkg/secret/secret.go
+++ b/matrix-tools/internal/pkg/secret/secret.go
@@ -9,6 +9,7 @@ package secret
 import (
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"math/big"
@@ -25,7 +26,7 @@ const (
 	UnknownSecretType SecretType = iota
 	Rand32
 	SigningKey
-	Hex32
+	RandBytes
 	Registration
 	RSA
 	EcdsaPrime256v1
@@ -80,11 +81,19 @@ func GenerateSecret(client kubernetes.Interface, secretLabels map[string]string,
 			} else {
 				return fmt.Errorf("failed to generate signing key: %w", err)
 			}
-		case Hex32:
-			if hexBytes, err := generateRandomBytesHex(32); err == nil {
-				existingSecret.Data[key] = hexBytes
+		case RandBytes:
+			if len(generatorArgs) < 2 {
+				return fmt.Errorf("randbytes requires length and encoding arguments: randbytes:<length>:<encoding>")
+			}
+			length, err := strconv.Atoi(generatorArgs[0])
+			if err != nil {
+				return fmt.Errorf("failed to parse length for randbytes: %w", err)
+			}
+			encoding := generatorArgs[1]
+			if encodedBytes, err := generateRandomBytes(length, encoding); err == nil {
+				existingSecret.Data[key] = encodedBytes
 			} else {
-				return fmt.Errorf("failed to generate Hex32 : %w", err)
+				return fmt.Errorf("failed to generate randbytes: %w", err)
 			}
 		case RSA:
 			bits, err := strconv.Atoi(generatorArgs[0])
@@ -139,12 +148,20 @@ func generateRandomString(size int) ([]byte, error) {
 	return bytes, nil
 }
 
-func generateRandomBytesHex(size int) ([]byte, error) {
-	key := make([]byte, size)
+func generateRandomBytes(length int, encoding string) ([]byte, error) {
+	key := make([]byte, length)
 	if _, err := rand.Read(key); err != nil {
 		return nil, fmt.Errorf("failed to generate key : %w", err)
 	}
-	encodedKey := make([]byte, hex.EncodedLen(len(key)))
-	hex.Encode(encodedKey, key)
-	return encodedKey, nil
+
+	switch encoding {
+	case "hex":
+		encodedKey := make([]byte, hex.EncodedLen(len(key)))
+		hex.Encode(encodedKey, key)
+		return encodedKey, nil
+	case "base64":
+		return []byte(base64.RawStdEncoding.EncodeToString(key)), nil
+	default:
+		return nil, fmt.Errorf("unsupported encoding: %s. Supported encodings: hex, base64", encoding)
+	}
 }

--- a/matrix-tools/internal/pkg/secret/secret_test.go
+++ b/matrix-tools/internal/pkg/secret/secret_test.go
@@ -7,8 +7,11 @@ package secret
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/hex"
 	"reflect"
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert/yaml"
@@ -169,6 +172,34 @@ func TestGenerateSecret(t *testing.T) {
 			expectedError:       false,
 			expectedChange:      true,
 		},
+		{
+			name:                  "Create randbytes with hex encoding",
+			namespace:             "randbytes-hex",
+			initLabels:            map[string]string{"app.kubernetes.io/managed-by": "matrix-tools-init-secrets", "app.kubernetes.io/name": "create-secret"},
+			secretLabels:          map[string]string{"app.kubernetes.io/name": "test-secret"},
+			generatedSecretsTypes: map[string]SecretType{"key": RandBytes},
+			secretName:            "test-randbytes-hex",
+			secretKeys:            []string{"key"},
+			secretType:            RandBytes,
+			secretData:            nil,
+			secretGeneratorArgs:   []string{"32", "hex"},
+			expectedError:         false,
+			expectedChange:        true,
+		},
+		{
+			name:                  "Create randbytes with base64 encoding",
+			namespace:             "randbytes-base64",
+			initLabels:            map[string]string{"app.kubernetes.io/managed-by": "matrix-tools-init-secrets", "app.kubernetes.io/name": "create-secret"},
+			secretLabels:          map[string]string{"app.kubernetes.io/name": "test-secret"},
+			generatedSecretsTypes: map[string]SecretType{"key": RandBytes},
+			secretName:            "test-randbytes-base64",
+			secretKeys:            []string{"key"},
+			secretType:            RandBytes,
+			secretData:            nil,
+			secretGeneratorArgs:   []string{"32", "base64"},
+			expectedError:         false,
+			expectedChange:        true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -221,6 +252,33 @@ func TestGenerateSecret(t *testing.T) {
 						case Rand32:
 							if len(string(value)) != 32 {
 								t.Fatalf("Unexpected data in secret: %v", value)
+							}
+						case RandBytes:
+							// Decode the value and verify we get the expected number of bytes
+							if len(tc.secretGeneratorArgs) == 2 {
+								expectedLength, _ := strconv.Atoi(tc.secretGeneratorArgs[0])
+								encoding := tc.secretGeneratorArgs[1]
+
+								switch encoding {
+								case "hex":
+									decoded, err := hex.DecodeString(string(value))
+									if err != nil {
+										t.Fatalf("Failed to decode hex value: %v", err)
+									}
+									if len(decoded) != expectedLength {
+										t.Fatalf("Unexpected randbytes hex decoded length. Expected %d, got %d", expectedLength, len(decoded))
+									}
+								case "base64":
+									decoded, err := base64.RawStdEncoding.DecodeString(string(value))
+									if err != nil {
+										t.Fatalf("Failed to decode base64 value: %v", err)
+									}
+									if len(decoded) != expectedLength {
+										t.Fatalf("Unexpected randbytes base64 decoded length. Expected %d, got %d", expectedLength, len(decoded))
+									}
+								default:
+									t.Fatalf("Unexpected encoding: %s", encoding)
+								}
 							}
 						case SigningKey:
 							expectedPattern := "ed25519 1 ([a-zA-Z0-9\\/\\+]+)"

--- a/newsfragments/1528.changed.md
+++ b/newsfragments/1528.changed.md
@@ -1,0 +1,1 @@
+matrix-tools: Update to 0.9.0. Introduces a new `randbytes` init-secrets generator, which replaces the `hex32` generator.


### PR DESCRIPTION
This generator will handle various encoding, starting with `hex` and `base64`.