### PR TITLE
MatrixRTC: configure Redis

### DIFF
--- a/charts/matrix-stack/ci/example-default-enabled-components-checkov-values.yaml
+++ b/charts/matrix-stack/ci/example-default-enabled-components-checkov-values.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# source_fragments: deployment-markers-checkov.yaml deployment-markers-minimal.yaml element-admin-checkov.yaml element-admin-minimal.yaml element-web-checkov.yaml element-web-minimal.yaml haproxy-checkov.yaml init-secrets-checkov.yaml init-secrets-minimal.yaml matrix-authentication-service-checkov.yaml matrix-authentication-service-minimal.yaml matrix-rtc-checkov.yaml matrix-rtc-minimal.yaml postgres-checkov.yaml postgres-minimal.yaml server-name.yaml synapse-checkov.yaml synapse-minimal.yaml well-known-minimal.yaml
+# source_fragments: deployment-markers-checkov.yaml deployment-markers-minimal.yaml element-admin-checkov.yaml element-admin-minimal.yaml element-web-checkov.yaml element-web-minimal.yaml haproxy-checkov.yaml init-secrets-checkov.yaml init-secrets-minimal.yaml matrix-authentication-service-checkov.yaml matrix-authentication-service-minimal.yaml matrix-rtc-checkov.yaml matrix-rtc-minimal.yaml postgres-checkov.yaml postgres-minimal.yaml redis-checkov.yaml server-name.yaml synapse-checkov.yaml synapse-minimal.yaml well-known-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # wellKnownDelegation don't have any required properties to be set and defaults to enabled
@@ -58,6 +58,11 @@ matrixRTC:
       checkov.io/skip2: CKV_K8S_43=No digests
       checkov.io/skip3: CKV2_K8S_6=No network policy yet
 postgres:
+  annotations:
+    checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
+    checkov.io/skip2: CKV_K8S_43=No digests
+    checkov.io/skip3: CKV2_K8S_6=No network policy yet
+redis:
   annotations:
     checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
     checkov.io/skip2: CKV_K8S_43=No digests

--- a/charts/matrix-stack/ci/fragments/matrix-rtc-redis-secrets-externally.yaml
+++ b/charts/matrix-stack/ci/fragments/matrix-rtc-redis-secrets-externally.yaml
@@ -1,0 +1,11 @@
+# Copyright 2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+matrixRTC:
+  # The authoriser doesn't yet support an external Redis
+  sfu:
+    redis:
+      password:
+        secret: "{{ $.Release.Name }}-redis-credentials"
+        secretKey: "password"

--- a/charts/matrix-stack/ci/fragments/matrix-rtc-redis-secrets-in-helm.yaml
+++ b/charts/matrix-stack/ci/fragments/matrix-rtc-redis-secrets-in-helm.yaml
@@ -1,0 +1,10 @@
+# Copyright 2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+matrixRTC:
+  # The authoriser doesn't yet support an external Redis
+  sfu:
+    redis:
+      password:
+        value: "test-redis-password"

--- a/charts/matrix-stack/ci/fragments/matrix-rtc-redis.yaml
+++ b/charts/matrix-stack/ci/fragments/matrix-rtc-redis.yaml
@@ -1,0 +1,10 @@
+# Copyright 2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+matrixRTC:
+  # The authoriser doesn't yet support an external Redis
+  sfu:
+    redis:
+      host: "external-redis.example.com"
+      port: 6379

--- a/charts/matrix-stack/ci/matrix-rtc-checkov-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-checkov-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# source_fragments: init-secrets-checkov.yaml init-secrets-minimal.yaml matrix-rtc-checkov.yaml matrix-rtc-minimal.yaml
+# source_fragments: init-secrets-checkov.yaml init-secrets-minimal.yaml matrix-rtc-checkov.yaml matrix-rtc-minimal.yaml redis-checkov.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # postgres don't have any required properties to be set and defaults to enabled
@@ -32,6 +32,11 @@ matrixRTC:
       checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
       checkov.io/skip2: CKV_K8S_43=No digests
       checkov.io/skip3: CKV2_K8S_6=No network policy yet
