### PR TITLE
Update references in CI values file from redis to valkey for the built-in Valkey

### DIFF
--- a/charts/matrix-stack/ci/example-default-enabled-components-checkov-values.yaml
+++ b/charts/matrix-stack/ci/example-default-enabled-components-checkov-values.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# source_fragments: deployment-markers-checkov.yaml deployment-markers-minimal.yaml element-admin-checkov.yaml element-admin-minimal.yaml element-web-checkov.yaml element-web-minimal.yaml haproxy-checkov.yaml init-secrets-checkov.yaml init-secrets-minimal.yaml matrix-authentication-service-checkov.yaml matrix-authentication-service-minimal.yaml matrix-rtc-checkov.yaml matrix-rtc-minimal.yaml postgres-checkov.yaml postgres-minimal.yaml redis-checkov.yaml server-name.yaml synapse-checkov.yaml synapse-minimal.yaml well-known-minimal.yaml
+# source_fragments: deployment-markers-checkov.yaml deployment-markers-minimal.yaml element-admin-checkov.yaml element-admin-minimal.yaml element-web-checkov.yaml element-web-minimal.yaml haproxy-checkov.yaml init-secrets-checkov.yaml init-secrets-minimal.yaml matrix-authentication-service-checkov.yaml matrix-authentication-service-minimal.yaml matrix-rtc-checkov.yaml matrix-rtc-minimal.yaml postgres-checkov.yaml postgres-minimal.yaml server-name.yaml synapse-checkov.yaml synapse-minimal.yaml valkey-checkov.yaml well-known-minimal.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # wellKnownDelegation don't have any required properties to be set and defaults to enabled
@@ -62,11 +62,6 @@ postgres:
     checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
     checkov.io/skip2: CKV_K8S_43=No digests
     checkov.io/skip3: CKV2_K8S_6=No network policy yet
-redis:
-  annotations:
-    checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
-    checkov.io/skip2: CKV_K8S_43=No digests
-    checkov.io/skip3: CKV2_K8S_6=No network policy yet
 serverName: ess.localhost
 synapse:
   annotations:
@@ -80,3 +75,8 @@ synapse:
       checkov.io/skip3: CKV2_K8S_6=No network policy yet
   ingress:
     host: synapse.ess.localhost
+valkey:
+  annotations:
+    checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
+    checkov.io/skip2: CKV_K8S_43=No digests
+    checkov.io/skip3: CKV2_K8S_6=No network policy yet

--- a/charts/matrix-stack/ci/fragments/valkey-checkov.yaml
+++ b/charts/matrix-stack/ci/fragments/valkey-checkov.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 
-redis:
+valkey:
   annotations:
     checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
     checkov.io/skip2: CKV_K8S_43=No digests

--- a/charts/matrix-stack/ci/fragments/valkey-pytest-base-extras.yaml
+++ b/charts/matrix-stack/ci/fragments/valkey-pytest-base-extras.yaml
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 
-redis:
+valkey:
   podSecurityContext:
     runAsGroup: 0

--- a/charts/matrix-stack/ci/hookshot-checkov-values.yaml
+++ b/charts/matrix-stack/ci/hookshot-checkov-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# source_fragments: hookshot-checkov.yaml hookshot-ingress.yaml hookshot-minimal.yaml init-secrets-checkov.yaml init-secrets-minimal.yaml redis-checkov.yaml server-name.yaml
+# source_fragments: hookshot-checkov.yaml hookshot-ingress.yaml hookshot-minimal.yaml init-secrets-checkov.yaml init-secrets-minimal.yaml server-name.yaml valkey-checkov.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # postgres don't have any required properties to be set and defaults to enabled
@@ -30,13 +30,13 @@ matrixAuthenticationService:
   enabled: false
 matrixRTC:
   enabled: false
-redis:
+serverName: ess.localhost
+synapse:
+  enabled: false
+valkey:
   annotations:
     checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
     checkov.io/skip2: CKV_K8S_43=No digests
     checkov.io/skip3: CKV2_K8S_6=No network policy yet
-serverName: ess.localhost
-synapse:
-  enabled: false
 wellKnownDelegation:
   enabled: false

--- a/charts/matrix-stack/ci/matrix-rtc-checkov-values.yaml
+++ b/charts/matrix-stack/ci/matrix-rtc-checkov-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# source_fragments: init-secrets-checkov.yaml init-secrets-minimal.yaml matrix-rtc-checkov.yaml matrix-rtc-minimal.yaml redis-checkov.yaml
+# source_fragments: init-secrets-checkov.yaml init-secrets-minimal.yaml matrix-rtc-checkov.yaml matrix-rtc-minimal.yaml valkey-checkov.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # postgres don't have any required properties to be set and defaults to enabled
@@ -32,12 +32,12 @@ matrixRTC:
       checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
       checkov.io/skip2: CKV_K8S_43=No digests
       checkov.io/skip3: CKV2_K8S_6=No network policy yet
