### PR TITLE
Add support for `emptyDir.medium` configurability

### DIFF
--- a/charts/matrix-stack/source/common/ephemeralStorage.json
+++ b/charts/matrix-stack/source/common/ephemeralStorage.json
@@ -5,6 +5,14 @@
       "type": "string",
       "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$",
       "description": "The maximum size of the emptyDir volume, as a Kubernetes quantity string e.g. 10Mi."
+    },
+    "medium": {
+      "type": "string",
+      "enum": [
+        "",
+        "Memory"
+      ],
+      "description": "The storage medium of the emptyDir volume. \"Memory\" uses tmpfs (RAM-backed); empty string uses the node's default storage."
     }
   }
 }

--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -15,7 +15,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 ## The matrix-tools image, used in multiple components
 matrixTools:
 {{ image(registry="ghcr.io", repository="element-hq/ess-helm/matrix-tools", tag="0.10.0") | indent(2) }}
-{{ ephemeralStorages([("renderedConfig", "rendered-config emptyDir used in all components to render configuration", "1Mi")]) | indent(2) }}
+{{ ephemeralStorages([("renderedConfig", "rendered-config emptyDir used in all components to render configuration", "1Mi", "Memory")]) | indent(2) }}
 
 ## CertManager Issuer to configure by default automatically on all ingresses
 ## If configured, the chart will automatically generate the tlsSecret name for all ingresses
@@ -603,13 +603,15 @@ networking:
 {% endmacro %}
 
 {% macro ephemeralStorages(entries) %}
-## Configures sizeLimit (maximum size) for this component's emptyDir volumes.
+## Configures sizeLimit (maximum size) and medium for this component's emptyDir volumes.
 ## Each sizeLimit is a Kubernetes quantity string, e.g. 10Mi.
+## medium is either "Memory" (tmpfs-backed) or "" (node default storage).
 ephemeralStorages:
-{%- for key, description, sizeLimit in entries %}
+{%- for key, description, sizeLimit, medium in entries %}
   ## {{ description }}
   {{ key }}:
     sizeLimit: {{ sizeLimit }}
+    medium: {{ medium }}
 {%- endfor %}
 {%- endmacro %}
 

--- a/charts/matrix-stack/source/element-admin.yaml.j2
+++ b/charts/matrix-stack/source/element-admin.yaml.j2
@@ -34,4 +34,4 @@ replicas: 1
 {{- sub_schema_values.probe("liveness") }}
 {{- sub_schema_values.probe("readiness") }}
 {{- sub_schema_values.probe("startup") }}
-{{- sub_schema_values.ephemeralStorages([("tmp", "nginx temporary files (/tmp)", "10Mi")]) }}
+{{- sub_schema_values.ephemeralStorages([("tmp", "nginx temporary files (/tmp)", "10Mi", "Memory")]) }}

--- a/charts/matrix-stack/source/element-web.yaml.j2
+++ b/charts/matrix-stack/source/element-web.yaml.j2
@@ -42,4 +42,4 @@ replicas: 1
 {{- sub_schema_values.probe("liveness") }}
 {{- sub_schema_values.probe("readiness", periodSeconds=3) }}
 {{- sub_schema_values.probe("startup", failureThreshold=4, periodSeconds=3) }}
-{{- sub_schema_values.ephemeralStorages([("tmp", "nginx temporary files (/tmp)", "10Mi")]) }}
+{{- sub_schema_values.ephemeralStorages([("tmp", "nginx temporary files (/tmp)", "10Mi", "Memory")]) }}

--- a/charts/matrix-stack/source/hookshot.yaml.j2
+++ b/charts/matrix-stack/source/hookshot.yaml.j2
@@ -56,4 +56,4 @@ replicas: 1
 {{ sub_schema_values.probe("liveness", failureThreshold=9) }}
 {{ sub_schema_values.probe("readiness", failureThreshold=9) }}
 {{ sub_schema_values.probe("startup", failureThreshold=9) }}
-{{ sub_schema_values.ephemeralStorages([("tmp", "temporary files (/tmp)", "10Mi")]) }}
+{{ sub_schema_values.ephemeralStorages([("tmp", "temporary files (/tmp)", "10Mi", "Memory")]) }}

--- a/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
+++ b/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
@@ -86,7 +86,7 @@ syn2mas:
   {{- sub_schema_values.tolerations() | indent(2) }}
   {{- sub_schema_values.topologySpreadConstraints() | indent(2) }}
 
-  {{- sub_schema_values.ephemeralStorages([("tmpMasCli", "temporary mas-cli copy (/tmp-mas-cli)", "100Mi")]) | indent(2) }}
+  {{- sub_schema_values.ephemeralStorages([("tmpMasCli", "temporary mas-cli copy (/tmp-mas-cli)", "100Mi", "Memory")]) | indent(2) }}
 
   ## Runs the syn2mas process in dryRun mode.
   ## Force the authentication to happen with legacy authentication.

--- a/charts/matrix-stack/source/postgres.yaml.j2
+++ b/charts/matrix-stack/source/postgres.yaml.j2
@@ -48,4 +48,4 @@ essPasswords: {}
 {{- sub_schema_values.probe("liveness", timeoutSeconds=2) }}
 {{- sub_schema_values.probe("readiness", timeoutSeconds=2) }}
 {{- sub_schema_values.probe("startup", failureThreshold=8) }}
-{{- sub_schema_values.ephemeralStorages([("tmp", "temporary files (/tmp)", "10Mi"), ("varRun", "postgresql runtime directory (/var/run)", "1Mi")]) }}
+{{- sub_schema_values.ephemeralStorages([("tmp", "temporary files (/tmp)", "10Mi", "Memory"), ("varRun", "postgresql runtime directory (/var/run)", "1Mi", "Memory")]) }}

