### PR TITLE
Add default mode tests on mounted volumes

### DIFF
--- a/charts/matrix-stack/templates/element-web/deployment.yaml
+++ b/charts/matrix-stack/templates/element-web/deployment.yaml
@@ -92,11 +92,11 @@ spec:
 {{- end }}
       volumes:
       - configMap:
-          defaultMode: 420
+          defaultMode: 256
           name: {{ $.Release.Name }}-element-web
         name: config
       - configMap:
-          defaultMode: 420
+          defaultMode: 256
           name: {{ $.Release.Name }}-element-web-nginx
         name: nginx-config
       - emptyDir: {{- $.Values.elementWeb.ephemeralStorages.tmp | toYaml | nindent 10 }}

--- a/charts/matrix-stack/templates/ess-library/_render_config.tpl
+++ b/charts/matrix-stack/templates/ess-library/_render_config.tpl
@@ -91,12 +91,13 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- with required "element-io.ess-library.render-config-volumes missing context" .context -}}
 {{- $nameSuffix := required "element-io.ess-library.render-config-volumes missing context.nameSuffix" .nameSuffix -}}
 - configMap:
-    defaultMode: 420
+    defaultMode: 256
     name: {{ include (printf "element-io.%s.configmap-name" $nameSuffix) (dict "root" $root "context" .) }}
   name: plain-config
 {{- range $secret := include (printf "element-io.%s.configSecrets" $nameSuffix) (dict "root" $root "context" .) | fromJsonArray }}
 {{- with (tpl $secret $root) }}
 - secret:
+    defaultMode: 256
     secretName: {{ . }}
   name: secret-{{ . | sha256sum | trunc 12  }}
 {{- end }}

--- a/charts/matrix-stack/templates/haproxy/deployment.yaml
+++ b/charts/matrix-stack/templates/haproxy/deployment.yaml
@@ -124,18 +124,18 @@ spec:
       volumes:
       - configMap:
           name: "{{ $.Release.Name }}-haproxy"
-          defaultMode: 420
+          defaultMode: 256
         name: haproxy-config
 {{- if $.Values.synapse.enabled }}
       - configMap:
           name: "{{ $.Release.Name }}-synapse-haproxy"
-          defaultMode: 420
+          defaultMode: 256
         name: synapse-haproxy
 {{- end }}
 {{- if $.Values.wellKnownDelegation.enabled }}
       - configMap:
           name: "{{ $.Release.Name }}-well-known-haproxy"
-          defaultMode: 420
+          defaultMode: 256
         name: well-known-haproxy
 {{- end }}
 {{- range .extraVolumes }}

--- a/charts/matrix-stack/templates/init-secrets/job.yaml
+++ b/charts/matrix-stack/templates/init-secrets/job.yaml
@@ -78,7 +78,7 @@ spec:
 {{- end }}
 {{- if include "element-io.init-secrets.registration-templates" (dict "root" $) }}
       - configMap:
-          defaultMode: 420
+          defaultMode: 256
           name: {{ $.Release.Name }}-init-secrets
         name: registration-templates
 {{- end -}}

--- a/charts/matrix-stack/templates/matrix-authentication-service/syn2mas_job.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/syn2mas_job.yaml
@@ -219,6 +219,7 @@ spec:
           name: {{ include "element-io.synapse.configmap-name" (dict "root" $ "context" (dict "isHook" $isHook)) }}
       - name: plain-mas-config
         configMap:
+          defaultMode: 256
           name: {{ include "element-io.matrix-authentication-service.configmap-name" (dict "root" $ "context" (dict "isHook" $isHook)) }}
 {{- range $_, $secret := include "element-io.syn2mas.configSecrets" (dict "root" $ "context" (dict "synapseContext" $synapseContext "masContext" $masContext)) | fromJsonArray }}
 {{- with tpl $secret $ }}

--- a/charts/matrix-stack/templates/matrix-authentication-service/syn2mas_job.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/syn2mas_job.yaml
@@ -215,7 +215,7 @@ spec:
       volumes:
       - name: plain-syn-config
         configMap:
-          defaultMode: 420
+          defaultMode: 256
           name: {{ include "element-io.synapse.configmap-name" (dict "root" $ "context" (dict "isHook" $isHook)) }}
       - name: plain-mas-config
         configMap:
@@ -223,6 +223,7 @@ spec:
 {{- range $_, $secret := include "element-io.syn2mas.configSecrets" (dict "root" $ "context" (dict "synapseContext" $synapseContext "masContext" $masContext)) | fromJsonArray }}
 {{- with tpl $secret $ }}
       - secret:
+          defaultMode: 256
           secretName: {{ . }}
         name: "secret-{{ . | sha256sum | trunc 12 }}"
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-rtc/authorisation_deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/authorisation_deployment.yaml
@@ -85,6 +85,7 @@ spec:
 {{- range $secret := include "element-io.matrix-rtc-authorisation-service.configSecrets" (dict "root" $ "context" $.Values.matrixRTC) | fromJsonArray }}
 {{- with (tpl $secret $) }}
       - secret:
+          defaultMode: 256
           secretName: {{ . }}
         name: "secret-{{ . | sha256sum | trunc 12 }}"
 {{- end }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
@@ -194,10 +194,12 @@ spec:
 {{- if .exposedServices.turnTLS.tlsSecret }}
       - name: secret-turn-tls
         secret:
+          defaultMode: 256
           secretName: {{ tpl .exposedServices.turnTLS.tlsSecret $ }}
 {{- else if $.Values.certManager }}
       - name: secret-turn-tls
         secret:
+          defaultMode: 256
           secretName: "{{ $.Release.Name }}-turn-tls-certmanager-tls"
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/postgres/statefulset.yaml
+++ b/charts/matrix-stack/templates/postgres/statefulset.yaml
@@ -208,6 +208,7 @@ spec:
 {{- range $secret := include "element-io.postgres.configSecrets" (dict "root" $ "context" .) | fromJsonArray }}
 {{- with (tpl $secret $) }}
       - secret:
+          defaultMode: 256
           secretName: {{ . }}
         name: "secret-{{ . | sha256sum | trunc 12 }}"
 {{- end }}
@@ -217,6 +218,7 @@ spec:
 {{- end }}
       - name: config
         configMap:
+          defaultMode: 256
           name: {{ $.Release.Name }}-postgres
       - name: database
         persistentVolumeClaim:

--- a/charts/matrix-stack/templates/postgres/statefulset.yaml
+++ b/charts/matrix-stack/templates/postgres/statefulset.yaml
@@ -202,6 +202,7 @@ spec:
         name: var-run
 {{- if and $.Values.initSecrets.enabled (include "element-io.init-secrets.postgres-generated-secrets" (dict "root" $)) }}
       - secret:
+          defaultMode: 256
           secretName: {{ $.Release.Name }}-generated
         name: secret-generated
 {{- end }}

--- a/charts/matrix-stack/templates/synapse/_synapse_pod.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_pod.tpl
@@ -197,11 +197,12 @@ We have an init container to render & merge the config for several reasons:
     - name: as-{{ $idx }}
 {{- with $appservice.configMap }}
       configMap:
-        defaultMode: 420
+        defaultMode: 256
         name: "{{ tpl . $root }}"
 {{- end }}
 {{- with $appservice.secret }}
       secret:
+        defaultMode: 256
         secretName: "{{ tpl . $root }}"
 {{- end }}
 {{- end }}

--- a/charts/matrix-stack/templates/valkey/valkey_statefulset.yaml
+++ b/charts/matrix-stack/templates/valkey/valkey_statefulset.yaml
@@ -109,7 +109,7 @@ spec:
       volumes:
       - configMap:
           name: "{{ $.Release.Name }}-valkey"
-          defaultMode: 420
+          defaultMode: 256
         name: config
 {{- range .extraVolumes }}
       - {{- (tpl (. | toYaml) $) | nindent 8 }}

--- a/newsfragments/1573.changed.md
+++ b/newsfragments/1573.changed.md
@@ -1,0 +1,1 @@
+Change permissions of mounted ConfigMaps and Secrets to deny Read-Write access from others, and only give Read access to owners and groups.

--- a/tests/manifests/test_volumes.py
+++ b/tests/manifests/test_volumes.py
@@ -18,18 +18,25 @@ from .utils import iterate_deployables_workload_parts, iterate_pod_template
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
 async def test_volume_default_mode(values, templates):
+    allowed_default_modes = {
+        # For configmaps and Secrets, only owners & groups should be able to read the content
+        ## 256 (decimal) = 400 (octal)
+        ## 320 (decimal) = 500 (octal)
+        "configMap": (256, 320),
+        "secret": (256, 320),
+    }
     for pod_template_details in iterate_pod_template(templates):
         for v in pod_template_details.pod_template["spec"].get("volumes", []):
             if "configMap" in v:
+                volume_type = "configMap"
                 default_mode = v["configMap"].get("defaultMode")
             elif "secret" in v:
-                default_mode = v["secret"].get("secret")
+                volume_type = "secret"
+                default_mode = v["secret"].get("defaultMode")
             else:
                 continue
 
-            # 256 (decimal) = 400 (octal)
-            # 320 (decimal) = 500 (octal)
-            assert default_mode in (256, 320), (
+            assert default_mode in allowed_default_modes[volume_type], (
                 f"{pod_template_details.manifest_id} volume {v['name']} does not have an accepted mode"
             )
 

--- a/tests/manifests/test_volumes.py
+++ b/tests/manifests/test_volumes.py
@@ -17,6 +17,25 @@ from .utils import iterate_deployables_workload_parts, iterate_pod_template
 
 @pytest.mark.parametrize("values_file", values_files_to_test)
 @pytest.mark.asyncio_cooperative
+async def test_volume_default_mode(values, templates):
+    for pod_template_details in iterate_pod_template(templates):
+        for v in pod_template_details.pod_template["spec"].get("volumes", []):
+            if "configMap" in v:
+                default_mode = v["configMap"].get("defaultMode")
+            elif "secret" in v:
+                default_mode = v["secret"].get("secret")
+            else:
+                continue
+
+            # 256 (decimal) = 400 (octal)
+            # 320 (decimal) = 500 (octal)
+            assert default_mode in (256, 320), (
+                f"{pod_template_details.manifest_id} volume {v['name']} does not have an accepted mode"
+            )
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
 async def test_extra_volumes(values, make_templates, release_name):
     def extra_volumes(deployable_details: DeployableDetails):
         return deepfreeze(


### PR DESCRIPTION
A simple hardening to the files mounted in Kubernetes. 

Default situation is somewhat OK, due to those config files and secrets being created in tmpfs allocated to the pods. 

This just applies some proper defense in depth and only gives the smallest permissions (400) to those files, from Kubernetes defaults of 644.

We cannot apply this to emptyDir yet as the feature is still alpha here:
https://kubernetes.io/docs/reference/kubernetes-api/core/pod-v1/#EmptyDirVolumeSource