### PR TITLE
Allow configuration of `hostAliases` on the MatrixRTC SFU

### DIFF
--- a/charts/matrix-stack/source/matrix-rtc.json
+++ b/charts/matrix-stack/source/matrix-rtc.json
@@ -132,6 +132,9 @@
         "annotations": {
           "$ref": "file://common/workloadAnnotations.json"
         },
+        "hostAliases": {
+          "$ref": "file://common/hostAliases.json"
+        },
         "hostNetwork": {
           "type": "boolean"
         },

--- a/charts/matrix-stack/source/matrix-rtc.yaml.j2
+++ b/charts/matrix-stack/source/matrix-rtc.yaml.j2
@@ -96,6 +96,7 @@ sfu:
 {{- sub_schema_values.extraVolumes("Matrix RTC SFU") | indent(2) }}
 {{- sub_schema_values.extraVolumeMounts("Matrix RTC SFU") | indent(2) }}
 {{- sub_schema_values.extraInitContainers("Matrix RTC SFU") | indent(2) }}
+{{- sub_schema_values.hostAliases() | indent(2) }}
 {{- sub_schema_values.labels() | indent(2) }}
 {{- sub_schema_values.workloadAnnotations() | indent(2) }}
 {{- sub_schema_values.containersSecurityContext() | indent(2) }}

--- a/charts/matrix-stack/templates/ess-library/_pods.tpl
+++ b/charts/matrix-stack/templates/ess-library/_pods.tpl
@@ -11,6 +11,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- $instanceSuffix := required "element-io.ess-library.pods.commonSpec missing context.instanceSuffix" .instanceSuffix -}}
 {{- $serviceAccountNameSuffix := .serviceAccountNameSuffix | default .instanceSuffix -}}
 {{- $usesMatrixTools := .usesMatrixTools | default false -}}
+{{- $makesOutboundRequests := .makesOutboundRequests | default false -}}
 {{- $mountServiceAccountToken := .mountServiceAccountToken | default false -}}
 {{- $kind := required "element-io.ess-library.pods.commonSpec missing context.kind" .kind -}}
 {{- if not (has $kind (list "Deployment" "StatefulSet" "Job")) -}}
@@ -20,6 +21,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 automountServiceAccountToken: {{ $mountServiceAccountToken }}
 serviceAccountName: {{ include "element-io.ess-library.serviceAccountName" (dict "root" $root "context" (dict "serviceAccount" .serviceAccount "nameSuffix" $serviceAccountNameSuffix)) }}
 {{- include "element-io.ess-library.pods.pullSecrets" (dict "root" $root "context" (dict "pullSecrets" ((.image).pullSecrets | default list) "usesMatrixTools" $usesMatrixTools)) }}
+{{- if $makesOutboundRequests }}
+{{- with .hostAliases }}
+hostAliases:
+  {{- tpl (toYaml . | nindent 2) $root }}
+{{- end }}
+{{- end }}
 {{- with .podSecurityContext }}
 securityContext:
   {{- toYaml . | nindent 2 }}

--- a/charts/matrix-stack/templates/hookshot/hookshot_statefulset.yaml
+++ b/charts/matrix-stack/templates/hookshot/hookshot_statefulset.yaml
@@ -33,14 +33,11 @@ spec:
         {{- toYaml . | nindent 8 }}
 {{- end }}
     spec:
-{{- with .hostAliases }}
-      hostAliases:
-        {{- tpl (toYaml . | nindent 8) $ }}
-{{- end }}
 {{- include "element-io.ess-library.pods.commonSpec" (dict "root" $ "context" (dict "componentValues" .
                                                                                     "instanceSuffix" "hookshot"
                                                                                     "kind" "StatefulSet"
                                                                                     "usesMatrixTools" true
+                                                                                    "makesOutboundRequests" true
                                                                                     "mountServiceAccountToken" false)) | nindent 6 }}
       initContainers:
       {{- include "element-io.ess-library.render-config-container" (dict "root" $ "context"

--- a/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-authentication-service/deployment.yaml
@@ -43,11 +43,7 @@ spec:
         {{- toYaml . | nindent 8 }}
 {{- end }}
     spec:
-{{- with .hostAliases }}
-      hostAliases:
-        {{- tpl (toYaml . | nindent 8) $ }}
-{{- end }}
-{{- include "element-io.ess-library.pods.commonSpec" (dict "root" $ "context" (dict "componentValues" . "instanceSuffix" "matrix-authentication-service" "kind" "Deployment" "usesMatrixTools" true)) | nindent 6 }}
+{{- include "element-io.ess-library.pods.commonSpec" (dict "root" $ "context" (dict "componentValues" . "instanceSuffix" "matrix-authentication-service" "kind" "Deployment" "makesOutboundRequests" true "usesMatrixTools" true)) | nindent 6 }}
       initContainers:
       {{ include "element-io.matrix-authentication-service.render-config-container" (dict "root" $ "context" .) | nindent 6 }}
       - name: db-wait

--- a/charts/matrix-stack/templates/matrix-rtc/authorisation_deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/authorisation_deployment.yaml
@@ -31,11 +31,7 @@ spec:
         {{- toYaml . | nindent 8 }}
 {{- end }}
     spec:
-{{- with .hostAliases }}
-      hostAliases:
-        {{- tpl (toYaml . | nindent 8) $ }}
-{{- end }}
-{{- include "element-io.ess-library.pods.commonSpec" (dict "root" $ "context" (dict "componentValues" . "instanceSuffix" "matrix-rtc-authorisation-service" "kind" "Deployment")) | nindent 6 }}
+{{- include "element-io.ess-library.pods.commonSpec" (dict "root" $ "context" (dict "componentValues" . "instanceSuffix" "matrix-rtc-authorisation-service" "kind" "Deployment" "makesOutboundRequests" true)) | nindent 6 }}
 {{- with .extraInitContainers }}
       initContainers:
       {{- toYaml . | nindent 6 }}

--- a/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
+++ b/charts/matrix-stack/templates/matrix-rtc/sfu_deployment.yaml
@@ -35,11 +35,7 @@ spec:
         {{- toYaml . | nindent 8 }}
 {{- end }}
     spec:
-{{- with .hostAliases }}
-      hostAliases:
-        {{- tpl (toYaml . | nindent 8) $ }}
-{{- end }}
-{{- include "element-io.ess-library.pods.commonSpec" (dict "root" $ "context" (dict "componentValues" . "instanceSuffix" "matrix-rtc-sfu" "kind" "Deployment" "usesMatrixTools" true)) | nindent 6 }}
+{{- include "element-io.ess-library.pods.commonSpec" (dict "root" $ "context" (dict "componentValues" . "instanceSuffix" "matrix-rtc-sfu" "kind" "Deployment" "makesOutboundRequests" true "usesMatrixTools" true)) | nindent 6 }}
       hostNetwork: {{ .hostNetwork }}
       initContainers:
       {{- include "element-io.ess-library.render-config-container" (dict "root" $ "context"

--- a/charts/matrix-stack/templates/synapse/_synapse_pod.tpl
+++ b/charts/matrix-stack/templates/synapse/_synapse_pod.tpl
@@ -44,14 +44,9 @@ template:
                                           "instanceSuffix" ($isHook | ternary "synapse-check-config" (printf "synapse-%s" $processType))
                                           "serviceAccountNameSuffix" ($isHook | ternary "synapse-check-config" "synapse")
                                           "kind" ($isHook | ternary "Job" "StatefulSet")
+                                          "makesOutboundRequests" (not $isHook)
                                           "usesMatrixTools" true)
                                     ) | nindent 4 }}
-{{- if not $isHook }}
-{{- with .hostAliases }}
-    hostAliases:
-      {{- tpl (toYaml . | nindent 6) $root }}
-{{- end }}
-{{- end }}
 {{- /*
 We have an init container to render & merge the config for several reasons:
 * We have external, user-supplied Secrets and don't want to use `lookup` as that doesn't work with things like ArgoCD

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -5448,6 +5448,24 @@
                 "type": "string"
               }
             },
+            "hostAliases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "ip": {
+                    "type": "string"
+                  },
+                  "hostnames": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
             "hostNetwork": {
               "type": "boolean"
             },

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -1136,6 +1136,18 @@ matrixRTC:
     # Extra initContainers to add to Matrix RTC SFU, as a yaml array
     extraInitContainers: []
 
+    ## The list of hosts aliases to configure on the pod spec.
+    ## It should be avoid as much as possible to use this feature.
+    ## Please prefer using an DNS entry to resolve your hostnames.
+    ## This can be used as a workaround when entries cannot be resolved using DNS, for example for our automated testings.
+    ## e.g.
+    ## hostAliases:
+    ## - ip: 192.0.2.1  # An IP resolution to add to /etc/hosts
+    ##   # A list of hostnames to be associated with the above IP
+    ##   hostnames:
+    ##   - ess.localhost
+    ##   - synapse.ess.localhost
+    hostAliases: []
     ## Labels to add to all manifest for this component
     labels: {}
     ## Defines the annotations to add to the workload

--- a/newsfragments/1574.changed.1.md
+++ b/newsfragments/1574.changed.1.md
@@ -1,0 +1,3 @@
+Allow configuration of `hostAliases` on the MatrixRTC SFU.
+
+It now makes outbound requests to Redis and the MatrixRTC authoriser.

--- a/newsfragments/1574.changed.md
+++ b/newsfragments/1574.changed.md
@@ -1,0 +1,1 @@
+Unify `hostAliases` handling in supported components.

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -594,7 +594,6 @@ all_components_details = [
                 has_exposed_services=True,
                 has_ingress=False,
                 is_singleton=True,
-                makes_outbound_requests=False,
             ),
         ),
         additional_secret_values_files=(


### PR DESCRIPTION
After https://github.com/element-hq/ess-helm/pull/1519 and https://github.com/element-hq/ess-helm/pull/1555 the MatrixRTC SFU does make outbound requests so should have `hostAlias` support.

Handling is moved into `element-io.ess-library.pods.commonSpec` as more things are about to rely on `makesOutboundRequests`