--- a/charts/matrix-stack/source/synapse.yaml.j2
+++ b/charts/matrix-stack/source/synapse.yaml.j2
@@ -107,7 +107,7 @@ replicas: 1
 {{- sub_schema_values.affinity() }}
 {{- sub_schema_values.podSecurityContext(user_id='10091', group_id='10091') }}
 {{- sub_schema_values.resources(requests_memory='100Mi', requests_cpu='100m', limits_memory='4Gi') }}
-{{- sub_schema_values.ephemeralStorages([("media", "media store emptyDir fallback (/media)", "100Mi"),]) }}
+{{- sub_schema_values.ephemeralStorages([("media", "media store emptyDir fallback (/media)", "100Mi", "Memory"),]) }}
 {{- sub_schema_values.serviceAccount() }}
 {{- sub_schema_values.serviceMonitors() }}
 {{- sub_schema_values.tolerations() }}

--- a/charts/matrix-stack/templates/element-admin/deployment.yaml
+++ b/charts/matrix-stack/templates/element-admin/deployment.yaml
@@ -71,14 +71,7 @@ spec:
         - {{ (. | toYaml) | nindent 10 }}
 {{- end }}
       volumes:
-      - emptyDir:
-          {{- with $.Values.elementAdmin.ephemeralStorages.tmp.medium }}
-          medium: {{ . }}
-          {{- end }}
-          {{- with $.Values.elementAdmin.ephemeralStorages.tmp.sizeLimit }}
-          sizeLimit: {{ . }}
-          {{- end }}
-        name: tmp
+{{- include "element-io.ess-library.empty-dir" (dict "root" $ "context" (dict "componentValues" $.Values.elementAdmin "ephemeralStorage" "tmp" "volumeName" "tmp")) | nindent 6 }}
 {{- range .extraVolumes }}
       - {{- (tpl (. | toYaml) $) | nindent 8 }}
 {{- end }}

--- a/charts/matrix-stack/templates/element-admin/deployment.yaml
+++ b/charts/matrix-stack/templates/element-admin/deployment.yaml
@@ -72,7 +72,9 @@ spec:
 {{- end }}
       volumes:
       - emptyDir:
-          medium: Memory
+          {{- with $.Values.elementAdmin.ephemeralStorages.tmp.medium }}
+          medium: {{ . }}
+          {{- end }}
           {{- with $.Values.elementAdmin.ephemeralStorages.tmp.sizeLimit }}
           sizeLimit: {{ . }}
           {{- end }}

--- a/charts/matrix-stack/templates/element-admin/deployment.yaml
+++ b/charts/matrix-stack/templates/element-admin/deployment.yaml
@@ -71,7 +71,8 @@ spec:
         - {{ (. | toYaml) | nindent 10 }}
 {{- end }}
       volumes:
-{{- include "element-io.ess-library.empty-dir" (dict "root" $ "context" (dict "componentValues" $.Values.elementAdmin "ephemeralStorage" "tmp" "volumeName" "tmp")) | nindent 6 }}
+      - emptyDir: {{- $.Values.elementAdmin.ephemeralStorages.tmp | toYaml | nindent 10 }}
+        name: tmp
 {{- range .extraVolumes }}
       - {{- (tpl (. | toYaml) $) | nindent 8 }}
 {{- end }}

--- a/charts/matrix-stack/templates/element-web/deployment.yaml
+++ b/charts/matrix-stack/templates/element-web/deployment.yaml
@@ -99,7 +99,8 @@ spec:
           defaultMode: 420
           name: {{ $.Release.Name }}-element-web-nginx
         name: nginx-config
-{{- include "element-io.ess-library.empty-dir" (dict "root" $ "context" (dict "componentValues" $.Values.elementWeb "ephemeralStorage" "tmp" "volumeName" "tmp")) | nindent 6 }}
+      - emptyDir: {{- $.Values.elementWeb.ephemeralStorages.tmp | toYaml | nindent 10 }}
+        name: tmp
 {{- range .extraVolumes }}
       - {{- (tpl (. | toYaml) $) | nindent 8 }}
 {{- end }}

--- a/charts/matrix-stack/templates/element-web/deployment.yaml
+++ b/charts/matrix-stack/templates/element-web/deployment.yaml
@@ -100,7 +100,9 @@ spec:
           name: {{ $.Release.Name }}-element-web-nginx
         name: nginx-config
       - emptyDir:
-          medium: Memory
+          {{- with $.Values.elementWeb.ephemeralStorages.tmp.medium }}
+          medium: {{ . }}
+          {{- end }}
           {{- with $.Values.elementWeb.ephemeralStorages.tmp.sizeLimit }}
           sizeLimit: {{ . }}
           {{- end }}

--- a/charts/matrix-stack/templates/element-web/deployment.yaml
+++ b/charts/matrix-stack/templates/element-web/deployment.yaml
@@ -99,14 +99,7 @@ spec:
           defaultMode: 420
           name: {{ $.Release.Name }}-element-web-nginx
         name: nginx-config
-      - emptyDir:
-          {{- with $.Values.elementWeb.ephemeralStorages.tmp.medium }}
-          medium: {{ . }}
-          {{- end }}
-          {{- with $.Values.elementWeb.ephemeralStorages.tmp.sizeLimit }}
-          sizeLimit: {{ . }}
-          {{- end }}
-        name: tmp
+{{- include "element-io.ess-library.empty-dir" (dict "root" $ "context" (dict "componentValues" $.Values.elementWeb "ephemeralStorage" "tmp" "volumeName" "tmp")) | nindent 6 }}
 {{- range .extraVolumes }}
       - {{- (tpl (. | toYaml) $) | nindent 8 }}
 {{- end }}

