### PR TITLE
Only run a single Redis Pod

### DIFF
--- a/charts/matrix-stack/templates/ess-library/_workloads.tpl
+++ b/charts/matrix-stack/templates/ess-library/_workloads.tpl
@@ -19,10 +19,14 @@ selector:
     app.kubernetes.io/instance: {{ $root.Release.Name }}-{{ $nameSuffix }}
 {{- if eq "Deployment" $kind }}
 strategy:
+{{- if ne "redis" $nameSuffix }}
   type: RollingUpdate
   rollingUpdate:
     maxSurge: 2
     maxUnavailable: {{ min (max 0 (sub .replicas 1)) 1 }}
+{{- else }}
+  type: Recreate
+{{- end }}
 {{- else }}
 serviceName: {{ $root.Release.Name }}-{{ $serviceNameSuffix }}
 updateStrategy:

--- a/newsfragments/1557.fixed.md
+++ b/newsfragments/1557.fixed.md
@@ -1,0 +1,1 @@
+Fix there being multiple independent Redis `Pods` running during upgrades.

--- a/tests/manifests/test_pod_replicas.py
+++ b/tests/manifests/test_pod_replicas.py
@@ -30,6 +30,12 @@ async def test_deployments_statefulsets_have_replicas_by_default(values, templat
         )
 
         if pod_template_details.manifest["kind"] == "Deployment":
+            if deployable_details.name == "redis":
+                assert manifest_spec["strategy"]["type"] == "Recreate"
+                assert "rollingUpdate" not in manifest_spec["strategy"]
+                continue
+
+            assert manifest_spec["strategy"]["type"] == "RollingUpdate"
             max_unavailable = manifest_spec["strategy"]["rollingUpdate"]["maxUnavailable"]
             if expected_replicas > 1:
                 assert max_unavailable == 1, (
@@ -64,6 +70,10 @@ async def test_deployments_statefulsets_respect_replicas(values, make_templates)
         )
 
         if pod_template_details.manifest["kind"] == "Deployment":
+            if deployable_details.name == "redis":
+                assert "rollingUpdate" not in manifest_spec["strategy"]
+                continue
+
             max_unavailable = manifest_spec["strategy"]["rollingUpdate"]["maxUnavailable"]
             if deployable_details.is_singleton:
                 assert max_unavailable == 0, (


### PR DESCRIPTION
We really want #1368 but this is a quick pragmatic fix.

Not making this configurable given we want to move to a `StatefulSet`