### PR TITLE
Add support for configuring `dnsPolicy`

### DIFF
--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -110,6 +110,11 @@ networking:
 # {{ key }}: {}
 {%- endmacro %}
 
+{% macro dnsPolicy(key='dnsPolicy', default_value='""') %}
+## Set DNS policy for the pod. Kubernetes defaults to ClusterFirst if no value is provided here
+{{ key }}: {{ default_value }}
+{%- endmacro %}
+
 {% macro extraEnv(key='extraEnv') %}
 ## Defines additional environment variables to be injected onto this workload
 ## e.g.

--- a/charts/matrix-stack/source/hookshot.json
+++ b/charts/matrix-stack/source/hookshot.json
@@ -74,6 +74,9 @@
     "containersSecurityContext": {
       "$ref": "file://common/containersSecurityContext.json"
     },
+    "dnsPolicy": {
+      "type": "string"
+    },
     "extraEnv": {
       "$ref": "file://common/extraEnv.json"
     },

--- a/charts/matrix-stack/source/hookshot.yaml.j2
+++ b/charts/matrix-stack/source/hookshot.yaml.j2
@@ -49,6 +49,7 @@ replicas: 1
 {{ sub_schema_values.topologySpreadConstraints() }}
 {{ sub_schema_values.podSecurityContext(user_id=10007, group_id=10007) }}
 {{ sub_schema_values.containersSecurityContext() }}
+{{ sub_schema_values.dnsPolicy() }}
 {{ sub_schema_values.workloadAnnotations() }}
 {{ sub_schema_values.serviceMonitors() }}
 {{ sub_schema_values.extraEnv() }}

--- a/charts/matrix-stack/source/matrix-rtc.json
+++ b/charts/matrix-stack/source/matrix-rtc.json
@@ -58,6 +58,9 @@
     "containersSecurityContext": {
       "$ref": "file://common/containersSecurityContext.json"
     },
+    "dnsPolicy": {
+      "type": "string"
+    },
     "serviceMonitors": {
       "$ref": "file://common/serviceMonitors.json"
     },