+redis:
+  annotations:
+    checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
+    checkov.io/skip2: CKV_K8S_43=No digests
+    checkov.io/skip3: CKV2_K8S_6=No network policy yet
 synapse:
   enabled: false
 wellKnownDelegation:

--- a/charts/matrix-stack/ci/matrix-rtc-secrets-externally-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-secrets-externally-values.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# source_fragments: init-secrets-disabled.yaml matrix-rtc-additional-secrets-externally.yaml matrix-rtc-minimal.yaml matrix-rtc-secrets-externally.yaml
+# source_fragments: init-secrets-disabled.yaml matrix-rtc-additional-secrets-externally.yaml matrix-rtc-minimal.yaml matrix-rtc-redis-secrets-externally.yaml matrix-rtc-redis.yaml matrix-rtc-secrets-externally.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # postgres don't have any required properties to be set and defaults to enabled
@@ -25,11 +25,18 @@ matrixRTC:
     secret:
       secret: "{{ $.Release.Name }}-matrix-rtc-external"
       secretKey: livekitSecret
+  # The authoriser doesn't yet support an external Redis
   sfu:
     additional:
       example-value:
         configSecret: "{{ $.Release.Name }}-mrtc-external"
         configSecretKey: config
+    redis:
+      host: "external-redis.example.com"
+      password:
+        secret: "{{ $.Release.Name }}-redis-credentials"
+        secretKey: "password"
+      port: 6379
 synapse:
   enabled: false
 wellKnownDelegation:

--- a/charts/matrix-stack/ci/matrix-rtc-secrets-in-helm-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-secrets-in-helm-values.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# source_fragments: init-secrets-disabled.yaml matrix-rtc-additional-in-helm.yaml matrix-rtc-minimal.yaml matrix-rtc-secrets-in-helm.yaml
+# source_fragments: init-secrets-disabled.yaml matrix-rtc-additional-in-helm.yaml matrix-rtc-minimal.yaml matrix-rtc-redis-secrets-in-helm.yaml matrix-rtc-redis.yaml matrix-rtc-secrets-in-helm.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # postgres don't have any required properties to be set and defaults to enabled
@@ -24,11 +24,17 @@ matrixRTC:
     key: CHANGEME-oolahd9xooshohSh5IeQu1natheur1oo
     secret:
       value: CHANGEME-gohseengahch9pheedi5OomeHea6maem
+  # The authoriser doesn't yet support an external Redis
   sfu:
     additional:
       example-value:
         config: |
           example: value
+    redis:
+      host: "external-redis.example.com"
+      password:
+        value: "test-redis-password"
+      port: 6379
 synapse:
   enabled: false
 wellKnownDelegation:

--- a/charts/matrix-stack/ci/pytest-matrix-rtc-standalone-values.yaml
+++ b/charts/matrix-stack/ci/pytest-matrix-rtc-standalone-values.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# source_fragments: init-secrets-minimal.yaml init-secrets-pytest-extras.yaml matrix-rtc-minimal.yaml matrix-rtc-pytest-extras.yaml matrix-rtc-turn-tls.yaml
+# source_fragments: init-secrets-minimal.yaml init-secrets-pytest-extras.yaml matrix-rtc-minimal.yaml matrix-rtc-pytest-extras.yaml matrix-rtc-turn-tls.yaml redis-pytest-base-extras.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # postgres don't have any required properties to be set and defaults to enabled
@@ -52,6 +52,9 @@ matrixRTC:
       level: debug
     podSecurityContext:
       runAsGroup: 0
+redis:
+  podSecurityContext:
+    runAsGroup: 0
 synapse:
   enabled: false
 wellKnownDelegation:

--- a/charts/matrix-stack/ci/pytest-matrix-rtc-synapse-wellknown-values.yaml
+++ b/charts/matrix-stack/ci/pytest-matrix-rtc-synapse-wellknown-values.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# source_fragments: init-secrets-minimal.yaml init-secrets-pytest-extras.yaml matrix-rtc-minimal.yaml matrix-rtc-pytest-extras.yaml matrix-rtc-turn-tls.yaml postgres-minimal.yaml server-name.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml well-known-minimal.yaml well-known-pytest-base-extras.yaml
+# source_fragments: init-secrets-minimal.yaml init-secrets-pytest-extras.yaml matrix-rtc-minimal.yaml matrix-rtc-pytest-extras.yaml matrix-rtc-turn-tls.yaml postgres-minimal.yaml redis-pytest-base-extras.yaml server-name.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml well-known-minimal.yaml well-known-pytest-base-extras.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:
@@ -56,6 +56,9 @@ matrixRTC:
     podSecurityContext:
       runAsGroup: 0
 postgres:
+  podSecurityContext:
+    runAsGroup: 0
+redis:
   podSecurityContext:
     runAsGroup: 0
 serverName: ess.localhost

--- a/charts/matrix-stack/configs/hookshot/config-override.yaml.tpl
+++ b/charts/matrix-stack/configs/hookshot/config-override.yaml.tpl
@@ -36,7 +36,7 @@ cache:
 {{- if .redis }}
   redisUri: "redis{{ if .redis.tls }}s{{ end }}://{{ if .redis.password }}:${HOOKSHOT_REDIS_PASSWORD}@{{ end }}{{ tpl .redis.host $root }}:{{ .redis.port | default 6379 }}/{{ .redis.db | default 0 }}"
 {{- else }}
-  redisUri: "redis://{{ $root.Release.Name }}-redis.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}:6379"
+  redisUri: "redis://{{ $root.Release.Name }}-redis.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}:6379/1"
 {{- end }}
 
 logging:

--- a/charts/matrix-stack/configs/matrix-rtc/sfu/config-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/matrix-rtc/sfu/config-overrides.yaml.tpl
@@ -74,6 +74,20 @@ turn:
 {{- end }}
 {{- end }}
 
+redis:
+{{- if .redis }}
+  address: {{ tpl .redis.host $root }}:{{ .redis.port | default 6379 }}
+{{- with .redis.db }}
+  db: {{ . }}
+{{- end }}
+{{- if .redis.password }}
+  password: ${SFU_REDIS_PASSWORD}
+{{- end }}
+{{- else }}
+  address: "{{ $root.Release.Name }}-redis.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}:6379"
+  db: 3
+{{- end }}
+
 room:
   auto_create: false
 

--- a/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
+++ b/charts/matrix-stack/configs/synapse/synapse-04-homeserver-overrides.yaml.tpl
@@ -219,6 +219,7 @@ redis:
 {{- end }}
 {{- else }}
   host: "{{ $root.Release.Name }}-redis.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}"
+  dbid: 0
 {{- end }}
 {{- if include "element-io.synapse.streamWriterWorkers" (dict "root" $root) | fromJsonArray }}
 

--- a/charts/matrix-stack/source/matrix-rtc.json
+++ b/charts/matrix-stack/source/matrix-rtc.json
@@ -148,6 +148,9 @@
             "podIP"
           ]
         },
+        "redis": {
+          "$ref": "file://common/redis.json"
+        },
         "additional": {
           "$ref": "file://common/additional.json"
         },

--- a/charts/matrix-stack/source/matrix-rtc.yaml.j2
+++ b/charts/matrix-stack/source/matrix-rtc.yaml.j2
@@ -76,6 +76,8 @@ sfu:
   ## Full details on available configuration options can be found at https://docs.livekit.io/home/self-hosting/deployment/#configuration
   {{- sub_schema_values.additionalConfig() | indent(2) }}
 
+  {{- sub_schema_values.redis() | indent(2) }}
+
   # Use 0 replicas to stop the SFU
   replicas: 1
 

--- a/charts/matrix-stack/templates/matrix-rtc/_helpers.tpl
+++ b/charts/matrix-stack/templates/matrix-rtc/_helpers.tpl
@@ -64,6 +64,8 @@ app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" .
 {{- $root := .root -}}
 {{- with required "element-io.matrix-rtc-authorisation-service.overrideEnv missing context" .context -}}
 env:
+- name: "LIVEKIT_REDIS_URL"
+  value: "redis://{{ $root.Release.Name }}-redis.{{ $root.Release.Namespace }}.svc.{{ $root.Values.clusterDomain }}:6379/2"
 - name: "LIVEKIT_KEY"
   value: {{ .livekitAuth.key }}
 - name: "LIVEKIT_SECRET_FROM_FILE"

