### PR TITLE
haproxy: `element-io.synapse.ingress.additionalPaths` helper

### DIFF
--- a/charts/matrix-stack/configs/synapse/partial-haproxy.cfg.tpl
+++ b/charts/matrix-stack/configs/synapse/partial-haproxy.cfg.tpl
@@ -103,7 +103,8 @@ frontend synapse-http-in
 {{- end }}
   use_backend return_204_synapse if { method OPTIONS }
 
-{{- range .ingress.additionalPaths -}}
+{{- /* `internally_and_externally` must be placed under `/_matrix` or `/_synapse` to be routed properly by haproxy */}}
+{{- range (include "element-io.synapse.ingress.additionalPaths" (dict "root" $root "context" .)) | fromYamlArray -}}
 {{- if eq .availability "internally_and_externally" }}
 
 {{- $additionalPathId := printf "%s_%s" .service.name (.service.port.name | default .service.port.number) }}
@@ -263,7 +264,8 @@ backend synapse-{{ $workerType }}
 {{- end }}
 {{- end }}
 
-{{- range .ingress.additionalPaths -}}
+{{- /* `internally_and_externally` must be placed under `/_matrix` or `/_synapse` to be routed properly by haproxy */}}
+{{- range (include "element-io.synapse.ingress.additionalPaths" (dict "root" $root "context" .)) | fromYamlArray -}}
 {{- if eq .availability "internally_and_externally" }}
 {{- $additionalPathId := printf "%s_%s" .service.name (.service.port.name | default .service.port.number) }}
 backend synapse-be_{{ $additionalPathId }}

--- a/charts/matrix-stack/templates/synapse/synapse_ingress.yaml
+++ b/charts/matrix-stack/templates/synapse/synapse_ingress.yaml
@@ -1,6 +1,6 @@
 {{- /*
 Copyright 2024 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -26,6 +26,9 @@ spec:
   - host: {{ (tpl .ingress.host $) | quote }}
     http:
       paths:
+{{- /* `only_externally` and `blocked` path are handled in the public Ingress only so that internal routing isn't impacted,
+      while `internally_and_externally` must be placed under `/_matrix` or `/_synapse` and will be handled by `synapse/haproxy-partial.cfg
+*/ -}}
 {{- range (include "element-io.synapse.ingress.additionalPaths" (dict "root" $ "context" .)) | fromYamlArray -}}
 {{- if eq .availability "only_externally" }}
       - path: {{ .path }}

--- a/newsfragments/1534.internal.md
+++ b/newsfragments/1534.internal.md
@@ -1,0 +1,1 @@
+Use `element-io.synapse.ingress.additionalPaths` helper instead of `synapse.ingress.additionalPaths` in `haproxy-partial.cfg`.


### PR DESCRIPTION
This makes the templates more consistent with how we refer to Synapse additional paths.