@@ -208,6 +211,9 @@
         },
         "containersSecurityContext": {
           "$ref": "file://common/containersSecurityContext.json"
+        },
+        "dnsPolicy": {
+          "type": "string"
         },
         "nodeSelector": {
           "$ref": "file://common/nodeSelector.json"

--- a/charts/matrix-stack/source/matrix-rtc.yaml.j2
+++ b/charts/matrix-stack/source/matrix-rtc.yaml.j2
@@ -27,6 +27,7 @@ replicas: 1
 {{- sub_schema_values.labels() }}
 {{- sub_schema_values.workloadAnnotations() }}
 {{- sub_schema_values.containersSecurityContext() }}
+{{- sub_schema_values.dnsPolicy() }}
 {{- sub_schema_values.hostAliases() }}
 {{- sub_schema_values.extraEnv() }}
 {{- sub_schema_values.extraVolumes("Matrix RTC") }}
@@ -100,6 +101,7 @@ sfu:
 {{- sub_schema_values.labels() | indent(2) }}
 {{- sub_schema_values.workloadAnnotations() | indent(2) }}
 {{- sub_schema_values.containersSecurityContext() | indent(2) }}
+{{- sub_schema_values.dnsPolicy(default_value='\"{{ $.Values.matrixRTC.sfu.hostNetwork | ternary \\"ClusterFirstWithHostNet\\" \\"\\" }}\"') | indent(2) }}
 {{- sub_schema_values.nodeSelector() | indent(2) }}
 {{- sub_schema_values.priorityClassName() | indent(2) }}
 {{- sub_schema_values.schedulerName() | indent(2) }}

--- a/charts/matrix-stack/source/matrixAuthenticationService.json
+++ b/charts/matrix-stack/source/matrixAuthenticationService.json
@@ -132,6 +132,9 @@
     "containersSecurityContext": {
       "$ref": "file://common/containersSecurityContext.json"
     },
+    "dnsPolicy": {
+      "type": "string"
+    },
     "extraEnv": {
       "$ref": "file://common/extraEnv.json"
     },

--- a/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
+++ b/charts/matrix-stack/source/matrixAuthenticationService.yaml.j2
@@ -40,6 +40,7 @@ privateKeys: {}
 {{ sub_schema_values.topologySpreadConstraints() }}
 {{ sub_schema_values.podSecurityContext(user_id=10005, group_id=10005) }}
 {{ sub_schema_values.containersSecurityContext() }}
+{{ sub_schema_values.dnsPolicy() }}
 {{ sub_schema_values.workloadAnnotations() }}
 {{ sub_schema_values.serviceMonitors() }}
 {{ sub_schema_values.extraEnv() }}

--- a/charts/matrix-stack/source/synapse.json
+++ b/charts/matrix-stack/source/synapse.json
@@ -167,6 +167,9 @@
     "containersSecurityContext": {
       "$ref": "file://common/containersSecurityContext.json"
     },
+    "dnsPolicy": {
+      "type": "string"
+    },
     "extraEnv": {
       "$ref": "file://common/extraEnv.json"
     },

--- a/charts/matrix-stack/source/synapse.yaml.j2
+++ b/charts/matrix-stack/source/synapse.yaml.j2
@@ -100,6 +100,7 @@ replicas: 1
 {{- sub_schema_values.labels() }}
 {{- sub_schema_values.workloadAnnotations() }}
 {{- sub_schema_values.containersSecurityContext() }}
+{{- sub_schema_values.dnsPolicy() }}
 {{- sub_schema_values.extraEnv() }}
 {{- sub_schema_values.hostAliases() }}
 {{- sub_schema_values.nodeSelector() }}

--- a/charts/matrix-stack/templates/ess-library/_pods.tpl
+++ b/charts/matrix-stack/templates/ess-library/_pods.tpl
@@ -22,6 +22,9 @@ automountServiceAccountToken: {{ $mountServiceAccountToken }}
 serviceAccountName: {{ include "element-io.ess-library.serviceAccountName" (dict "root" $root "context" (dict "serviceAccount" .serviceAccount "nameSuffix" $serviceAccountNameSuffix)) }}
 {{- include "element-io.ess-library.pods.pullSecrets" (dict "root" $root "context" (dict "pullSecrets" ((.image).pullSecrets | default list) "usesMatrixTools" $usesMatrixTools)) }}
 {{- if $makesOutboundRequests }}
+{{- with (tpl .dnsPolicy $root) }}
+dnsPolicy: {{ . }}
+{{- end }}
 {{- with .hostAliases }}
 hostAliases:
   {{- tpl (toYaml . | nindent 2) $root }}

--- a/charts/matrix-stack/values.schema.json
+++ b/charts/matrix-stack/values.schema.json
@@ -3956,6 +3956,9 @@
           "type": "object",
           "additionalProperties": false
         },
+        "dnsPolicy": {
+          "type": "string"
+        },
         "serviceMonitors": {
           "type": "object",
           "properties": {
@@ -6040,6 +6043,9 @@
               },
               "type": "object",
               "additionalProperties": false
+            },
+            "dnsPolicy": {
+              "type": "string"
             },
             "nodeSelector": {
               "type": "object",
@@ -12463,6 +12469,9 @@
           "type": "object",
           "additionalProperties": false
         },