--- a/charts/matrix-stack/templates/ess-library/_pods.tpl
+++ b/charts/matrix-stack/templates/ess-library/_pods.tpl
@@ -162,6 +162,23 @@ timeoutSeconds: {{ . }}
 {{- end }}
 {{- end }}
 
+{{- define "element-io.ess-library.empty-dir" -}}
+{{- $root := .root -}}
+{{- with required "element-io.ess-library.empty-dir missing context" .context -}}
+{{- $ephemeralStorage := required "element-io.ess-library.empty-dir missing ephemeralStorage" .ephemeralStorage -}}
+{{- $volumeName := required "element-io.ess-library.empty-dir missing volumeName" .volumeName -}}
+{{- $storage := get .componentValues.ephemeralStorages $ephemeralStorage -}}
+- emptyDir:
+{{- with $storage.medium }}
+    medium: {{ . }}
+{{- end }}
+{{- with $storage.sizeLimit }}
+    sizeLimit: {{ . }}
+{{- end }}
+  name: {{ $volumeName }}
+{{- end }}
+{{- end }}
+
 {{- define "element-io.ess-library.pods.env" -}}
 {{- $root := .root -}}
 {{- with required "element-io.ess-library.pods.env missing context" .context -}}

--- a/charts/matrix-stack/templates/ess-library/_pods.tpl
+++ b/charts/matrix-stack/templates/ess-library/_pods.tpl
@@ -162,23 +162,6 @@ timeoutSeconds: {{ . }}
 {{- end }}
 {{- end }}
 
-{{- define "element-io.ess-library.empty-dir" -}}
-{{- $root := .root -}}
-{{- with required "element-io.ess-library.empty-dir missing context" .context -}}
-{{- $ephemeralStorage := required "element-io.ess-library.empty-dir missing ephemeralStorage" .ephemeralStorage -}}
-{{- $volumeName := required "element-io.ess-library.empty-dir missing volumeName" .volumeName -}}
-{{- $storage := get .componentValues.ephemeralStorages $ephemeralStorage -}}
-- emptyDir:
-{{- with $storage.medium }}
-    medium: {{ . }}
-{{- end }}
-{{- with $storage.sizeLimit }}
-    sizeLimit: {{ . }}
-{{- end }}
-  name: {{ $volumeName }}
-{{- end }}
-{{- end }}
-
 {{- define "element-io.ess-library.pods.env" -}}
 {{- $root := .root -}}
 {{- with required "element-io.ess-library.pods.env missing context" .context -}}

--- a/charts/matrix-stack/templates/ess-library/_render_config.tpl
+++ b/charts/matrix-stack/templates/ess-library/_render_config.tpl
@@ -101,14 +101,7 @@ SPDX-License-Identifier: AGPL-3.0-only
   name: secret-{{ . | sha256sum | trunc 12  }}
 {{- end }}
 {{- end }}
-- emptyDir:
-    {{- with $root.Values.matrixTools.ephemeralStorages.renderedConfig.medium }}
-    medium: {{ . }}
-    {{- end }}
-    {{- with $root.Values.matrixTools.ephemeralStorages.renderedConfig.sizeLimit }}
-    sizeLimit: {{ . }}
-    {{- end }}
-  name: "rendered-config"
+{{- include "element-io.ess-library.empty-dir" (dict "root" $root "context" (dict "componentValues" $root.Values.matrixTools "ephemeralStorage" "renderedConfig" "volumeName" "rendered-config")) | nindent 0 }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/matrix-stack/templates/ess-library/_render_config.tpl
+++ b/charts/matrix-stack/templates/ess-library/_render_config.tpl
@@ -102,7 +102,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- end }}
 {{- end }}
 - emptyDir:
-    medium: Memory
+    {{- with $root.Values.matrixTools.ephemeralStorages.renderedConfig.medium }}
+    medium: {{ . }}
+    {{- end }}
     {{- with $root.Values.matrixTools.ephemeralStorages.renderedConfig.sizeLimit }}
     sizeLimit: {{ . }}
     {{- end }}

--- a/charts/matrix-stack/templates/ess-library/_render_config.tpl
+++ b/charts/matrix-stack/templates/ess-library/_render_config.tpl
@@ -101,7 +101,8 @@ SPDX-License-Identifier: AGPL-3.0-only
   name: secret-{{ . | sha256sum | trunc 12  }}
 {{- end }}
 {{- end }}
-{{- include "element-io.ess-library.empty-dir" (dict "root" $root "context" (dict "componentValues" $root.Values.matrixTools "ephemeralStorage" "renderedConfig" "volumeName" "rendered-config")) | nindent 0 }}
+- emptyDir: {{- $root.Values.matrixTools.ephemeralStorages.renderedConfig | toYaml | nindent 4 }}
+  name: rendered-config
 {{- end -}}
 {{- end -}}
 

--- a/charts/matrix-stack/templates/hookshot/hookshot_statefulset.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_statefulset.yaml
@@ -159,7 +159,9 @@ spec:
           claimName: {{ include "element-io.hookshot.pvcName" (dict "root" $) }}
 {{- end }}
       - emptyDir:
-          medium: Memory
+          {{- with $.Values.hookshot.ephemeralStorages.tmp.medium }}
+          medium: {{ . }}
+          {{- end }}
           {{- with $.Values.hookshot.ephemeralStorages.tmp.sizeLimit }}
           sizeLimit: {{ . }}
           {{- end }}