--- a/charts/matrix-stack/templates/matrix-rtc/_sfu_helpers.tpl
+++ b/charts/matrix-stack/templates/matrix-rtc/_sfu_helpers.tpl
@@ -50,6 +50,25 @@ env:
         )
       )
     }}
+{{- if $root.Values.matrixRTC.sfu.redis }}
+{{- if $root.Values.matrixRTC.sfu.redis.password }}
+- name: SFU_REDIS_PASSWORD
+  value: >-
+    {{
+      printf "{{ readfile \"/secrets/%s\" | quote }}"
+        (
+          include "element-io.ess-library.provided-secret-path" (
+            dict "root" $root
+            "context" (dict
+              "secretPath" "matrixRTC.sfu.redis.password"
+              "defaultSecretName" (include "element-io.matrix-rtc-sfu.secret-name" (dict "root" $root "context" .))
+              "defaultSecretKey" "REDIS_PASSWORD"
+            )
+          )
+        )
+    }}
+{{- end }}
+{{- end }}
 {{- end -}}
 {{- end -}}
 
@@ -61,6 +80,13 @@ env:
 {{- $prop := index $root.Values.matrixRTC.sfu.additional $key }}
 {{- if $prop.configSecret }}
 {{ $configSecrets = append $configSecrets (tpl $prop.configSecret $root) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- with $root.Values.matrixRTC.sfu.redis }}
