### PR TITLE
Make clear that ephemeral-storage requests/limits can be set

### DIFF
--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -500,10 +500,15 @@ networking:
   requests:
     memory: {{ requests_memory }}
     cpu: {{ requests_cpu }}
+    ## No ephemeral-storage requests by default
+    # ephemeral-storage:
 
   ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
   limits:
     memory: {{ limits_memory }}
+    ## No CPU or ephemeral-storage limits by default
+    # cpu:
+    # ephemeral-storage:
 {%- endmacro %}
 
 {% macro serviceAccount(key='serviceAccount') %}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -339,10 +339,15 @@ initSecrets:
     requests:
       memory: 50Mi
       cpu: 50m
+      ## No ephemeral-storage requests by default
+      # ephemeral-storage:
 
     ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     limits:
       memory: 200Mi
+      ## No CPU or ephemeral-storage limits by default
+      # cpu:
+      # ephemeral-storage:
   ## Controls configuration of the ServiceAccount for this component
   serviceAccount:
     ## Whether a ServiceAccount should be created by the chart or not
@@ -515,10 +520,15 @@ deploymentMarkers:
     requests:
       memory: 50Mi
       cpu: 50m
+      ## No ephemeral-storage requests by default
+      # ephemeral-storage:
 
     ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     limits:
       memory: 200Mi
+      ## No CPU or ephemeral-storage limits by default
+      # cpu:
+      # ephemeral-storage:
   ## Controls configuration of the ServiceAccount for this component
   serviceAccount:
     ## Whether a ServiceAccount should be created by the chart or not
@@ -779,10 +789,15 @@ matrixRTC:
     requests:
       memory: 50Mi
       cpu: 50m
+      ## No ephemeral-storage requests by default
+      # ephemeral-storage:
 
     ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     limits:
       memory: 200Mi
+      ## No CPU or ephemeral-storage limits by default
+      # cpu:
+      # ephemeral-storage:
   ## Whether to deploy ServiceMonitors into the cluster for this component
   ## Requires the ServiceMonitor CRDs to be in the cluster
   serviceMonitors:
@@ -1195,10 +1210,15 @@ matrixRTC:
       requests:
         memory: 150Mi
         cpu: 100m
+        ## No ephemeral-storage requests by default
+        # ephemeral-storage:
 
       ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
       limits:
         memory: 4Gi
+        ## No CPU or ephemeral-storage limits by default
+        # cpu:
+        # ephemeral-storage:
     ## Controls configuration of the ServiceAccount for this component
     serviceAccount:
       ## Whether a ServiceAccount should be created by the chart or not
@@ -1487,10 +1507,15 @@ elementAdmin:
     requests:
       memory: 50Mi
       cpu: 50m
+      ## No ephemeral-storage requests by default
+      # ephemeral-storage:
 
     ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     limits:
       memory: 200Mi
+      ## No CPU or ephemeral-storage limits by default
+      # cpu:
+      # ephemeral-storage:
   ## Controls configuration of the ServiceAccount for this component
   serviceAccount:
     ## Whether a ServiceAccount should be created by the chart or not
@@ -1775,10 +1800,15 @@ elementWeb:
     requests:
       memory: 50Mi
       cpu: 50m
+      ## No ephemeral-storage requests by default
+      # ephemeral-storage:
 
     ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     limits:
       memory: 200Mi
+      ## No CPU or ephemeral-storage limits by default
+      # cpu:
+      # ephemeral-storage:
   ## Controls configuration of the ServiceAccount for this component
   serviceAccount:
     ## Whether a ServiceAccount should be created by the chart or not
@@ -2022,10 +2052,15 @@ haproxy:
     requests:
       memory: 100Mi
       cpu: 100m
+      ## No ephemeral-storage requests by default
+      # ephemeral-storage:
 
     ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     limits:
       memory: 200Mi
+      ## No CPU or ephemeral-storage limits by default
+      # cpu:
+      # ephemeral-storage:
   ## Controls configuration of the ServiceAccount for this component
   serviceAccount:
     ## Whether a ServiceAccount should be created by the chart or not
@@ -2308,10 +2343,15 @@ hookshot:
     requests:
       memory: 100Mi
       cpu: 10m
+      ## No ephemeral-storage requests by default
+      # ephemeral-storage:
 
     ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     limits:
       memory: 1000Mi
+      ## No CPU or ephemeral-storage limits by default
+      # cpu:
+      # ephemeral-storage:
 
   # Extra volumes to mount in Hookshot, as a yaml array
   # This supports helm templating
@@ -2754,10 +2794,15 @@ matrixAuthenticationService:
     requests:
       memory: 50Mi
       cpu: 50m
+      ## No ephemeral-storage requests by default
+      # ephemeral-storage:
 
     ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     limits:
       memory: 350Mi
+      ## No CPU or ephemeral-storage limits by default
+      # cpu:
+      # ephemeral-storage:
 
   ## Labels to add to all manifest for this component
   labels: {}
@@ -3162,10 +3207,15 @@ matrixAuthenticationService:
       requests:
         memory: 50Mi
         cpu: 50m
+        ## No ephemeral-storage requests by default
+        # ephemeral-storage:
 
       ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
       limits:
         memory: 350Mi
+        ## No CPU or ephemeral-storage limits by default
+        # cpu:
+        # ephemeral-storage:
     ## Controls configuration of the ServiceAccount for this component
     serviceAccount:
       ## Whether a ServiceAccount should be created by the chart or not
@@ -3264,10 +3314,15 @@ postgres:
       requests:
         memory: 10Mi
         cpu: 10m