--- a/charts/matrix-stack/templates/hookshot/hookshot_statefulset.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_statefulset.yaml
@@ -158,6 +158,7 @@ spec:
         persistentVolumeClaim:
           claimName: {{ include "element-io.hookshot.pvcName" (dict "root" $) }}
 {{- end }}
-{{- include "element-io.ess-library.empty-dir" (dict "root" $ "context" (dict "componentValues" $.Values.hookshot "ephemeralStorage" "tmp" "volumeName" "tmp")) | nindent 6 }}
+      - emptyDir: {{- $.Values.hookshot.ephemeralStorages.tmp | toYaml | nindent 10 }}
+        name: tmp
 {{- end }}
 {{- end -}}

--- a/charts/matrix-stack/templates/hookshot/hookshot_statefulset.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_statefulset.yaml
@@ -158,13 +158,6 @@ spec:
         persistentVolumeClaim:
           claimName: {{ include "element-io.hookshot.pvcName" (dict "root" $) }}
 {{- end }}
-      - emptyDir:
-          {{- with $.Values.hookshot.ephemeralStorages.tmp.medium }}
-          medium: {{ . }}
-          {{- end }}
-          {{- with $.Values.hookshot.ephemeralStorages.tmp.sizeLimit }}
-          sizeLimit: {{ . }}
-          {{- end }}
-        name: tmp
+{{- include "element-io.ess-library.empty-dir" (dict "root" $ "context" (dict "componentValues" $.Values.hookshot "ephemeralStorage" "tmp" "volumeName" "tmp")) | nindent 6 }}
 {{- end }}
 {{- end -}}

--- a/charts/matrix-stack/templates/matrix-authentication-service/syn2mas_job.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/syn2mas_job.yaml
@@ -231,13 +231,17 @@ spec:
       - {{- (tpl (. | toYaml) $) | nindent 8 }}
 {{- end }}
       - emptyDir:
-          medium: Memory
+          {{- with $.Values.matrixTools.ephemeralStorages.renderedConfig.medium }}
+          medium: {{ . }}
+          {{- end }}
           {{- with $.Values.matrixTools.ephemeralStorages.renderedConfig.sizeLimit }}
           sizeLimit: {{ . }}
           {{- end }}
         name: "rendered-config"
       - emptyDir:
-          medium: Memory
+          {{- with $.Values.matrixAuthenticationService.syn2mas.ephemeralStorages.tmpMasCli.medium }}
+          medium: {{ . }}
+          {{- end }}
           {{- with $.Values.matrixAuthenticationService.syn2mas.ephemeralStorages.tmpMasCli.sizeLimit }}
           sizeLimit: {{ . }}
           {{- end }}

--- a/charts/matrix-stack/templates/matrix-authentication-service/syn2mas_job.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/syn2mas_job.yaml
@@ -230,22 +230,8 @@ spec:
 {{- range .extraVolumes }}
       - {{- (tpl (. | toYaml) $) | nindent 8 }}
 {{- end }}
