### PR TITLE
Replace Redis container image with latest Valkey image

### DIFF
--- a/.github/element-docs-words.txt
+++ b/.github/element-docs-words.txt
@@ -51,5 +51,6 @@ templatable
 threepids
 towncrier
 Traefik
+Valkey
 Wifi
 zizmor

--- a/charts/matrix-stack/source/redis.yaml.j2
+++ b/charts/matrix-stack/source/redis.yaml.j2
@@ -12,7 +12,7 @@ maxMemoryPolicy: allkeys-lru
 # Use 0 replicas to stop Redis
 replicas: 1
 
-{{- sub_schema_values.image(registry='docker.io', repository='library/redis', tag='7.4-alpine') }}
+{{- sub_schema_values.image(registry='docker.io', repository='valkey/valkey', tag='9.1-alpine') }}
 {{- sub_schema_values.labels() }}
 {{- sub_schema_values.workloadAnnotations() }}
 {{- sub_schema_values.containersSecurityContext() }}

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -3833,11 +3833,11 @@ redis:
     registry: docker.io
 
     ## The path in the registry where the container image is located
-    repository: library/redis
+    repository: valkey/valkey
 
     ## The tag of the container image to use.
     ## One of tag or digest must be provided.
-    tag: "7.4-alpine"
+    tag: "9.1-alpine"
 
     ## Container digest to use. Used to pull the image instead of the image tag if set
     ## The tag will still be set as the app.kubernetes.io/version label

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 <!--
 Copyright 2025 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->
@@ -22,9 +22,10 @@ Synapse is a Matrix homeserver. It provides the core functionality of a Matrix s
 
 Synapse can be deployed as a multiple-workers deployment. Adding specialized workers will offload processes and traffic from the main process, and allow to handle more users without compromising performance. See the [Synapse Workers documentation](https://github.com/element-hq/synapse/blob/develop/docs/workers.md) for more informations.
 
-### Redis Pub/Sub
+### Valkey Pub/Sub & small cache
 
-Redis Pub/Sub allows Synapse to broadcast events between Synapse workers.
+Valkey Pub/Sub allows Synapse to broadcast events between Synapse workers.
+Valkey is also used as a small cache for Hookshot to make MatrixRTC restart-safe.
 
 ### HAproxy
 
@@ -65,4 +66,3 @@ The Chart provides a check-config hook that runs synapse's `synapse.config` comm
 ### Init Secrets Hook
 
 Init secrets allows the chart to generate random passwords with a Helm Hook without having to generate them beforehand. For a production deployment, you should save the generated secret somewhere to be able to recover it if needed.
-

--- a/newsfragments/1558.changed.md
+++ b/newsfragments/1558.changed.md
@@ -1,0 +1,1 @@
+Replace Redis with Valkey.


### PR DESCRIPTION
Simply replace the built-in Redis with Valkey. No schema changes, no values changes, no naming changes at this point in time. Those will come in later PRs, each of which should be self-contained and provide value in and of themselves