### PR TITLE
Upgrade Postgres Exporter to v0.20.1

### DIFF
--- a/charts/matrix-stack/source/postgres.yaml.j2
+++ b/charts/matrix-stack/source/postgres.yaml.j2
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 enabled: true
 
 postgresExporter:
-  {{- sub_schema_values.image(registry='docker.io', repository='prometheuscommunity/postgres-exporter', tag='v0.18.1') | indent(2) }}
+  {{- sub_schema_values.image(registry='ghcr.io', repository='prometheus-community/postgres-exporter', tag='v0.20.1') | indent(2) }}
   {{- sub_schema_values.resources(requests_memory='10Mi', requests_cpu='10m', limits_memory='500Mi')| indent(2) }}
   {{- sub_schema_values.extraVolumeMounts("PostgresExporter") | indent(2) }}
   {{- sub_schema_values.containersSecurityContext() | indent(2) }}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -3236,14 +3236,14 @@ postgres:
     image:
       ## The host and (optional) port of the container image registry for this component.
       ## If not specified Docker Hub is implied
-      registry: docker.io
+      registry: ghcr.io
 
       ## The path in the registry where the container image is located
-      repository: prometheuscommunity/postgres-exporter
+      repository: prometheus-community/postgres-exporter
 
       ## The tag of the container image to use.
       ## One of tag or digest must be provided.
-      tag: "v0.18.1"
+      tag: "v0.20.1"
 
       ## Container digest to use. Used to pull the image instead of the image tag if set
       ## The tag will still be set as the app.kubernetes.io/version label

--- a/newsfragments/1537.changed.md
+++ b/newsfragments/1537.changed.md
@@ -1,0 +1,7 @@
+Upgrade Postgres Exporter to v0.20.1.
+
+Full Changelogs:
+- [v0.19.0](https://github.com/prometheus-community/postgres_exporter/releases/tag/v0.19.0)
+- [v0.19.1](https://github.com/prometheus-community/postgres_exporter/releases/tag/v0.19.1)
+- [v0.20.0](https://github.com/prometheus-community/postgres_exporter/releases/tag/v0.20.0)
+- [v0.20.1](https://github.com/prometheus-community/postgres_exporter/releases/tag/v0.20.1)


### PR DESCRIPTION
No particular reason. But also no particular reason not to