-      - emptyDir:
-          {{- with $.Values.matrixTools.ephemeralStorages.renderedConfig.medium }}
-          medium: {{ . }}
-          {{- end }}
-          {{- with $.Values.matrixTools.ephemeralStorages.renderedConfig.sizeLimit }}
-          sizeLimit: {{ . }}
-          {{- end }}
-        name: "rendered-config"
-      - emptyDir:
-          {{- with $.Values.matrixAuthenticationService.syn2mas.ephemeralStorages.tmpMasCli.medium }}
-          medium: {{ . }}
-          {{- end }}
-          {{- with $.Values.matrixAuthenticationService.syn2mas.ephemeralStorages.tmpMasCli.sizeLimit }}
-          sizeLimit: {{ . }}
-          {{- end }}
-        name: "tmp-mas-cli"
+{{- include "element-io.ess-library.empty-dir" (dict "root" $ "context" (dict "componentValues" $.Values.matrixTools "ephemeralStorage" "renderedConfig" "volumeName" "rendered-config")) | nindent 6 }}
+{{- include "element-io.ess-library.empty-dir" (dict "root" $ "context" (dict "componentValues" $.Values.matrixAuthenticationService.syn2mas "ephemeralStorage" "tmpMasCli" "volumeName" "tmp-mas-cli")) | nindent 6 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-authentication-service/syn2mas_job.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/syn2mas_job.yaml
@@ -230,8 +230,10 @@ spec:
 {{- range .extraVolumes }}
       - {{- (tpl (. | toYaml) $) | nindent 8 }}
 {{- end }}
-{{- include "element-io.ess-library.empty-dir" (dict "root" $ "context" (dict "componentValues" $.Values.matrixTools "ephemeralStorage" "renderedConfig" "volumeName" "rendered-config")) | nindent 6 }}
-{{- include "element-io.ess-library.empty-dir" (dict "root" $ "context" (dict "componentValues" $.Values.matrixAuthenticationService.syn2mas "ephemeralStorage" "tmpMasCli" "volumeName" "tmp-mas-cli")) | nindent 6 }}
+      - emptyDir: {{- $.Values.matrixTools.ephemeralStorages.renderedConfig | toYaml | nindent 10 }}
+        name: rendered-config
+      - emptyDir: {{- $.Values.matrixAuthenticationService.syn2mas.ephemeralStorages.tmpMasCli | toYaml | nindent 10 }}
+        name: tmp-mas-cli
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/postgres/statefulset.yaml
+++ b/charts/matrix-stack/templates/postgres/statefulset.yaml
@@ -197,13 +197,17 @@ spec:
       terminationGracePeriodSeconds: 60
       volumes:
       - emptyDir:
-          medium: Memory
+          {{- with $.Values.postgres.ephemeralStorages.tmp.medium }}
+          medium: {{ . }}
+          {{- end }}
           {{- with $.Values.postgres.ephemeralStorages.tmp.sizeLimit }}
           sizeLimit: {{ . }}
           {{- end }}
         name: tmp
       - emptyDir:
-          medium: Memory
+          {{- with $.Values.postgres.ephemeralStorages.varRun.medium }}
+          medium: {{ . }}
+          {{- end }}
           {{- with $.Values.postgres.ephemeralStorages.varRun.sizeLimit }}
           sizeLimit: {{ . }}
           {{- end }}

--- a/charts/matrix-stack/templates/postgres/statefulset.yaml
+++ b/charts/matrix-stack/templates/postgres/statefulset.yaml
@@ -196,22 +196,8 @@ spec:
 {{- end }}
       terminationGracePeriodSeconds: 60
       volumes:
-      - emptyDir:
-          {{- with $.Values.postgres.ephemeralStorages.tmp.medium }}
-          medium: {{ . }}
-          {{- end }}
-          {{- with $.Values.postgres.ephemeralStorages.tmp.sizeLimit }}
-          sizeLimit: {{ . }}
-          {{- end }}
-        name: tmp
-      - emptyDir:
-          {{- with $.Values.postgres.ephemeralStorages.varRun.medium }}
-          medium: {{ . }}
-          {{- end }}
-          {{- with $.Values.postgres.ephemeralStorages.varRun.sizeLimit }}
-          sizeLimit: {{ . }}
-          {{- end }}
-        name: var-run
+{{- include "element-io.ess-library.empty-dir" (dict "root" $ "context" (dict "componentValues" $.Values.postgres "ephemeralStorage" "tmp" "volumeName" "tmp")) | nindent 6 }}
+{{- include "element-io.ess-library.empty-dir" (dict "root" $ "context" (dict "componentValues" $.Values.postgres "ephemeralStorage" "varRun" "volumeName" "var-run")) | nindent 6 }}
 {{- if and $.Values.initSecrets.enabled (include "element-io.init-secrets.postgres-generated-secrets" (dict "root" $)) }}
       - secret:
           secretName: {{ $.Release.Name }}-generated

--- a/charts/matrix-stack/templates/postgres/statefulset.yaml
+++ b/charts/matrix-stack/templates/postgres/statefulset.yaml
@@ -196,8 +196,10 @@ spec:
 {{- end }}
       terminationGracePeriodSeconds: 60
       volumes:
-{{- include "element-io.ess-library.empty-dir" (dict "root" $ "context" (dict "componentValues" $.Values.postgres "ephemeralStorage" "tmp" "volumeName" "tmp")) | nindent 6 }}
-{{- include "element-io.ess-library.empty-dir" (dict "root" $ "context" (dict "componentValues" $.Values.postgres "ephemeralStorage" "varRun" "volumeName" "var-run")) | nindent 6 }}
+      - emptyDir: {{- $.Values.postgres.ephemeralStorages.tmp | toYaml | nindent 10 }}
+        name: tmp
+      - emptyDir: {{- $.Values.postgres.ephemeralStorages.varRun | toYaml | nindent 10 }}
+        name: var-run
 {{- if and $.Values.initSecrets.enabled (include "element-io.init-secrets.postgres-generated-secrets" (dict "root" $)) }}
       - secret:
           secretName: {{ $.Release.Name }}-generated

--- a/charts/matrix-stack/templates/synapse/_synapse_pod.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_pod.tpl
@@ -206,7 +206,9 @@ We have an init container to render & merge the config for several reasons:
       name: "media"
 {{- else }}
     - emptyDir:
-        medium: Memory
+        {{- with $root.Values.synapse.ephemeralStorages.media.medium }}
+        medium: {{ . }}
+        {{- end }}
         {{- with $root.Values.synapse.ephemeralStorages.media.sizeLimit }}
         sizeLimit: {{ . }}
         {{- end }}

--- a/charts/matrix-stack/templates/synapse/_synapse_pod.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_pod.tpl
@@ -205,7 +205,8 @@ We have an init container to render & merge the config for several reasons:
         claimName: {{ include "element-io.synapse.pvcName" (dict "root" $root "context" .) }}
       name: "media"
 {{- else }}
-{{- include "element-io.ess-library.empty-dir" (dict "root" $root "context" (dict "componentValues" $root.Values.synapse "ephemeralStorage" "media" "volumeName" "media")) | nindent 4 }}
+    - emptyDir: {{- $root.Values.synapse.ephemeralStorages.media | toYaml | nindent 8 }}
+      name: media
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/_synapse_pod.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_pod.tpl
@@ -205,14 +205,7 @@ We have an init container to render & merge the config for several reasons:
         claimName: {{ include "element-io.synapse.pvcName" (dict "root" $root "context" .) }}
       name: "media"
 {{- else }}
-    - emptyDir:
-        {{- with $root.Values.synapse.ephemeralStorages.media.medium }}
-        medium: {{ . }}
-        {{- end }}
-        {{- with $root.Values.synapse.ephemeralStorages.media.sizeLimit }}
-        sizeLimit: {{ . }}
-        {{- end }}
-      name: "media"
+{{- include "element-io.ess-library.empty-dir" (dict "root" $root "context" (dict "componentValues" $root.Values.synapse "ephemeralStorage" "media" "volumeName" "media")) | nindent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -140,6 +140,14 @@
                   "type": "string",
                   "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$",
                   "description": "The maximum size of the emptyDir volume, as a Kubernetes quantity string e.g. 10Mi."
+                },
+                "medium": {
+                  "type": "string",
+                  "enum": [
+                    "",
+                    "Memory"
+                  ],
+                  "description": "The storage medium of the emptyDir volume. \"Memory\" uses tmpfs (RAM-backed); empty string uses the node's default storage."
                 }
               },
               "additionalProperties": false
@@ -8654,6 +8662,14 @@
                   "type": "string",
                   "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$",
                   "description": "The maximum size of the emptyDir volume, as a Kubernetes quantity string e.g. 10Mi."
+                },
+                "medium": {
+                  "type": "string",
+                  "enum": [
+                    "",
+                    "Memory"
+                  ],
+                  "description": "The storage medium of the emptyDir volume. \"Memory\" uses tmpfs (RAM-backed); empty string uses the node's default storage."
                 }
               },
               "additionalProperties": false
