### PR TITLE
Remove newlines from values files fragments

### DIFF
--- a/charts/matrix-stack/ci/fragments/matrix-rtc-secrets-externally.yaml
+++ b/charts/matrix-stack/ci/fragments/matrix-rtc-secrets-externally.yaml
@@ -1,6 +1,5 @@
-
 # Copyright 2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/charts/matrix-stack/ci/fragments/matrix-rtc-secrets-in-helm.yaml
+++ b/charts/matrix-stack/ci/fragments/matrix-rtc-secrets-in-helm.yaml
@@ -1,7 +1,5 @@
-
-
 # Copyright 2025 New Vector Ltd
-# Copyright 2025 Element Creations Ltd
+# Copyright 2025-2026 Element Creations Ltd
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/newsfragments/1541.internal.md
+++ b/newsfragments/1541.internal.md
@@ -1,0 +1,1 @@
+Remove leading newlines from values files fragments.


### PR DESCRIPTION
Hopefully fix the failures we've seen in e.g. https://github.com/element-hq/ess-helm/actions/runs/32942996436/job/98097718410?pr=1532 and #1540 when regenerating these in CI