### PR TITLE
Preserve replacement env vars

### DIFF
--- a/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
+++ b/charts/matrix-stack/source/common/sub_schema_values.yaml.j2
@@ -14,7 +14,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 ## The matrix-tools image, used in multiple components
 matrixTools:
-{{ image(registry="ghcr.io", repository="element-hq/ess-helm/matrix-tools", tag="0.10.0") | indent(2) }}
+{{ image(registry="ghcr.io", repository="element-hq/ess-helm/matrix-tools", tag="0.10.1") | indent(2) }}
 {{ ephemeralStorages([("renderedConfig", "rendered-config emptyDir used in all components to render configuration", "1Mi", "Memory")]) | indent(2) }}
 
 ## CertManager Issuer to configure by default automatically on all ingresses

--- a/charts/matrix-stack/values.yaml
+++ b/charts/matrix-stack/values.yaml
@@ -21,7 +21,7 @@ matrixTools:
 
     ## The tag of the container image to use.
     ## One of tag or digest must be provided.
-    tag: "0.10.0"
+    tag: "0.10.1"
 
     ## Container digest to use. Used to pull the image instead of the image tag if set
     ## The tag will still be set as the app.kubernetes.io/version label

--- a/matrix-tools/internal/pkg/renderer/renderer.go
+++ b/matrix-tools/internal/pkg/renderer/renderer.go
@@ -131,7 +131,7 @@ func RenderConfig(sourceConfigs []io.Reader, arrayOverwriteKeys []string) (map[s
 			// We need to capture any (non-escaping) character before the env var so that we can
 			// re-add it into replacementValue below or it gets lost as it was part of the regex so gets replaced
 			nonEscapedEnvVarsRe := regexp.MustCompile(`([^\\]|^)\$\{` + envVar + `\}`)
-			replacementValue = []byte("${1}" + buffer.String())
+			replacementValue = []byte("${1}" + strings.ReplaceAll(buffer.String(), "$", "$$"))
 			fileContent = nonEscapedEnvVarsRe.ReplaceAll(fileContent, replacementValue)
 		}
 

--- a/matrix-tools/internal/pkg/renderer/renderer_test.go
+++ b/matrix-tools/internal/pkg/renderer/renderer_test.go
@@ -192,6 +192,20 @@ escapedKey: \${REPLACE_WITH}
 			},
 			err: false,
 		},
+		{
+			name: "Preserves ${thing} within env vars used as replacements",
+			readers: []io.Reader{
+				bytes.NewBuffer([]byte(`
+fromEnvVar: ${ENV_VAR}`)),
+			},
+			env: map[string]string{
+				"ENV_VAR": "here is ${something} that looks like an env var replacement",
+			},
+			expected: map[string]any{
+				"fromEnvVar": "here is ${something} that looks like an env var replacement",
+			},
+			err: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/newsfragments/1579.fixed.md
+++ b/newsfragments/1579.fixed.md
@@ -1,0 +1,1 @@
+Fix `${thing}` within an environment variable that is used as a replacement not being preserved.


### PR DESCRIPTION
Regression from https://github.com/element-hq/ess-helm/pull/1509.

Without the fix the test fails with

```
--- FAIL: TestRenderConfig (0.00s)
    --- FAIL: TestRenderConfig/Preserves_${thing}_within_env_vars_used_as_replacements (0.00s)
        /home/ben/Work/github/element-hq/ess-helm-oss/matrix-tools/internal/pkg/renderer/renderer_test.go:224: expected: map[fromEnvVar:here is ${something} that looks like an env var replacement], got: map[fromEnvVar:here is  that looks like an env var replacement]
```