@@ -10140,6 +10156,14 @@
                   "type": "string",
                   "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$",
                   "description": "The maximum size of the emptyDir volume, as a Kubernetes quantity string e.g. 10Mi."
+                },
+                "medium": {
+                  "type": "string",
+                  "enum": [
+                    "",
+                    "Memory"
+                  ],
+                  "description": "The storage medium of the emptyDir volume. \"Memory\" uses tmpfs (RAM-backed); empty string uses the node's default storage."
                 }
               },
               "additionalProperties": false
@@ -13636,6 +13660,14 @@
                   "type": "string",
                   "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$",
                   "description": "The maximum size of the emptyDir volume, as a Kubernetes quantity string e.g. 10Mi."
+                },
+                "medium": {
+                  "type": "string",
+                  "enum": [
+                    "",
+                    "Memory"
+                  ],
+                  "description": "The storage medium of the emptyDir volume. \"Memory\" uses tmpfs (RAM-backed); empty string uses the node's default storage."
                 }
               },
               "additionalProperties": false
@@ -15289,6 +15321,14 @@
                       "type": "string",
                       "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$",
                       "description": "The maximum size of the emptyDir volume, as a Kubernetes quantity string e.g. 10Mi."
+                    },
+                    "medium": {
+                      "type": "string",
+                      "enum": [
+                        "",
+                        "Memory"
+                      ],
+                      "description": "The storage medium of the emptyDir volume. \"Memory\" uses tmpfs (RAM-backed); empty string uses the node's default storage."
                     }
                   },
                   "additionalProperties": false
@@ -19039,6 +19079,14 @@
                   "type": "string",
                   "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$",
                   "description": "The maximum size of the emptyDir volume, as a Kubernetes quantity string e.g. 10Mi."
+                },
+                "medium": {
+                  "type": "string",
+                  "enum": [
+                    "",
+                    "Memory"
+                  ],
+                  "description": "The storage medium of the emptyDir volume. \"Memory\" uses tmpfs (RAM-backed); empty string uses the node's default storage."
                 }
               },
               "additionalProperties": false
@@ -19050,6 +19098,14 @@
                   "type": "string",
                   "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$",
                   "description": "The maximum size of the emptyDir volume, as a Kubernetes quantity string e.g. 10Mi."
+                },
+                "medium": {
+                  "type": "string",
+                  "enum": [
+                    "",
+                    "Memory"
+                  ],
+                  "description": "The storage medium of the emptyDir volume. \"Memory\" uses tmpfs (RAM-backed); empty string uses the node's default storage."
                 }
               },
               "additionalProperties": false
@@ -23265,6 +23321,14 @@
                   "type": "string",
                   "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$",
                   "description": "The maximum size of the emptyDir volume, as a Kubernetes quantity string e.g. 10Mi."
+                },
+                "medium": {
+                  "type": "string",
+                  "enum": [
+                    "",
+                    "Memory"
+                  ],
+                  "description": "The storage medium of the emptyDir volume. \"Memory\" uses tmpfs (RAM-backed); empty string uses the node's default storage."
                 }
               },
               "additionalProperties": false

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -37,12 +37,14 @@ matrixTools:
     ## - name: dockerhub
     pullSecrets: []
 
-  ## Configures sizeLimit (maximum size) for this component's emptyDir volumes.
+  ## Configures sizeLimit (maximum size) and medium for this component's emptyDir volumes.
   ## Each sizeLimit is a Kubernetes quantity string, e.g. 10Mi.
+  ## medium is either "Memory" (tmpfs-backed) or "" (node default storage).
   ephemeralStorages:
     ## rendered-config emptyDir used in all components to render configuration
     renderedConfig:
       sizeLimit: 1Mi
+      medium: Memory
 
 ## CertManager Issuer to configure by default automatically on all ingresses
 ## If configured, the chart will automatically generate the tlsSecret name for all ingresses
@@ -1611,12 +1613,14 @@ elementAdmin:
 
     ## Number of seconds after which the probe times out
     timeoutSeconds: 1
-  ## Configures sizeLimit (maximum size) for this component's emptyDir volumes.
+  ## Configures sizeLimit (maximum size) and medium for this component's emptyDir volumes.
   ## Each sizeLimit is a Kubernetes quantity string, e.g. 10Mi.
+  ## medium is either "Memory" (tmpfs-backed) or "" (node default storage).
   ephemeralStorages:
     ## nginx temporary files (/tmp)
     tmp:
       sizeLimit: 10Mi
+      medium: Memory
 
 elementWeb:
   enabled: true
@@ -1910,12 +1914,14 @@ elementWeb:
 
     ## Number of seconds after which the probe times out
     timeoutSeconds: 1
-  ## Configures sizeLimit (maximum size) for this component's emptyDir volumes.
+  ## Configures sizeLimit (maximum size) and medium for this component's emptyDir volumes.
   ## Each sizeLimit is a Kubernetes quantity string, e.g. 10Mi.
+  ## medium is either "Memory" (tmpfs-backed) or "" (node default storage).
   ephemeralStorages:
     ## nginx temporary files (/tmp)
     tmp:
       sizeLimit: 10Mi