+{{- if .password }}
+{{- if .password.secret }}
+{{ $configSecrets = append $configSecrets (tpl .password.secret $root) }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -101,6 +127,12 @@ keys-template.yaml: |
 {{- if $prop.config }}
 user-{{ $key }}: {{ $prop.config | b64enc }}
 {{- end }}
+{{- end }}
+{{- end }}
+{{- with ($root.Values.matrixRTC.sfu.redis).password }}
+{{- include "element-io.ess-library.check-credential" (dict "root" $root "context" (dict "secretPath" "matrixRTC.sfu.redis.password" "initIfAbsent" false)) -}}
+{{- with .value }}
+REDIS_PASSWORD: {{ . | b64enc | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_configmap.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_configmap.yaml
@@ -1,6 +1,6 @@
 {{- /*
 Copyright 2024 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -14,7 +14,7 @@ kind: ConfigMap
 metadata:
   labels:
     {{- include "element-io.matrix-rtc-sfu.labels" (dict "root" $ "context" .) | nindent 4 }}
-  name: {{ $.Release.Name }}-matrix-rtc-sfu
+  name: {{ include "element-io.matrix-rtc-sfu.configmap-name" (dict "root" $ "context" .) }}
   namespace: {{ $.Release.Namespace }}
 data:
   {{- (include "element-io.matrix-rtc-sfu.configmap-data" (dict "root" $ "context" .)) | nindent 2 }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_secret.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_secret.yaml
@@ -1,6 +1,6 @@
 {{- /*
 Copyright 2025 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -13,7 +13,7 @@ type: Opaque
 metadata:
   labels:
     {{- include "element-io.matrix-rtc-sfu.labels" (dict "root" $ "context" .sfu) | nindent 4 }}
-  name: {{ $.Release.Name }}-matrix-rtc-sfu
+  name: {{ include "element-io.matrix-rtc-sfu.secret-name" (dict "root" $ "context" .) }}
   namespace: {{ $.Release.Namespace }}
 data:
   {{- include "element-io.matrix-rtc-sfu.secret-data" (dict "root" $ "context" .) | nindent 2 -}}

--- a/charts/matrix-stack/templates/redis/_helpers.tpl
+++ b/charts/matrix-stack/templates/redis/_helpers.tpl
@@ -36,7 +36,9 @@ env: []
 {{- $root := .root -}}
 {{- $synapseNeedsRedis := and $root.Values.synapse.enabled (not $root.Values.synapse.redis) (include "element-io.synapse.enabledWorkers" (dict "root" $root) | fromJson) -}}
 {{- $hookshotNeedsRedis := and $root.Values.hookshot.enabled (not $root.Values.hookshot.redis) -}}
-{{- if or $synapseNeedsRedis $hookshotNeedsRedis -}}
+{{- /* This very deliberately doesn't allow for external Redis right now as the authoriser doesn't support auth with the password coming from a file (i.e. an existing Secret) */ -}}
+{{- $matrixRTCNeedsRedis := $root.Values.matrixRTC.enabled -}}
+{{- if or $synapseNeedsRedis $hookshotNeedsRedis $matrixRTCNeedsRedis -}}
 true
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -5464,6 +5464,74 @@
                 "podIP"
               ]
             },
+            "redis": {
+              "type": "object",
+              "required": [
+                "host"
+              ],
+              "properties": {
+                "host": {
+                  "type": "string",
+                  "description": "Redis host address"
+                },
+                "port": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535,
+                  "default": 6379
+                },
+                "db": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 15,
+                  "default": 0
+                },
+                "password": {
+                  "type": "object",
+                  "oneOf": [
+                    {
+                      "required": [
+                        "value"
+                      ],
+                      "not": {
+                        "required": [
+                          "secret",
+                          "secretKey"
+                        ]
+                      }
+                    },
+                    {
+                      "required": [
+                        "secret",
+                        "secretKey"
+                      ],
+                      "not": {
+                        "required": [
+                          "value"
+                        ]
+                      }
+                    }
+                  ],
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    },
+                    "secret": {
+                      "type": "string"
+                    },
+                    "secretKey": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "type": "boolean",
+                  "default": false
+                }
+              },
+              "additionalProperties": false
+            },
             "additional": {
               "type": "object",
               "additionalProperties": {

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -948,6 +948,33 @@ matrixRTC:
     ## Most settings are configurable but some settings are owned by the chart and can't overwritten
     additional: {}
 
+    ## Details of the external Redis to use
+    ## Does not need to be set if the internal Redis should be used
+    ## This is useful for production environments where you want to use
+    ## managed Redis services (AWS Elasticache, Azure Cache for Redis, etc.)
+    # redis:
+      ## Redis host
+      # host:
+
+      ## Redis port
+      # port: 6379
+
+      ## Redis database number (0-15)
+      # db: 0
+
+      ## Redis password (optional - many managed services require auth).
+      ## It can either be provided inline in the Helm chart e.g.:
+      ## password:
+      ##   value: SecretValue
+      ##
+      ## Or it can be provided via an existing Secret e.g.:
+      ## password:
+      ##   secret: existing-secret
+      ##   secretKey: key-in-secret
+      # password: {}
+
+      ## Enable TLS for Redis connection
+      # tls: false
 
     # Use 0 replicas to stop the SFU
     replicas: 1

--- a/newsfragments/1555.changed.1.md
+++ b/newsfragments/1555.changed.1.md
@@ -1,0 +1,1 @@
+Move Hookshot to a distinct `dbid` on the shared Redis.

--- a/newsfragments/1555.changed.2.md
+++ b/newsfragments/1555.changed.2.md
@@ -1,0 +1,3 @@
+Configure Redis against the MatrixRTC authoriser to prevent calls from failing after restarting it.
+
+Using an external Redis with the MatrixRTC authoriser is not yet supported.

--- a/newsfragments/1555.changed.3.md
+++ b/newsfragments/1555.changed.3.md
@@ -1,0 +1,1 @@
+Configure Redis against the MatrixRTC SFU given it is now deployed for MatrixRTC.

--- a/newsfragments/1555.changed.md
+++ b/newsfragments/1555.changed.md
@@ -1,0 +1,1 @@
+Make the `dbid` Synapse uses in Redis explicit.


### PR DESCRIPTION
#1519 supported delayed events. It also adds Redis support to provide restart-safety for delayed events when the authoriser pod restarts. As per #1546 Redis is only used on startup and so multiple replicas aren't possible.

As `LIVEKIT_REDIS_URL` is a single string and so we can't support loading the password from a file. For this reason we're temporarily not allowing an external Redis with the authoriser as we'd have to restrict the auth options. The plan is to update the authoriser to support separate env vars for auth and so an external Redis can be fully supported.

Given the number of distinct usages of Redis make sure each component that uses it uses its own distinct db.

And given that Redis is being spun up for the authoriser we might as well configure it on the SFU too