### PR TITLE
Upgrade Redis Exporter to v1.89.0

### DIFF
--- a/charts/matrix-stack/source/redis.yaml.j2
+++ b/charts/matrix-stack/source/redis.yaml.j2
@@ -36,7 +36,7 @@ replicas: 1
 {{- sub_schema_values.probe("startup", failureThreshold=5) }}
 
 redisExporter:
-  {{- sub_schema_values.image(registry='ghcr.io', repository='oliver006/redis_exporter', tag='v1.84.0') | indent(2) }}
+  {{- sub_schema_values.image(registry='ghcr.io', repository='oliver006/redis_exporter', tag='v1.89.0') | indent(2) }}
   {{- sub_schema_values.resources(requests_memory='10Mi', requests_cpu='10m', limits_memory='50Mi')| indent(2) }}
   {{- sub_schema_values.extraVolumeMounts("Redis Exporter") | indent(2) }}
   {{- sub_schema_values.containersSecurityContext() | indent(2) }}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -3953,7 +3953,7 @@ redis:
 
       ## The tag of the container image to use.
       ## One of tag or digest must be provided.
-      tag: "v1.84.0"
+      tag: "v1.89.0"
 
       ## Container digest to use. Used to pull the image instead of the image tag if set
       ## The tag will still be set as the app.kubernetes.io/version label

--- a/newsfragments/1538.changed.md
+++ b/newsfragments/1538.changed.md
@@ -1,0 +1,8 @@
+Upgrade Redis Exporter to v1.89.0.
+
+Full Changelogs:
+- [v1.85.0](https://github.com/oliver006/redis_exporter/releases/tag/v1.85.0)
+- [v1.86.0](https://github.com/oliver006/redis_exporter/releases/tag/v1.86.0)
+- [v1.87.0](https://github.com/oliver006/redis_exporter/releases/tag/v1.87.0)
+- [v1.88.0](https://github.com/oliver006/redis_exporter/releases/tag/v1.88.0)
+- [v1.89.0](https://github.com/oliver006/redis_exporter/releases/tag/v1.89.0)


### PR DESCRIPTION
No particular reason. But also no particular reason not to