### PR TITLE
Well Known: always use HTTPS when redirecting to Element Web

### DIFF
--- a/charts/matrix-stack/configs/well-known/partial-haproxy.cfg.tpl
+++ b/charts/matrix-stack/configs/well-known/partial-haproxy.cfg.tpl
@@ -32,11 +32,10 @@ frontend well-known-in
 
 {{ if .baseDomainRedirect.enabled }}
 {{- if .baseDomainRedirect.url }}
-  http-request redirect  code 301  location {{ .baseDomainRedirect.url }} unless well-known
+  http-request redirect code 301 location {{ .baseDomainRedirect.url }} unless well-known
 {{- else if $root.Values.elementWeb.enabled }}
 {{- with $root.Values.elementWeb }}
-{{- $elementWebHttps := include "element-io.ess-library.ingress.tlsHostsSecret" (dict "root" $root "context" (dict "hosts" (list .ingress.host) "tlsSecret" .ingress.tlsSecret "ingressName" "element-web")) }}
-  http-request redirect  code 301  location http{{ if $elementWebHttps }}s{{ end }}://{{ tpl .ingress.host $root }} unless well-known
+  http-request redirect code 301 location https://{{ tpl .ingress.host $root }} unless well-known
 {{- end }}
 {{- end }}
 {{- end }}

--- a/newsfragments/1589.changed.md
+++ b/newsfragments/1589.changed.md
@@ -1,0 +1,1 @@
+Always use HTTPS when redirecting to Element Web from unknown paths on `serverName`.


### PR DESCRIPTION
https://github.com/element-hq/ess-helm/pull/231 introduced the option to redirect to Element Web when a path on `<serverName>` wasn't matched by a well-known file.

It included a conditional as to whether it redirected to HTTP or HTTPS. However a) Element Web requires TLS (to run things like service workers in a secure context), b) all other links in ESS Pro are HTTPS only and c) misunderstands why `element-io.ess-library.ingress.tlsHostsSecret` might not return anything. For c) this because TLS is expected to be terminated upstream of the cluster but TLS will still be used by users connecting to the endpoint.

Remove this conditional and always use HTTPS