+        ## No ephemeral-storage requests by default
+        # ephemeral-storage:
 
       ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
       limits:
         memory: 500Mi
+        ## No CPU or ephemeral-storage limits by default
+        # cpu:
+        # ephemeral-storage:
     # Extra volumes to mount in PostgresExporter, as a yaml array
     extraVolumeMounts: []
 
@@ -3572,10 +3627,15 @@ postgres:
     requests:
       memory: 100Mi
       cpu: 100m
+      ## No ephemeral-storage requests by default
+      # ephemeral-storage:
 
     ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     limits:
       memory: 4Gi
+      ## No CPU or ephemeral-storage limits by default
+      # cpu:
+      # ephemeral-storage:
   ## Controls configuration of the ServiceAccount for this component
   serviceAccount:
     ## Whether a ServiceAccount should be created by the chart or not
@@ -3837,10 +3897,15 @@ redis:
     requests:
       memory: 50Mi
       cpu: 50m
+      ## No ephemeral-storage requests by default
+      # ephemeral-storage:
 
     ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     limits:
       memory: 50Mi
+      ## No CPU or ephemeral-storage limits by default
+      # cpu:
+      # ephemeral-storage:
   ## Controls configuration of the ServiceAccount for this component
   serviceAccount:
     ## Whether a ServiceAccount should be created by the chart or not
@@ -3974,10 +4039,15 @@ redis:
       requests:
         memory: 10Mi
         cpu: 10m
+        ## No ephemeral-storage requests by default
+        # ephemeral-storage:
 
       ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
       limits:
         memory: 50Mi
+        ## No CPU or ephemeral-storage limits by default
+        # cpu:
+        # ephemeral-storage:
     # Extra volumes to mount in Redis Exporter, as a yaml array
     extraVolumeMounts: []
 
@@ -4090,10 +4160,15 @@ synapse:
       requests:
         memory: 50Mi
         cpu: 50m
+        ## No ephemeral-storage requests by default
+        # ephemeral-storage:
 
       ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
       limits:
         memory: 200Mi
+        ## No CPU or ephemeral-storage limits by default
+        # cpu:
+        # ephemeral-storage:
   ## Details of the external Postgres Database to use
   ## Does not need to be set if postgres.enabled=True
   # postgres:
@@ -5801,10 +5876,15 @@ synapse:
     requests:
       memory: 100Mi
       cpu: 100m
+      ## No ephemeral-storage requests by default
+      # ephemeral-storage:
 
     ## Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     limits:
       memory: 4Gi
+      ## No CPU or ephemeral-storage limits by default
+      # cpu:
+      # ephemeral-storage:
   ## Controls configuration of the ServiceAccount for this component
   serviceAccount:
     ## Whether a ServiceAccount should be created by the chart or not

--- a/newsfragments/1544.changed.md
+++ b/newsfragments/1544.changed.md
@@ -1,0 +1,1 @@
+Make clearer which requests and limits are set by default vs omitted by default.

--- a/tests/manifests/test_pod_resources.py
+++ b/tests/manifests/test_pod_resources.py
@@ -11,6 +11,44 @@ from .utils import iterate_deployables_workload_parts, iterate_pod_template
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
+async def test_pod_have_cpu_and_memory_requests_and_memory_limits_by_default(values, templates):
+    for pod_template_details in iterate_pod_template(templates):
+        for container in pod_template_details.pod_template["spec"]["containers"]:
+            assert "resources" in container, (
+                f"{pod_template_details.manifest_id} has container {container['name']} without resources"
+            )
+
+            assert "requests" in container["resources"], (
+                f"{pod_template_details.manifest_id} has container {container['name']} without resource requests"
+            )
+            requests = container["resources"]["requests"]
+            assert "cpu" in requests, (
+                f"{pod_template_details.manifest_id} has container {container['name']} without CPU requests"
+            )
+            assert "memory" in requests, (
+                f"{pod_template_details.manifest_id} has container {container['name']} without memory requests"
+            )
+            assert len(requests) == 2, (
+                f"{pod_template_details.manifest_id} has container {container['name']} with unexpected default requests"
+            )
+
+            assert "limits" in container["resources"], (
+                f"{pod_template_details.manifest_id} has container {container['name']} without resource limits"
+            )
+            limits = container["resources"]["limits"]
+            assert "cpu" not in limits, (
+                f"{pod_template_details.manifest_id} has container {container['name']} with CPU limits"
+            )
+            assert "memory" in limits, (
+                f"{pod_template_details.manifest_id} has container {container['name']} without memory limits"
+            )
+            assert len(limits) == 1, (
+                f"{pod_template_details.manifest_id} has container {container['name']} with unexpected default limits"
+            )
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
 async def test_pod_resources_are_configurable(values, make_templates):
     counter = 1
 
@@ -20,10 +58,12 @@ async def test_pod_resources_are_configurable(values, make_templates):
             "requests": {
                 "cpu": f"{1000 + counter}",
                 "memory": f"{2000 + counter}Mi",
+                "ephemeral-storage": f"{3000 + counter}Mi",
             },
             "limits": {
-                "cpu": f"{3000 + counter}",
-                "memory": f"{4000 + counter}Mi",
+                "cpu": f"{4000 + counter}",
+                "memory": f"{5000 + counter}Mi",
+                "ephemeral-storage": f"{600 + counter}Gi",
             },
         }
         counter += 1


### PR DESCRIPTION
I had thought more work would be required to support `ephemeral-storage` but we just pass `resources` straight through. Encoded it in a test that it is supported