+        "dnsPolicy": {
+          "type": "string"
+        },
         "extraEnv": {
           "type": "array",
           "items": {
@@ -15776,6 +15785,9 @@
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "dnsPolicy": {
+          "type": "string"
         },
         "extraEnv": {
           "type": "array",
@@ -24117,6 +24129,9 @@
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "dnsPolicy": {
+          "type": "string"
         },
         "extraEnv": {
           "type": "array",

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -692,6 +692,8 @@ matrixRTC:
     ## localhostProfile must only be set set if type Localhost. It indicates the path of the pre-configured profile on the node, relative to the kubelet's configured Seccomp profile location (configured with the --root-dir flag).
     # seccompProfile:
     #  type: RuntimeDefault
+  ## Set DNS policy for the pod. Kubernetes defaults to ClusterFirst if no value is provided here
+  dnsPolicy: ""
   ## The list of hosts aliases to configure on the pod spec.
   ## It should be avoid as much as possible to use this feature.
   ## Please prefer using an DNS entry to resolve your hostnames.
@@ -1180,6 +1182,8 @@ matrixRTC:
       ## localhostProfile must only be set set if type Localhost. It indicates the path of the pre-configured profile on the node, relative to the kubelet's configured Seccomp profile location (configured with the --root-dir flag).
       # seccompProfile:
       #  type: RuntimeDefault
+    ## Set DNS policy for the pod. Kubernetes defaults to ClusterFirst if no value is provided here
+    dnsPolicy: "{{ $.Values.matrixRTC.sfu.hostNetwork | ternary \"ClusterFirstWithHostNet\" \"\" }}"
     ## NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
     nodeSelector: {}
     ## If specified, indicates the pod's priority and must reference the name of an existing PriorityClass object.
@@ -2580,6 +2584,9 @@ hookshot:
     # seccompProfile:
     #  type: RuntimeDefault
 
+  ## Set DNS policy for the pod. Kubernetes defaults to ClusterFirst if no value is provided here
+  dnsPolicy: ""
+
   ## Defines the annotations to add to the workload
   # annotations: {}
 
@@ -3039,6 +3046,9 @@ matrixAuthenticationService:
     ## localhostProfile must only be set set if type Localhost. It indicates the path of the pre-configured profile on the node, relative to the kubelet's configured Seccomp profile location (configured with the --root-dir flag).
     # seccompProfile:
     #  type: RuntimeDefault
+
+  ## Set DNS policy for the pod. Kubernetes defaults to ClusterFirst if no value is provided here
+  dnsPolicy: ""
 
   ## Defines the annotations to add to the workload
   # annotations: {}
@@ -5886,6 +5896,8 @@ synapse:
     ## localhostProfile must only be set set if type Localhost. It indicates the path of the pre-configured profile on the node, relative to the kubelet's configured Seccomp profile location (configured with the --root-dir flag).
     # seccompProfile:
     #  type: RuntimeDefault
+  ## Set DNS policy for the pod. Kubernetes defaults to ClusterFirst if no value is provided here
+  dnsPolicy: ""
   ## Defines additional environment variables to be injected onto this workload
   ## e.g.
   ## extraEnv:

--- a/newsfragments/1575.added.md
+++ b/newsfragments/1575.added.md
@@ -1,0 +1,1 @@
+Add the ability to configure `dnsPolicy` on components that make outbound requests.

--- a/newsfragments/1575.changed.md
+++ b/newsfragments/1575.changed.md
@@ -1,0 +1,1 @@
+Default the MatrixRTC SFU to `dnsPolicy: ClusterFirstWithHostNet` when running with `hostNetwork: true`.

--- a/tests/manifests/__init__.py
+++ b/tests/manifests/__init__.py
@@ -15,6 +15,7 @@ class PropertyType(Enum):
     AdditionalConfig = "additional"
     Affinity = "affinity"
     ContainersSecurityContext = "containersSecurityContext"
+    DNSPolicy = "dnsPolicy"
     Enabled = "enabled"
     Env = "extraEnv"
     EphemeralStorages = "ephemeralStorages"
@@ -389,6 +390,7 @@ class ComponentDetails(DeployableDetails):
 def make_synapse_worker_sub_component(worker_name: str, worker_type: str) -> SubComponentDetails:
     values_file_path_overrides: dict[PropertyType, ValuesFilePath] = {
         PropertyType.AdditionalConfig: ValuesFilePath.read_elsewhere("synapse", "additional"),
+        PropertyType.DNSPolicy: ValuesFilePath.read_elsewhere("synapse", "dnsPolicy"),
         PropertyType.Env: ValuesFilePath.read_elsewhere("synapse", "extraEnv"),
         PropertyType.EphemeralStorages: ValuesFilePath.read_elsewhere("synapse", "ephemeralStorages"),
         PropertyType.HostAliases: ValuesFilePath.read_elsewhere("synapse", "hostAliases"),
@@ -729,6 +731,7 @@ all_components_details = [
                 values_file_path=ValuesFilePath.read_write("synapse", "checkConfigHook"),
                 values_file_path_overrides={
                     PropertyType.AdditionalConfig: ValuesFilePath.read_elsewhere("synapse", "additional"),
+                    PropertyType.DNSPolicy: ValuesFilePath.read_elsewhere("synapse", "dnsPolicy"),
                     PropertyType.Env: ValuesFilePath.read_elsewhere("synapse", "extraEnv"),
                     PropertyType.EphemeralStorages: ValuesFilePath.read_elsewhere("synapse", "ephemeralStorages"),
                     PropertyType.Image: ValuesFilePath.read_elsewhere("synapse", "image"),

--- a/tests/manifests/test_pod_dns.py
+++ b/tests/manifests/test_pod_dns.py
@@ -1,0 +1,61 @@
+# Copyright 2026 Element Creations Ltd
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import random
+
+import pytest
+
+from . import DeployableDetails, PropertyType, values_files_to_test
+from .utils import (
+    iterate_deployables_parts,
+    iterate_pod_template,
+)
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_pod_has_no_dnsPolicy_by_default_unless_hostNetwork(templates):
+    for pod_template_details in iterate_pod_template(templates):
+        pod_spec = pod_template_details.pod_template["spec"]
+
+        if pod_spec.get("hostNetwork", False):
+            assert "dnsPolicy" in pod_spec, (
+                f"{pod_template_details.manifest_id} sets hostNetwork=true but doesn't set dnsPolicy"
+            )
+            assert pod_spec["dnsPolicy"] == "ClusterFirstWithHostNet", (
+                f"{pod_template_details.manifest_id} sets hostNetwork=true but doesn't set "
+                "dnsPolicy=ClusterFirstWithHostNet"
+            )
+        else:
+            assert "dnsPolicy" not in pod_spec, (
+                f"{pod_template_details.manifest_id} does not hostNetwork=true but has set a default dnsPolicy"
+            )
+
+
+@pytest.mark.parametrize("values_file", values_files_to_test)
+@pytest.mark.asyncio_cooperative
+async def test_pod_gets_configured_dnsPolicy(values, make_templates):
+    def set_dnspolicy(deployable_details: DeployableDetails):
+        dnsPolicy = random.choice(["ClusterFirst", "ClusterFirstWithHostNetwork", "Default", "None"])
+        deployable_details.set_helm_values(values, PropertyType.DNSPolicy, dnsPolicy)
+
+    iterate_deployables_parts(set_dnspolicy, lambda deployable_details: deployable_details.makes_outbound_requests)
+    for pod_template_details in iterate_pod_template(await make_templates(values)):
+        pod_spec = pod_template_details.pod_template["spec"]
+
+        deployable_details = pod_template_details.deployable_details()
+        if not deployable_details.makes_outbound_requests:
+            assert "dnsPolicy" not in pod_spec, (
+                f"{pod_template_details.manifest_id} has set a dnsPolicy but doesn't make outbound requests"
+            )
+            continue
+
+        assert "dnsPolicy" in pod_spec, (
+            f"{pod_template_details.manifest_id} doesn't have a dnsPolicy when one is configured"
+        )
+
+        expected_dnsPolicy = deployable_details.get_helm_values(values, PropertyType.DNSPolicy)
+        assert pod_spec["dnsPolicy"] == expected_dnsPolicy, (
+            f"{pod_template_details.manifest_id} has an unexpected dnsPolicy"
+        )


### PR DESCRIPTION
The MatrixRTC SFU needs to be run with `ClusterFirstWithHostNet` when `hostNetwork: true`. For everything else we maintain the Kubernetes default (not set == `ClusterFirst` - `Default` is not the default value..... :upside_down_face: ).

Because we make this field templatable we can't make this an enum of the possible values