+      medium: Memory
 
 haproxy:
   replicas: 1
@@ -2622,12 +2628,14 @@ hookshot:
     ## Number of seconds after which the probe times out
     timeoutSeconds: 1
 
-  ## Configures sizeLimit (maximum size) for this component's emptyDir volumes.
+  ## Configures sizeLimit (maximum size) and medium for this component's emptyDir volumes.
   ## Each sizeLimit is a Kubernetes quantity string, e.g. 10Mi.
+  ## medium is either "Memory" (tmpfs-backed) or "" (node default storage).
   ephemeralStorages:
     ## temporary files (/tmp)
     tmp:
       sizeLimit: 10Mi
+      medium: Memory
 
 matrixAuthenticationService:
   enabled: true
@@ -3298,12 +3306,14 @@ matrixAuthenticationService:
     ##   # nodeTaintsPolicy: Honor/Ignore
     ##   # whenUnsatisfiable: DoNotSchedule/ScheduleAnyway
     topologySpreadConstraints: []
-    ## Configures sizeLimit (maximum size) for this component's emptyDir volumes.
+    ## Configures sizeLimit (maximum size) and medium for this component's emptyDir volumes.
     ## Each sizeLimit is a Kubernetes quantity string, e.g. 10Mi.
+    ## medium is either "Memory" (tmpfs-backed) or "" (node default storage).
     ephemeralStorages:
       ## temporary mas-cli copy (/tmp-mas-cli)
       tmpMasCli:
         sizeLimit: 100Mi
+        medium: Memory
 
     ## Runs the syn2mas process in dryRun mode.
     ## Force the authentication to happen with legacy authentication.
@@ -3768,15 +3778,18 @@ postgres:
 
     ## Number of seconds after which the probe times out
     timeoutSeconds: 1
-  ## Configures sizeLimit (maximum size) for this component's emptyDir volumes.
+  ## Configures sizeLimit (maximum size) and medium for this component's emptyDir volumes.
   ## Each sizeLimit is a Kubernetes quantity string, e.g. 10Mi.
+  ## medium is either "Memory" (tmpfs-backed) or "" (node default storage).
   ephemeralStorages:
     ## temporary files (/tmp)
     tmp:
       sizeLimit: 10Mi
+      medium: Memory
     ## postgresql runtime directory (/var/run)
     varRun:
       sizeLimit: 1Mi
+      medium: Memory
 
 redis:
   # redis maxmemory and maxmemory-policy settings. See https://redis.io/docs/latest/develop/reference/eviction/
@@ -5927,12 +5940,14 @@ synapse:
       ## No CPU or ephemeral-storage limits by default
       # cpu:
       # ephemeral-storage:
-  ## Configures sizeLimit (maximum size) for this component's emptyDir volumes.
+  ## Configures sizeLimit (maximum size) and medium for this component's emptyDir volumes.
   ## Each sizeLimit is a Kubernetes quantity string, e.g. 10Mi.
+  ## medium is either "Memory" (tmpfs-backed) or "" (node default storage).
   ephemeralStorages:
     ## media store emptyDir fallback (/media)
     media:
       sizeLimit: 100Mi
+      medium: Memory
   ## Controls configuration of the ServiceAccount for this component
   serviceAccount:
     ## Whether a ServiceAccount should be created by the chart or not

--- a/newsfragments/1554.added.md
+++ b/newsfragments/1554.added.md
@@ -1,0 +1,1 @@
+Add support for `emptyDir.medium` configurability.