-redis:
+synapse:
+  enabled: false
+valkey:
   annotations:
     checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
     checkov.io/skip2: CKV_K8S_43=No digests
     checkov.io/skip3: CKV2_K8S_6=No network policy yet
-synapse:
-  enabled: false
 wellKnownDelegation:
   enabled: false

--- a/charts/matrix-stack/ci/pytest-hookshot-values.yaml
+++ b/charts/matrix-stack/ci/pytest-hookshot-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# source_fragments: hookshot-encryption-enabled.yaml hookshot-minimal.yaml hookshot-pytest-extras.yaml init-secrets-minimal.yaml init-secrets-pytest-extras.yaml postgres-minimal.yaml redis-pytest-base-extras.yaml server-name.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml
+# source_fragments: hookshot-encryption-enabled.yaml hookshot-minimal.yaml hookshot-pytest-extras.yaml init-secrets-minimal.yaml init-secrets-pytest-extras.yaml postgres-minimal.yaml server-name.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml valkey-pytest-base-extras.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:
@@ -67,9 +67,6 @@ matrixRTC:
 postgres:
   podSecurityContext:
     runAsGroup: 0
-redis:
-  podSecurityContext:
-    runAsGroup: 0
 serverName: ess.localhost
 synapse:
   checkConfigHook:
@@ -84,6 +81,9 @@ synapse:
   ingress:
     host: synapse.{{ $.Values.serverName }}
     tlsSecret: "{{ $.Release.Name }}-synapse-web-tls"
+  podSecurityContext:
+    runAsGroup: 0
+valkey:
   podSecurityContext:
     runAsGroup: 0
 wellKnownDelegation:

--- a/charts/matrix-stack/ci/pytest-hookshot-with-mas-values.yaml
+++ b/charts/matrix-stack/ci/pytest-hookshot-with-mas-values.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# source_fragments: hookshot-minimal.yaml hookshot-pytest-extras.yaml init-secrets-minimal.yaml init-secrets-pytest-extras.yaml matrix-authentication-service-minimal.yaml matrix-authentication-service-pytest-extras.yaml postgres-minimal.yaml redis-pytest-base-extras.yaml server-name.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml
+# source_fragments: hookshot-minimal.yaml hookshot-pytest-extras.yaml init-secrets-minimal.yaml init-secrets-pytest-extras.yaml matrix-authentication-service-minimal.yaml matrix-authentication-service-pytest-extras.yaml postgres-minimal.yaml server-name.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml valkey-pytest-base-extras.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:
@@ -82,9 +82,6 @@ matrixRTC:
 postgres:
   podSecurityContext:
     runAsGroup: 0
-redis:
-  podSecurityContext:
-    runAsGroup: 0
 serverName: ess.localhost
 synapse:
   checkConfigHook:
@@ -99,6 +96,9 @@ synapse:
   ingress:
     host: synapse.{{ $.Values.serverName }}
     tlsSecret: "{{ $.Release.Name }}-synapse-web-tls"
+  podSecurityContext:
+    runAsGroup: 0
+valkey:
   podSecurityContext:
     runAsGroup: 0
 wellKnownDelegation:

--- a/charts/matrix-stack/ci/pytest-matrix-rtc-standalone-values.yaml
+++ b/charts/matrix-stack/ci/pytest-matrix-rtc-standalone-values.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# source_fragments: init-secrets-minimal.yaml init-secrets-pytest-extras.yaml matrix-rtc-minimal.yaml matrix-rtc-pytest-extras.yaml matrix-rtc-turn-tls.yaml redis-pytest-base-extras.yaml
+# source_fragments: init-secrets-minimal.yaml init-secrets-pytest-extras.yaml matrix-rtc-minimal.yaml matrix-rtc-pytest-extras.yaml matrix-rtc-turn-tls.yaml valkey-pytest-base-extras.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 # postgres don't have any required properties to be set and defaults to enabled
@@ -52,10 +52,10 @@ matrixRTC:
       level: debug
     podSecurityContext:
       runAsGroup: 0
-redis:
-  podSecurityContext:
-    runAsGroup: 0
 synapse:
   enabled: false
+valkey:
+  podSecurityContext:
+    runAsGroup: 0
 wellKnownDelegation:
   enabled: false

--- a/charts/matrix-stack/ci/pytest-matrix-rtc-synapse-wellknown-values.yaml
+++ b/charts/matrix-stack/ci/pytest-matrix-rtc-synapse-wellknown-values.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# source_fragments: init-secrets-minimal.yaml init-secrets-pytest-extras.yaml matrix-rtc-minimal.yaml matrix-rtc-pytest-extras.yaml matrix-rtc-turn-tls.yaml postgres-minimal.yaml redis-pytest-base-extras.yaml server-name.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml well-known-minimal.yaml well-known-pytest-base-extras.yaml
+# source_fragments: init-secrets-minimal.yaml init-secrets-pytest-extras.yaml matrix-rtc-minimal.yaml matrix-rtc-pytest-extras.yaml matrix-rtc-turn-tls.yaml postgres-minimal.yaml server-name.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml valkey-pytest-base-extras.yaml well-known-minimal.yaml well-known-pytest-base-extras.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:
@@ -58,9 +58,6 @@ matrixRTC:
 postgres:
   podSecurityContext:
     runAsGroup: 0
