### PR TITLE
Integration: Drop old tests skips

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -122,9 +122,6 @@ jobs:
     - name: Deploy with pytest once
       env:
         PYTEST_CI_FIRST_STEP: "1"
-      # Drop me after releasing next 26.3.x
-      # We are changing the k3d ports range, so we cannot setup matrix-rtc with the old values
-      if: ${{ env.MATRIX_TEST_FROM_REF == '26.2.3' && !contains(env.MATRIX_TEST_COMPONENT, 'matrix-rtc') || env.MATRIX_TEST_FROM_REF != '26.2.3' }}
       run: |
         if [ -f "tests/integration/env/${MATRIX_TEST_COMPONENT}.rc" ]; then
           # shellcheck source=/dev/null

--- a/newsfragments/1567.internal.md
+++ b/newsfragments/1567.internal.md
@@ -1,0 +1,1 @@
+CI: Cleanup old tests skips.

--- a/tests/integration/test_hookshot.py
+++ b/tests/integration/test_hookshot.py
@@ -4,12 +4,10 @@
 
 import asyncio
 import json
-import os
 import time
 from urllib.parse import urlparse
 
 import pytest
-import semver
 from lightkube import AsyncClient
 
 from .fixtures import ESSData, User
@@ -259,12 +257,6 @@ async def test_hookshot_webhook(
 # This creates an unencrypted room, invites hookshot, creates a webhook,
 # and verifies that hookshot posts webhook payloads to the room
 @pytest.mark.skipif(not value_file_has("hookshot.enabled", True), reason="Hookshot not enabled")
-@pytest.mark.skipif(
-    semver.Version.is_valid(os.environ.get("MATRIX_TEST_FROM_REF", ""))
-    and semver.VersionInfo.parse(os.environ.get("MATRIX_TEST_FROM_REF", "")).compare("26.1.3") <= 0
-    and os.environ.get("PYTEST_CI_FIRST_STEP", "") == "1",
-    reason="26.1.3 or earlier doesn't correctly mount widgets on the Synapse Ingress, so it fails before upgrading.",
-)
 @pytest.mark.asyncio_cooperative
 async def test_hookshot_widget(
     kube_client: AsyncClient,

--- a/tests/integration/test_networking.py
+++ b/tests/integration/test_networking.py
@@ -202,7 +202,6 @@ async def test_pods_monitored(
 @pytest.mark.skipif(
     os.environ.get("SKIP_SERVICE_MONITORS_CRDS", "false") == "true", reason="ServiceMonitors not deployed"
 )
-@pytest.mark.skipif(os.environ.get("MATRIX_TEST_FROM_REF", "") == "25.6.2", reason="This fails against 25.6.2.")
 @pytest.mark.asyncio_cooperative
 @pytest.mark.usefixtures("matrix_stack")
 async def test_service_monitors_point_to_metrics(


### PR DESCRIPTION
Those versions were released a while ago, we should not need those skips anymore.