### PR TITLE
Unpin Helm in CI again

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -110,9 +110,6 @@ jobs:
           k3d 5.8.3
 
     - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
-      with:
-        # 4.2.1 appears to hang on most integration tests.
-        version: 4.2.0
 
     - name: Checkout values files from previous ref
       run: |

--- a/newsfragments/1568.internal.md
+++ b/newsfragments/1568.internal.md
@@ -1,0 +1,1 @@
+CI: unpin Helm in the tests from v4.2.0.


### PR DESCRIPTION
Removes the pin added in https://github.com/element-hq/ess-helm/pull/1396