-redis:
-  podSecurityContext:
-    runAsGroup: 0
 serverName: ess.localhost
 synapse:
   checkConfigHook:
@@ -75,6 +72,9 @@ synapse:
   ingress:
     host: synapse.{{ $.Values.serverName }}
     tlsSecret: "{{ $.Release.Name }}-synapse-web-tls"
+  podSecurityContext:
+    runAsGroup: 0
+valkey:
   podSecurityContext:
     runAsGroup: 0
 wellKnownDelegation:

--- a/charts/matrix-stack/ci/pytest-synapse-values.yaml
+++ b/charts/matrix-stack/ci/pytest-synapse-values.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# source_fragments: init-secrets-minimal.yaml init-secrets-pytest-extras.yaml postgres-minimal.yaml redis-pytest-base-extras.yaml server-name.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml synapse-pytest-self-extras.yaml
+# source_fragments: init-secrets-minimal.yaml init-secrets-pytest-extras.yaml postgres-minimal.yaml server-name.yaml synapse-minimal.yaml synapse-pytest-base-extras.yaml synapse-pytest-self-extras.yaml valkey-pytest-base-extras.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:
@@ -26,9 +26,6 @@ matrixAuthenticationService:
 matrixRTC:
   enabled: false
 postgres:
-  podSecurityContext:
-    runAsGroup: 0
-redis:
   podSecurityContext:
     runAsGroup: 0
 serverName: ess.localhost
@@ -72,5 +69,8 @@ synapse:
     # initial-synchrotron & synchrotron have non-trivial routing behaviour
     synchrotron:
       enabled: true
+valkey:
+  podSecurityContext:
+    runAsGroup: 0
 wellKnownDelegation:
   enabled: false

--- a/charts/matrix-stack/ci/synapse-checkov-with-workers-values.yaml
+++ b/charts/matrix-stack/ci/synapse-checkov-with-workers-values.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# source_fragments: haproxy-checkov.yaml init-secrets-checkov.yaml init-secrets-minimal.yaml postgres-checkov.yaml postgres-minimal.yaml redis-checkov.yaml server-name.yaml synapse-checkov.yaml synapse-minimal.yaml synapse-some-workers-running.yaml
+# source_fragments: haproxy-checkov.yaml init-secrets-checkov.yaml init-secrets-minimal.yaml postgres-checkov.yaml postgres-minimal.yaml server-name.yaml synapse-checkov.yaml synapse-minimal.yaml synapse-some-workers-running.yaml valkey-checkov.yaml
 # DO NOT EDIT DIRECTLY. Edit the fragment files to add / modify / remove values
 
 deploymentMarkers:
@@ -32,11 +32,6 @@ postgres:
     checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
     checkov.io/skip2: CKV_K8S_43=No digests
     checkov.io/skip3: CKV2_K8S_6=No network policy yet
-redis:
-  annotations:
-    checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
-    checkov.io/skip2: CKV_K8S_43=No digests
-    checkov.io/skip3: CKV2_K8S_6=No network policy yet
 serverName: ess.localhost
 synapse:
   annotations:
@@ -59,5 +54,10 @@ synapse:
       enabled: true
     federation-reader:
       enabled: true
+valkey:
+  annotations:
+    checkov.io/skip1: CKV_K8S_11=We deliberately don't set CPU limits. Pod is BestEffort not Guaranteed
+    checkov.io/skip2: CKV_K8S_43=No digests
+    checkov.io/skip3: CKV2_K8S_6=No network policy yet
 wellKnownDelegation:
   enabled: false

--- a/newsfragments/1561.changed.md
+++ b/newsfragments/1561.changed.md
@@ -1,0 +1,9 @@
+Replace Redis with Valkey.
+
+The `redis` key at the top-level in the values file is deprecated.
+It is replaced by the top-level `valkey` key.
+The schema is identical apart from `redis.redisExporter` which is replaced by `valkey.valkeyExporter`.
+
+Values from `redis` are merged into `valkey` to control deployment of Valkey
+
+The top-level `redis` key will be removed in a later release and any user set values under `redis` should be moved to `valkey`.


### PR DESCRIPTION
#1559 deliberately did not touch the CI value files so as to prove the merging of values from `redis` -> `valkey` worked.

Now that this has been done, we do this rename. This should be a no-op and the end of the updating of things for the built-in Valkey.

Absent is any renaming of properties for external Redis/Valkey. The files in `charts/matrix-stack/ci` with `redis` in their name relate to an external Redis/Valkey and so should not be renamed yet