--- a/tests/manifests/test_ephemeral_storages.py
+++ b/tests/manifests/test_ephemeral_storages.py
@@ -109,3 +109,73 @@ async def test_ephemeral_storage_passed_through(values, base_values, make_templa
     for pod_template_details in iterate_pod_template(templates):
         deployable_details = pod_template_details.deployable_details()
         _assert_empty_dir_volumes(pod_template_details, deployable_details, values, base_values)
+
+
+def _non_default_medium(default_medium: str) -> str:
+    # "Memory" -> "" (omit from manifest); "" -> "Memory"
+    return "" if default_medium == "Memory" else "Memory"
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_ephemeral_storage_medium_configurable(values, base_values, make_templates):
+    """Each ephemeral storage's medium is configurable in both directions.
+
+    Every emptyDir volume is set to the non-default of its own default medium
+    """
+    # Configure the shared rendered-config volume directly, preserving its sizeLimit.
+    rendered_config_default_medium = base_values["matrixTools"]["ephemeralStorages"]["renderedConfig"]["medium"]
+    rendered_config_non_default = _non_default_medium(rendered_config_default_medium)
+    values.setdefault("matrixTools", {}).setdefault("ephemeralStorages", {}).setdefault("renderedConfig", {})[
+        "medium"
+    ] = rendered_config_non_default
+
+    # Configure each component-specific ephemeral storage's medium via set_helm_values.
+    def set_ephemeral_storage_medium(deployable_details: DeployableDetails):
+        ephemeral_storages = deployable_details.get_helm_values(base_values, PropertyType.EphemeralStorages)
+        if not ephemeral_storages:
+            return
+        values_to_set = {}
+        for ephemeral_storage in deployable_details.ephemeral_storages.values():
+            default_medium = ephemeral_storages[ephemeral_storage]["medium"]
+            values_to_set[ephemeral_storage] = {
+                "medium": _non_default_medium(default_medium),
+                "sizeLimit": ephemeral_storages[ephemeral_storage]["sizeLimit"],
+            }
+        if values_to_set:
+            deployable_details.set_helm_values(values, PropertyType.EphemeralStorages, values_to_set)
+
+    iterate_deployables_parts(
+        set_ephemeral_storage_medium, lambda deployable_details: deployable_details.has_ephemeral_storage
+    )
+
+    templates = await make_templates(values)
+    for pod_template_details in iterate_pod_template(templates):
+        deployable_details = pod_template_details.deployable_details()
+        volumes = pod_template_details.pod_template["spec"].get("volumes", [])
+        for volume in volumes:
+            if "emptyDir" not in volume:
+                continue
+            volume_name = volume["name"]
+            if volume_name == "rendered-config":
+                expected_medium = rendered_config_non_default
+            else:
+                assert volume_name in deployable_details.ephemeral_storages, (
+                    f"{pod_template_details.manifest_id}: emptyDir volume '{volume_name}' "
+                    f"is not registered in {deployable_details.name}'s ephemeral_storage"
+                )
+                ephemeral_storage = deployable_details.ephemeral_storages[volume_name]
+                default_medium = deployable_details.get_helm_values(base_values, PropertyType.EphemeralStorages)[
+                    ephemeral_storage
+                ]["medium"]
+                expected_medium = _non_default_medium(default_medium)
+            if expected_medium == "":
+                assert "medium" not in volume["emptyDir"], (
+                    f"{pod_template_details.manifest_id}: emptyDir volume '{volume_name}' "
+                    f"should omit medium (expected node default storage)"
+                )
+            else:
+                assert volume["emptyDir"].get("medium") == expected_medium, (
+                    f"{pod_template_details.manifest_id}: emptyDir volume '{volume_name}' "
+                    f"medium is {volume['emptyDir'].get('medium')!r} but expected {expected_medium!r}"
+                )

--- a/tests/manifests/test_ephemeral_storages.py
+++ b/tests/manifests/test_ephemeral_storages.py
@@ -133,8 +133,9 @@ async def test_ephemeral_storage_medium_configurable(values, base_values, make_t
     # Configure each component-specific ephemeral storage's medium via set_helm_values.
     def set_ephemeral_storage_medium(deployable_details: DeployableDetails):
         ephemeral_storages = deployable_details.get_helm_values(base_values, PropertyType.EphemeralStorages)
-        if not ephemeral_storages:
-            return
+        assert ephemeral_storages is not None, (
+            f"{deployable_details.name}: compement has `has_ephemeral_storage` but no EphemeralStorages values"
+        )
         values_to_set = {}
         for ephemeral_storage in deployable_details.ephemeral_storages.values():
             default_medium = ephemeral_storages[ephemeral_storage]["medium"]

--- a/tests/manifests/test_ephemeral_storages.py
+++ b/tests/manifests/test_ephemeral_storages.py
@@ -169,13 +169,7 @@ async def test_ephemeral_storage_medium_configurable(values, base_values, make_t
                     ephemeral_storage
                 ]["medium"]
                 expected_medium = _non_default_medium(default_medium)
-            if expected_medium == "":
-                assert "medium" not in volume["emptyDir"], (
-                    f"{pod_template_details.manifest_id}: emptyDir volume '{volume_name}' "
-                    f"should omit medium (expected node default storage)"
-                )
-            else:
-                assert volume["emptyDir"].get("medium") == expected_medium, (
-                    f"{pod_template_details.manifest_id}: emptyDir volume '{volume_name}' "
-                    f"medium is {volume['emptyDir'].get('medium')!r} but expected {expected_medium!r}"
-                )
+            assert volume["emptyDir"].get("medium") == expected_medium, (
+                f"{pod_template_details.manifest_id}: emptyDir volume '{volume_name}' "
+                f"medium is {volume['emptyDir'].get('medium')!r} but expected {expected_medium!r}"
+            )

--- a/tests/manifests/test_ephemeral_storages.py
+++ b/tests/manifests/test_ephemeral_storages.py
@@ -112,7 +112,7 @@ async def test_ephemeral_storage_passed_through(values, base_values, make_templa
 
 
 def _non_default_medium(default_medium: str) -> str:
-    # "Memory" -> "" (omit from manifest); "" -> "Memory"
+    # "Memory" -> "" ; "" -> "Memory"
     return "" if default_medium == "Memory" else "Memory"
 
 
@@ -130,8 +130,8 @@ async def test_ephemeral_storage_medium_configurable(values, base_values, make_t
         "medium"
     ] = rendered_config_non_default
 
-    # Configure each component-specific ephemeral storage's medium via set_helm_values.
-    def set_ephemeral_storage_medium(deployable_details: DeployableDetails):
+    # Configure each component-specific ephemeral storage to non default medium value
+    def set_ephemeral_storage_with_non_default_medium(deployable_details: DeployableDetails):
         ephemeral_storages = deployable_details.get_helm_values(base_values, PropertyType.EphemeralStorages)
         assert ephemeral_storages is not None, (
             f"{deployable_details.name}: compement has `has_ephemeral_storage` but no EphemeralStorages values"
@@ -147,7 +147,8 @@ async def test_ephemeral_storage_medium_configurable(values, base_values, make_t
             deployable_details.set_helm_values(values, PropertyType.EphemeralStorages, values_to_set)
 
     iterate_deployables_parts(
-        set_ephemeral_storage_medium, lambda deployable_details: deployable_details.has_ephemeral_storage
+        set_ephemeral_storage_with_non_default_medium,
+        lambda deployable_details: deployable_details.has_ephemeral_storage,
     )
 
     templates = await make_templates(values)


### PR DESCRIPTION
Built with GLM 5.2.

All `ephemeralStorages` get a new `medium` key. It can either be an empty string or `Memory`. If it is an empty string, it will result in on-disk ephemeral storage on the node. All our `ephemeralStorages` default to `Memory` for now.