### PR TITLE
Improve the validation and logic for `syn2mas` and the deployment markers

### DIFF
--- a/charts/matrix-stack/templates/deployment-markers/_helpers.tpl
+++ b/charts/matrix-stack/templates/deployment-markers/_helpers.tpl
@@ -1,6 +1,6 @@
 {{- /*
 Copyright 2025 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 */ -}}
@@ -43,38 +43,27 @@ app.kubernetes.io/version: {{ include "element-io.ess-library.labels.makeSafe" $
 
 {{- define "element-io.deployment-markers.markers" -}}
 {{- $root := .root -}}
-{{- /* We allow deploying of Synapse without Matrix Authentication Service, only
-   * if it was initialized as legacy_auth. This effectively prevents enabling Matrix Authentication Service
-   * until Synapse 2 Matrix Authentication Service has been run.
-   * We can run with Matrix Authentication Service enabled if we are running syn2mas.
-   * We stay in legacy_auth mode after the dryRun mode has been completed.
-   **/}}
-{{- if and $root.Values.synapse.enabled
-           (or (not $root.Values.matrixAuthenticationService.enabled)
-              (and $root.Values.matrixAuthenticationService.enabled
-                    $root.Values.matrixAuthenticationService.syn2mas.enabled
-                    $root.Values.matrixAuthenticationService.syn2mas.dryRun)) }}
+{{- /* We can't set any sensible marker if Synapse isn't enabled:
+     * If a MAS suddenly appears here we have no way of knowing whether it was previously deployed externally or not
+    */ -}}
+{{- if $root.Values.synapse.enabled }}
+  {{- if $root.Values.matrixAuthenticationService.enabled }}
+    {{- if $root.Values.matrixAuthenticationService.syn2mas.enabled }}
+      {{- if $root.Values.matrixAuthenticationService.syn2mas.dryRun }}
+        {{- /* We're only dry-run migrating so we're still stuck in legacy auth */ -}}
 - {{ (printf "%s-markers" $root.Release.Name) }}:MATRIX_STACK_MSC3861:legacy_auth:legacy_auth
-{{- end }}
-
-{{- /* We allow migrating from legacy_auth to syn2mas_migrated, if we are running syn2mas in migrate mode.
-  **/}}
-{{- if and $root.Values.synapse.enabled
-          $root.Values.matrixAuthenticationService.enabled
-          $root.Values.matrixAuthenticationService.syn2mas.enabled
-          (not $root.Values.matrixAuthenticationService.syn2mas.dryRun) }}
+      {{- else }}
+        {{- /* We're running the migration for real so allow to go legacy auth -> migrated but don't allow to stay in this state after another deploy */ -}}
 - {{ (printf "%s-markers" $root.Release.Name) }}:MATRIX_STACK_MSC3861:syn2mas_migrated:legacy_auth
-{{- end }}
-
-{{- /* We allow deploying of Synapse with Matrix Authentication Service, only
-   * if it was initialized as delegated_auth, or if syn2mas was just ran and migration was completed.
-   * This effectively prevents disabling Matrix Authentication Service
-   * once it has been enabled.
-  **/}}
-{{- if and $root.Values.synapse.enabled
-           $root.Values.matrixAuthenticationService.enabled
-           (not $root.Values.matrixAuthenticationService.syn2mas.enabled) }}
+      {{- end }}
+    {{- else }}
+      {{- /* We've started with MAS or migrated to MAS, so allow to come from migrated -> MAS as well as staying with MAS */ -}}
 - {{ (printf "%s-markers" $root.Release.Name) }}:MATRIX_STACK_MSC3861:delegated_auth:delegated_auth;syn2mas_migrated
+    {{- end }}
+  {{- else }}
+    {{- /* MAS not enabled at all, we're using legacy auth */ -}}
+- {{ (printf "%s-markers" $root.Release.Name) }}:MATRIX_STACK_MSC3861:legacy_auth:legacy_auth
+  {{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/matrix-stack/templates/matrix-authentication-service/_helpers.tpl
+++ b/charts/matrix-stack/templates/matrix-authentication-service/_helpers.tpl
@@ -15,6 +15,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 {{- if and (not $root.Values.postgres.enabled) (not .postgres) -}}
 {{ $messages = append $messages "matrixAuthenticationService.postgres is required when matrixAuthenticationService.enabled=true but postgres.enabled=false" }}
 {{- end }}
+{{- if and (not $root.Values.synapse.enabled) (.syn2mas.enabled) -}}
+{{ $messages = append $messages "synapse.enabled is required when matrixAuthenticationService.syn2mas.enabled=true" }}
+{{- end }}
 {{- with .additional }}
   {{- range $key := (. | keys | uniq | sortAlpha) }}
     {{- $prop := index $root.Values.matrixAuthenticationService.additional $key }}

--- a/docs/syn2mas.md
+++ b/docs/syn2mas.md
@@ -1,6 +1,6 @@
 <!--
 Copyright 2025 New Vector Ltd
-Copyright 2025 Element Creations Ltd
+Copyright 2025-2026 Element Creations Ltd
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->
@@ -25,6 +25,7 @@ The syn2mas migration will run in a couple of minutes. It involves **three key s
 
 - Please make sure to backup the synapse database before running the migration.
 - The migration is a **one-way process**.Once the system is in the `delegated_auth` state, it cannot be rolled back to `legacy_auth`.
+- The migration process only works if Synapse is deployed and managed by this instance of the chart. You cannot use the migration process to migrate from an external Synapse to an in-chart MAS.
 
 ## Step-by-Step Upgrade Process
 

--- a/newsfragments/1583.changed.1.md
+++ b/newsfragments/1583.changed.1.md
@@ -1,0 +1,1 @@
+Improve the clarity of the deployment markers logic.

--- a/newsfragments/1583.changed.md
+++ b/newsfragments/1583.changed.md
@@ -1,0 +1,1 @@
+Validate that the in-chart Synapse is enabled if `syn2mas` has been enabled.


### PR DESCRIPTION
This should be a no-op in terms of the changes to the deployment markers and the validation makes explicit an existing requirement